### PR TITLE
Split backends into `AbstractForwardBackend` and `AbstractReverseBackend`

### DIFF
--- a/ext/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/ext/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -4,10 +4,11 @@ using ChainRulesCore
 using DifferentiationInterface
 using LinearAlgebra
 
-ruleconfig(backend::ChainRulesBackend) = backend.ruleconfig
+ruleconfig(backend::ChainRulesForwardBackend) = backend.ruleconfig
+ruleconfig(backend::ChainRulesReverseBackend) = backend.ruleconfig
 
 function DifferentiationInterface.pushforward!(
-    dy::Y, backend::ChainRulesBackend{<:RuleConfig{>:HasForwardsMode}}, f, x::X, dx::X
+    _dy::Y, backend::ChainRulesForwardBackend, f, x::X, dx::X
 ) where {X,Y<:Number}
     rc = ruleconfig(backend)
     _, new_dy = frule_via_ad(rc, (NoTangent(), dx), f, x)
@@ -15,7 +16,7 @@ function DifferentiationInterface.pushforward!(
 end
 
 function DifferentiationInterface.pushforward!(
-    dy::Y, backend::ChainRulesBackend{<:RuleConfig{>:HasForwardsMode}}, f, x::X, dx::X
+    dy::Y, backend::ChainRulesForwardBackend, f, x::X, dx::X
 ) where {X,Y<:AbstractArray}
     rc = ruleconfig(backend)
     _, new_dy = frule_via_ad(rc, (NoTangent(), dx), f, x)
@@ -24,7 +25,7 @@ function DifferentiationInterface.pushforward!(
 end
 
 function DifferentiationInterface.pullback!(
-    dx::X, backend::ChainRulesBackend{<:RuleConfig{>:HasReverseMode}}, f, x::X, dy::Y
+    _dx::X, backend::ChainRulesReverseBackend, f, x::X, dy::Y
 ) where {X<:Number,Y}
     rc = ruleconfig(backend)
     _, pullback = rrule_via_ad(rc, f, x)
@@ -33,7 +34,7 @@ function DifferentiationInterface.pullback!(
 end
 
 function DifferentiationInterface.pullback!(
-    dx::X, backend::ChainRulesBackend{<:RuleConfig{>:HasReverseMode}}, f, x::X, dy::Y
+    dx::X, backend::ChainRulesReverseBackend, f, x::X, dy::Y
 ) where {X<:AbstractArray,Y}
     rc = ruleconfig(backend)
     _, pullback = rrule_via_ad(rc, f, x)

--- a/ext/DifferentiationInterfaceEnzymeExt.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt.jl
@@ -8,7 +8,7 @@ using Enzyme
 $(TYPEDSIGNATURES)
 """
 function DifferentiationInterface.pushforward!(
-    dy::Y, ::EnzymeBackend, f, x::X, dx::X
+    _dy::Y, ::EnzymeForwardBackend, f, x::X, dx::X
 ) where {X,Y}
     return only(autodiff(Forward, f, DuplicatedNoNeed, Duplicated(x, dx)))
 end
@@ -17,7 +17,7 @@ end
 $(TYPEDSIGNATURES)
 """
 function DifferentiationInterface.pullback!(
-    dx::X, ::EnzymeBackend, f, x::X, dy::Y
+    _dx::X, ::EnzymeReverseBackend, f, x::X, dy::Y
 ) where {X<:Number,Y<:Union{Real,Nothing}}
     return only(first(autodiff(Reverse, f, Active, Active(x)))) * dy
 end
@@ -26,7 +26,7 @@ end
 $(TYPEDSIGNATURES)
 """
 function DifferentiationInterface.pullback!(
-    dx::X, ::EnzymeBackend, f, x::X, dy::Y
+    dx::X, ::EnzymeReverseBackend, f, x::X, dy::Y
 ) where {X<:AbstractArray,Y<:Union{Real,Nothing}}
     dx .= zero(eltype(dx))
     autodiff(Reverse, f, Active, Duplicated(x, dx))

--- a/ext/DifferentiationInterfaceFiniteDiffExt.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt.jl
@@ -5,8 +5,6 @@ using DocStringExtensions
 using FiniteDiff
 using LinearAlgebra
 
-## Pushforward
-
 """
 $(TYPEDSIGNATURES)
 """
@@ -50,48 +48,4 @@ function DifferentiationInterface.pushforward!(
     return dy
 end
 
-## Pullback
-
-"""
-$(TYPEDSIGNATURES)
-"""
-function DifferentiationInterface.pullback!(
-    dx::X, ::FiniteDiffBackend, f, x::X, dy::Y
-) where {X<:Real,Y<:Real}
-    new_dx = dy * FiniteDiff.finite_difference_derivative(f, x)
-    return new_dx
-end
-
-"""
-$(TYPEDSIGNATURES)
-"""
-function DifferentiationInterface.pullback!(
-    dx::X, ::FiniteDiffBackend, f, x::X, dy::Y
-) where {X<:Real,Y<:AbstractArray}
-    new_dx = dot(dy, FiniteDiff.finite_difference_derivative(f, x))
-    return new_dx
-end
-
-"""
-$(TYPEDSIGNATURES)
-"""
-function DifferentiationInterface.pullback!(
-    dx::X, ::FiniteDiffBackend, f, x::X, dy::Y
-) where {X<:AbstractArray,Y<:Real}
-    g = FiniteDiff.finite_difference_gradient(f, x)
-    dx .= g .* dy
-    return dx
-end
-
-"""
-$(TYPEDSIGNATURES)
-"""
-function DifferentiationInterface.pullback!(
-    dx::X, ::FiniteDiffBackend, f, x::X, dy::Y
-) where {X<:AbstractArray,Y<:AbstractArray}
-    J = FiniteDiff.finite_difference_jacobian(f, x)
-    mul!(dx, transpose(J), dy)
-    return dx
-end
-
-end
+end # module

--- a/src/DifferentiationInterface.jl
+++ b/src/DifferentiationInterface.jl
@@ -19,7 +19,7 @@ abstract type AbstractReverseBackend <: AbstractBackend end
 """
     ChainRulesReverseBackend{RC}
 
-Performs autodiff with reverse-mode AD packages based on [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl), like [Zygote.jl](https://github.com/FluxML/Zygote.jl) or [Diffractor.jl](https://github.com/JuliaDiff/Diffractor.jl).
+Performs autodiff with reverse-mode AD packages based on [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl), like [Zygote.jl](https://github.com/FluxML/Zygote.jl).
 
 This must be constructed with an appropriate [`RuleConfig`](https://juliadiff.org/ChainRulesCore.jl/stable/rule_author/superpowers/ruleconfig.html) instance:
 
@@ -36,9 +36,13 @@ end
 """
     ChainRulesForwardBackend{RC}
 
-Performs autodiff with forward-mode AD packages based on [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl).
+Performs autodiff with forward-mode AD packages based on [ChainRulesCore.jl](https://github.com/JuliaDiff/ChainRulesCore.jl), like [Diffractor.jl](https://github.com/JuliaDiff/Diffractor.jl).
 
 This must be constructed with an appropriate [`RuleConfig`](https://juliadiff.org/ChainRulesCore.jl/stable/rule_author/superpowers/ruleconfig.html) instance.
+```julia
+using Diffractor, DifferentiationInterface
+backend = ChainRulesForwardBackend(Diffractor.DiffractorRuleConfig())
+```
 """
 struct ChainRulesForwardBackend{RC} <: AbstractForwardBackend
     # TODO: check RC<:RuleConfig{>:HasForwardsMode}

--- a/test/diffractor.jl
+++ b/test/diffractor.jl
@@ -1,4 +1,6 @@
 using Diffractor
 using DifferentiationInterface
 
-test_pushforward(ChainRulesBackend(Diffractor.DiffractorRuleConfig()); type_stability=false)
+test_pushforward(
+    ChainRulesForwardBackend(Diffractor.DiffractorRuleConfig()); type_stability=false
+)

--- a/test/enzyme.jl
+++ b/test/enzyme.jl
@@ -1,5 +1,5 @@
 using DifferentiationInterface
 using Enzyme
 
-test_pushforward(EnzymeBackend(); type_stability=true)
-test_pullback(EnzymeBackend(); output_type=Number, type_stability=true)
+test_pushforward(EnzymeForwardBackend(); type_stability=true)
+test_pullback(EnzymeReverseBackend(); output_type=Number, type_stability=true)

--- a/test/finitediff.jl
+++ b/test/finitediff.jl
@@ -2,4 +2,3 @@ using DifferentiationInterface
 using FiniteDiff
 
 test_pushforward(FiniteDiffBackend(); type_stability=false)
-test_pullback(FiniteDiffBackend(); type_stability=false)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,4 +1,5 @@
 using DifferentiationInterface
+using DifferentiationInterface: AbstractReverseBackend, AbstractForwardBackend
 using JET
 using Test
 
@@ -68,7 +69,7 @@ scenarios = [scenario1, scenario2, scenario3, scenario4]
 ## Test utilities
 
 function test_pushforward(
-    backend;
+    backend::AbstractForwardBackend;
     scenarios::Vector{<:Scenario}=scenarios,
     input_type::Type=Any,
     output_type::Type=Any,
@@ -97,7 +98,7 @@ function test_pushforward(
 end
 
 function test_pullback(
-    backend;
+    backend::AbstractReverseBackend;
     scenarios=scenarios,
     input_type::Type=Any,
     output_type::Type=Any,

--- a/test/zygote.jl
+++ b/test/zygote.jl
@@ -1,4 +1,4 @@
 using DifferentiationInterface
 using Zygote
 
-test_pullback(ChainRulesBackend(Zygote.ZygoteRuleConfig()); type_stability=false)
+test_pullback(ChainRulesReverseBackend(Zygote.ZygoteRuleConfig()); type_stability=false)


### PR DESCRIPTION
Introduces two subtypes of `AbstractBackend`: `AbstractForwardBackend` and `AbstractReverseBackend`

* split `EnzymeBackend` into `EnzymeForwardBackend` and `EnzymeReverseBackend`
* split `ChainRulesBackend` into `ChainRulesForwardBackend` and `ChainRulesReverseBackend`
* exclusively define `pullback!` on `AbstractReverseBackend`s
* exclusively define `pushforward!` on `AbstractForwardBackend`s