### PR TITLE
Add support for Jacobians

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [weakdeps]
@@ -26,8 +27,9 @@ DifferentiationInterfaceReverseDiffExt = ["ReverseDiff", "DiffResults"]
 ChainRulesCore = "1.19"
 DiffResults = "1.1"
 DocStringExtensions = "0.9"
-FiniteDiff = "2.22"
 Enzyme = "0.11"
+FillArrays = "1"
+FiniteDiff = "2.22"
 ForwardDiff = "0.10"
 LinearAlgebra = "1"
 ReverseDiff = "1.15"

--- a/ext/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/ext/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -2,7 +2,6 @@ module DifferentiationInterfaceChainRulesCoreExt
 
 using ChainRulesCore: NoTangent, frule_via_ad, rrule_via_ad
 using DifferentiationInterface
-import DifferentiationInterface: value_and_pushforward!
 
 ruleconfig(backend::ChainRulesForwardBackend) = backend.ruleconfig
 ruleconfig(backend::ChainRulesReverseBackend) = backend.ruleconfig

--- a/ext/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/ext/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -10,7 +10,7 @@ update!(_old::Number, new::Number) = new
 update!(old, new) = old .= new
 
 function DifferentiationInterface.value_and_pushforward!(
-    dy::Y, backend::ChainRulesForwardBackend, f, x::X, dx::X
+    dy::Y, backend::ChainRulesForwardBackend, f, x::X, dx
 ) where {X,Y}
     rc = ruleconfig(backend)
     y, new_dy = frule_via_ad(rc, (NoTangent(), dx), f, x)

--- a/ext/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/ext/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -2,6 +2,7 @@ module DifferentiationInterfaceChainRulesCoreExt
 
 using ChainRulesCore: NoTangent, frule_via_ad, rrule_via_ad
 using DifferentiationInterface
+import DifferentiationInterface: value_and_pushforward!
 
 ruleconfig(backend::ChainRulesForwardBackend) = backend.ruleconfig
 ruleconfig(backend::ChainRulesReverseBackend) = backend.ruleconfig

--- a/ext/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/ext/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -18,7 +18,7 @@ function DifferentiationInterface.value_and_pushforward!(
 end
 
 function DifferentiationInterface.value_and_pullback!(
-    dx::X, backend::ChainRulesReverseBackend, f, x::X, dy::Y
+    dx, backend::ChainRulesReverseBackend, f, x::X, dy::Y
 ) where {X,Y}
     rc = ruleconfig(backend)
     y, pullback = rrule_via_ad(rc, f, x)

--- a/ext/DifferentiationInterfaceEnzymeExt.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt.jl
@@ -44,11 +44,24 @@ function DifferentiationInterface.value_and_pullback!(
 end
 
 function DifferentiationInterface.value_and_pullback!(
-    dx, ::EnzymeReverseBackend, f, x::X, dy::Y
+    dx::X, ::EnzymeReverseBackend, f, x::X, dy::Y
 ) where {X<:AbstractArray,Y<:Union{Real,Nothing}}
     dx .= zero(eltype(dx))
     _, y = autodiff(ReverseWithPrimal, f, Active, Duplicated(x, dx))
     dx .*= dy
+    return y, dx
+end
+
+# Enzyme's Duplicated assumes x and dx to be of the same type.
+# When writing into pre-allocated arrays, e.g. Jacobians,
+# dx often is a view or SubArray.
+# This requires a specialized method that allocates a new dx.
+function DifferentiationInterface.value_and_pullback!(
+    dx, ::EnzymeReverseBackend, f, x::X, dy::Y
+) where {X<:AbstractArray,Y<:Union{Real,Nothing}}
+    _dx = zero(x)
+    _, y = autodiff(ReverseWithPrimal, f, Active, Duplicated(x, _dx))
+    @. dx = _dx * dy
     return y, dx
 end
 

--- a/ext/DifferentiationInterfaceEnzymeExt.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt.jl
@@ -3,6 +3,19 @@ module DifferentiationInterfaceEnzymeExt
 using DifferentiationInterface
 using Enzyme: Forward, ReverseWithPrimal, Active, Duplicated, autodiff
 
+const EnzymeBackends = Union{EnzymeForwardBackend,EnzymeReverseBackend}
+
+## Unit vector
+
+# Enzyme's `Duplicated(x, dx)` expects both arguments to be of the same type
+function DifferentiationInterface.unitvector(
+    ::EnzymeBackends, v::AbstractVector{T}, i
+) where {T}
+    uv = zero(v)
+    uv[i] = one(T)
+    return uv
+end
+
 ## Forward mode
 
 function DifferentiationInterface.value_and_pushforward!(

--- a/ext/DifferentiationInterfaceEnzymeExt.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt.jl
@@ -1,6 +1,7 @@
 module DifferentiationInterfaceEnzymeExt
 
 using DifferentiationInterface
+import DifferentiationInterface: value_and_pushforward!, value_and_pullback!
 using Enzyme: Forward, ReverseWithPrimal, Active, Duplicated, autodiff
 
 ## Forward mode

--- a/ext/DifferentiationInterfaceEnzymeExt.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt.jl
@@ -6,14 +6,14 @@ using Enzyme: Forward, ReverseWithPrimal, Active, Duplicated, autodiff
 ## Forward mode
 
 function DifferentiationInterface.value_and_pushforward!(
-    _dy::Y, ::EnzymeForwardBackend, f, x::X, dx::X
+    _dy::Y, ::EnzymeForwardBackend, f, x::X, dx
 ) where {X,Y<:Real}
     y, new_dy = autodiff(Forward, f, Duplicated, Duplicated(x, dx))
     return y, new_dy
 end
 
 function DifferentiationInterface.value_and_pushforward!(
-    dy::Y, ::EnzymeForwardBackend, f, x::X, dx::X
+    dy::Y, ::EnzymeForwardBackend, f, x::X, dx
 ) where {X,Y<:AbstractArray}
     y, new_dy = autodiff(Forward, f, Duplicated, Duplicated(x, dx))
     dy .= new_dy

--- a/ext/DifferentiationInterfaceEnzymeExt.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt.jl
@@ -23,7 +23,7 @@ end
 ## Reverse mode
 
 function DifferentiationInterface.value_and_pullback!(
-    _dx::X, ::EnzymeReverseBackend, f, x::X, dy::Y
+    _dx, ::EnzymeReverseBackend, f, x::X, dy::Y
 ) where {X<:Number,Y<:Union{Real,Nothing}}
     der, y = autodiff(ReverseWithPrimal, f, Active, Active(x))
     new_dx = dy * only(der)
@@ -31,7 +31,7 @@ function DifferentiationInterface.value_and_pullback!(
 end
 
 function DifferentiationInterface.value_and_pullback!(
-    dx::X, ::EnzymeReverseBackend, f, x::X, dy::Y
+    dx, ::EnzymeReverseBackend, f, x::X, dy::Y
 ) where {X<:AbstractArray,Y<:Union{Real,Nothing}}
     dx .= zero(eltype(dx))
     _, y = autodiff(ReverseWithPrimal, f, Active, Duplicated(x, dx))

--- a/ext/DifferentiationInterfaceEnzymeExt.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt.jl
@@ -1,7 +1,6 @@
 module DifferentiationInterfaceEnzymeExt
 
 using DifferentiationInterface
-import DifferentiationInterface: value_and_pushforward!, value_and_pullback!
 using Enzyme: Forward, ReverseWithPrimal, Active, Duplicated, autodiff
 
 ## Forward mode

--- a/ext/DifferentiationInterfaceFiniteDiffExt.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt.jl
@@ -11,7 +11,7 @@ using LinearAlgebra: dot, mul!
 const DEFAULT_FDTYPE = Val{:central}
 
 function DifferentiationInterface.value_and_pushforward!(
-    dy::Y, ::FiniteDiffBackend, f, x::X, dx::X
+    dy::Y, ::FiniteDiffBackend, f, x::X, dx
 ) where {X<:Number,Y<:Number}
     y = f(x)
     der = finite_difference_derivative(
@@ -26,7 +26,7 @@ function DifferentiationInterface.value_and_pushforward!(
 end
 
 function DifferentiationInterface.value_and_pushforward!(
-    dy::Y, ::FiniteDiffBackend, f, x::X, dx::X
+    dy::Y, ::FiniteDiffBackend, f, x::X, dx
 ) where {X<:Number,Y<:AbstractArray}
     y = f(x)
     finite_difference_gradient!(
@@ -43,7 +43,7 @@ function DifferentiationInterface.value_and_pushforward!(
 end
 
 function DifferentiationInterface.value_and_pushforward!(
-    dy::Y, ::FiniteDiffBackend, f, x::X, dx::X
+    dy::Y, ::FiniteDiffBackend, f, x::X, dx
 ) where {X<:AbstractArray,Y<:Number}
     y = f(x)
     g = finite_difference_gradient(
@@ -59,7 +59,7 @@ function DifferentiationInterface.value_and_pushforward!(
 end
 
 function DifferentiationInterface.value_and_pushforward!(
-    dy::Y, ::FiniteDiffBackend, f, x::X, dx::X
+    dy::Y, ::FiniteDiffBackend, f, x::X, dx
 ) where {X<:AbstractArray,Y<:AbstractArray}
     y = f(x)
     J = finite_difference_jacobian(

--- a/ext/DifferentiationInterfaceFiniteDiffExt.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt.jl
@@ -1,6 +1,8 @@
 module DifferentiationInterfaceFiniteDiffExt
 
 using DifferentiationInterface
+import DifferentiationInterface: value_and_pushforward!
+
 using FiniteDiff:
     finite_difference_derivative,
     finite_difference_gradient,

--- a/ext/DifferentiationInterfaceFiniteDiffExt.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt.jl
@@ -1,8 +1,6 @@
 module DifferentiationInterfaceFiniteDiffExt
 
 using DifferentiationInterface
-import DifferentiationInterface: value_and_pushforward!
-
 using FiniteDiff:
     finite_difference_derivative,
     finite_difference_gradient,

--- a/ext/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt.jl
@@ -1,6 +1,8 @@
 module DifferentiationInterfaceForwardDiffExt
 
 using DifferentiationInterface
+import DifferentiationInterface: value_and_pushforward!
+
 using DiffResults: DiffResults
 using ForwardDiff: Dual, Tag, value, extract_derivative, extract_derivative!
 using LinearAlgebra: mul!

--- a/ext/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt.jl
@@ -1,8 +1,6 @@
 module DifferentiationInterfaceForwardDiffExt
 
 using DifferentiationInterface
-import DifferentiationInterface: value_and_pushforward!
-
 using DiffResults: DiffResults
 using ForwardDiff: Dual, Tag, value, extract_derivative, extract_derivative!
 using LinearAlgebra: mul!

--- a/ext/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt.jl
@@ -6,7 +6,7 @@ using ForwardDiff: Dual, Tag, value, extract_derivative, extract_derivative!
 using LinearAlgebra: mul!
 
 function DifferentiationInterface.value_and_pushforward!(
-    _dy::Y, ::ForwardDiffBackend, f, x::X, dx::X
+    _dy::Y, ::ForwardDiffBackend, f, x::X, dx
 ) where {X<:Real,Y<:Real}
     T = typeof(Tag(f, X))
     xdual = Dual{T}(x, dx)
@@ -17,7 +17,7 @@ function DifferentiationInterface.value_and_pushforward!(
 end
 
 function DifferentiationInterface.value_and_pushforward!(
-    dy::Y, ::ForwardDiffBackend, f, x::X, dx::X
+    dy::Y, ::ForwardDiffBackend, f, x::X, dx
 ) where {X<:Real,Y<:AbstractArray}
     T = typeof(Tag(f, X))
     xdual = Dual{T}(x, dx)
@@ -28,7 +28,7 @@ function DifferentiationInterface.value_and_pushforward!(
 end
 
 function DifferentiationInterface.value_and_pushforward!(
-    _dy::Y, ::ForwardDiffBackend, f, x::X, dx::X
+    _dy::Y, ::ForwardDiffBackend, f, x::X, dx
 ) where {X<:AbstractArray,Y<:Real}
     T = typeof(Tag(f, X))  # TODO: unsure
     xdual = Dual{T}.(x, dx)  # TODO: allocation
@@ -39,7 +39,7 @@ function DifferentiationInterface.value_and_pushforward!(
 end
 
 function DifferentiationInterface.value_and_pushforward!(
-    dy::Y, ::ForwardDiffBackend, f, x::X, dx::X
+    dy::Y, ::ForwardDiffBackend, f, x::X, dx
 ) where {X<:AbstractArray,Y<:AbstractArray}
     T = typeof(Tag(f, X))  # TODO: unsure
     xdual = Dual{T}.(x, dx)  # TODO: allocation

--- a/ext/DifferentiationInterfaceReverseDiffExt.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt.jl
@@ -1,8 +1,6 @@
 module DifferentiationInterfaceReverseDiffExt
 
 using DifferentiationInterface
-import DifferentiationInterface: value_and_pullback!
-
 using DiffResults: DiffResults
 using ReverseDiff: gradient!, jacobian!
 using LinearAlgebra: mul!

--- a/ext/DifferentiationInterfaceReverseDiffExt.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt.jl
@@ -1,6 +1,8 @@
 module DifferentiationInterfaceReverseDiffExt
 
 using DifferentiationInterface
+import DifferentiationInterface: value_and_pullback!
+
 using DiffResults: DiffResults
 using ReverseDiff: gradient!, jacobian!
 using LinearAlgebra: mul!

--- a/ext/DifferentiationInterfaceReverseDiffExt.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt.jl
@@ -6,7 +6,7 @@ using ReverseDiff: gradient!, jacobian!
 using LinearAlgebra: mul!
 
 function DifferentiationInterface.value_and_pullback!(
-    dx::X, ::ReverseDiffBackend, f, x::X, dy::Y
+    dx, ::ReverseDiffBackend, f, x::X, dy::Y
 ) where {X<:AbstractArray,Y<:Real}
     res = DiffResults.DiffResult(zero(Y), dx)
     res = gradient!(res, f, x)
@@ -16,7 +16,7 @@ function DifferentiationInterface.value_and_pullback!(
 end
 
 function DifferentiationInterface.value_and_pullback!(
-    dx::X, ::ReverseDiffBackend, f, x::X, dy::Y
+    dx, ::ReverseDiffBackend, f, x::X, dy::Y
 ) where {X<:AbstractArray,Y<:AbstractArray}
     res = DiffResults.DiffResult(similar(dy), similar(dy, length(dy), length(x)))
     res = jacobian!(res, f, x)

--- a/src/DifferentiationInterface.jl
+++ b/src/DifferentiationInterface.jl
@@ -11,6 +11,7 @@ $(EXPORTS)
 module DifferentiationInterface
 
 using DocStringExtensions
+using FillArrays: OneElement
 
 abstract type AbstractBackend end
 abstract type AbstractForwardBackend <: AbstractBackend end
@@ -19,6 +20,8 @@ abstract type AbstractReverseBackend <: AbstractBackend end
 include("backends.jl")
 include("forward.jl")
 include("reverse.jl")
+include("unitvector.jl")
+include("jacobian.jl")
 
 export ChainRulesReverseBackend,
     ChainRulesForwardBackend,
@@ -29,5 +32,7 @@ export ChainRulesReverseBackend,
     ReverseDiffBackend
 export pushforward!, value_and_pushforward!
 export pullback!, value_and_pullback!
+export jacobian!, value_and_jacobian!
+export jacobian, value_and_jacobian
 
 end # module

--- a/src/forward.jl
+++ b/src/forward.jl
@@ -13,7 +13,7 @@ Compute a Jacobian-vector product inside `dy` and return it and the primal outpu
 - `dx`: tangent
 - `stuff`: optional backend-specific storage (cache, config), might be modified
 """
-function value_and_pushforward!(dy, backend, f, x, dx)
+function value_and_pushforward!(dy::Y, backend::AbstractBackend, f, x::X, dx::X) where {X,Y}
     return error("No package extension loaded for backend $backend.")
 end
 

--- a/src/forward.jl
+++ b/src/forward.jl
@@ -13,7 +13,7 @@ Compute a Jacobian-vector product inside `dy` and return it and the primal outpu
 - `dx`: tangent
 - `stuff`: optional backend-specific storage (cache, config), might be modified
 """
-function value_and_pushforward!(dy::Y, backend::AbstractBackend, f, x::X, dx::X) where {X,Y}
+function value_and_pushforward!(dy::Y, backend::AbstractBackend, f, x::X, dx) where {X,Y}
     return error("No package extension loaded for backend $backend.")
 end
 

--- a/src/forward.jl
+++ b/src/forward.jl
@@ -13,7 +13,9 @@ Compute a Jacobian-vector product inside `dy` and return it and the primal outpu
 - `dx`: tangent
 - `stuff`: optional backend-specific storage (cache, config), might be modified
 """
-function value_and_pushforward! end
+function value_and_pushforward!(dy, backend, f, x, dx)
+    return error("No package extension loaded for backend $backend.")
+end
 
 """
     pushforward!(dy, backend, f, x, dx[, stuff])

--- a/src/forward.jl
+++ b/src/forward.jl
@@ -20,11 +20,12 @@ end
 """
     pushforward!(dy, backend, f, x, dx[, stuff])
 
-Compute a Jacobian-vector product inside `dy` and return it.
+Compute a Jacobian-vector product inside `dy`.
+Returns the primal output of `f(x)` and the JVP `dy`.
 
 See [`value_and_pushforward!`](@ref).
 """
-function pushforward!(dy, backend, f, x, dx, stuff)
-    _, dy = value_and_pushforward!(dy, backend, f, x, dx, stuff)
+function pushforward!(dy, backend, f, x, dx)
+    _, dy = value_and_pushforward!(dy, backend, f, x, dx)
     return dy
 end

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -1,0 +1,79 @@
+const DOC_JACOBIAN_SHAPE = "For a function `f: ℝⁿ → ℝᵐ`, `J` is returned as a `m × n` matrix."
+
+## In-place mutating functions
+
+"""
+    value_and_jacobian!(J, backend, f, x[, stuff])
+
+Compute the Jacobian inside the pre-allocated matrix `J`.
+$DOC_JACOBIAN_SHAPE
+Returns the primal output of the computation `f(x)` and the corresponding Jacobian `J`.
+
+See [`value_and_jacobian`](@ref), [`jacobian!`](@ref) and [`jacobian`](@ref).
+"""
+function value_and_jacobian!(J::AbstractMatrix, backend::AbstractForwardBackend, f, x)
+    y = f(x)
+    for (i, dy) in Iterators.enumerate(eachcol(J))
+        dx = unitvector(backend, x, i)
+        pushforward!(dy, backend, f, x, dx) # mutate J in-place
+    end
+    return y, J
+end
+
+function value_and_jacobian!(J::AbstractMatrix, backend::AbstractReverseBackend, f, x)
+    y = f(x)
+    for (i, dx) in Iterators.enumerate(eachrow(J))
+        dy = unitvector(backend, y, i)
+        pullback!(dx, backend, f, x, dy) # mutate J in-place
+    end
+    return y, J
+end
+
+"""
+    jacobian!(J, backend, f, x[, stuff])
+
+Compute the Jacobian of `f` at `x` inside the pre-allocated matrix `J` and return `J`.
+$DOC_JACOBIAN_SHAPE
+
+See [`value_and_jacobian!`](@ref), [`value_and_jacobian`](@ref) and [`jacobian`](@ref).
+"""
+function jacobian!(J::AbstractMatrix, backend::AbstractBackend, f, x)
+    _, J = value_and_jacobian!(J, backend, f, x)
+    return J
+end
+
+## Allocating functions
+
+"""
+    value_and_jacobian(backend, f, x[, stuff])
+
+Return the primal output of the computation `f(x)` and the corresponding Jacobian `J`.
+$DOC_JACOBIAN_SHAPE
+
+See [`value_and_jacobian!`](@ref), [`jacobian!`](@ref) and [`jacobian`](@ref).
+"""
+function value_and_jacobian(backend::AbstractBackend, f, x)
+    y = f(x)
+    J = allocate_jacobian_buffer(x, y)
+    return y, J = value_and_jacobian!(J, backend, f, x)
+end
+
+function allocate_jacobian_buffer(x, y)
+    # The type of a derivative is the type julia promotes dy/dx to
+    T = typeof(one(eltype(X)) / one(eltype(Y)))
+    # For a function f: ℝⁿ → ℝᵐ , a matrix of size (m, n) is returned
+    return Matrix{T}(undef, length(y), length(x))
+end
+
+"""
+    jacobian(backend, f, x[, stuff])
+
+Return the Jacobian `J` of function `f` at `x`.
+$DOC_JACOBIAN_SHAPE
+
+See [`value_and_jacobian`](@ref), [`value_and_jacobian!`](@ref) and [`jacobian!`](@ref).
+"""
+function jacobian(backend::AbstractBackend, f, x)
+    _, J = value_and_jacobian(backend, f, x)
+    return J
+end

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -60,7 +60,7 @@ end
 
 function allocate_jacobian_buffer(x, y)
     # The type of a derivative is the type julia promotes dy/dx to
-    T = typeof(one(eltype(X)) / one(eltype(Y)))
+    T = typeof(one(eltype(y)) / one(eltype(x)))
     # For a function f: ℝⁿ → ℝᵐ , a matrix of size (m, n) is returned
     return Matrix{T}(undef, length(y), length(x))
 end

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -13,7 +13,7 @@ Compute a vector-Jacobian product inside `dx` and return it and the primal outpu
 - `dy`: cotangent
 - `stuff`: optional backend-specific storage (cache, config), might be modified
 """
-function value_and_pullback!(dx::X, backend::AbstractBackend, f, x::X, dy::Y) where {X,Y}
+function value_and_pullback!(dx, backend::AbstractBackend, f, x::X, dy::Y) where {X,Y}
     return error("No package extension loaded for backend $backend.")
 end
 

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -24,7 +24,7 @@ Compute a vector-Jacobian product inside `dx` and return it.
 
 See [`value_and_pullback!`](@ref).
 """
-function pullback!(dx, backend, f, x, dy, stuff)
-    _, dx = value_and_pullback!(dx, backend, f, x, dy, stuff)
+function pullback!(dx, backend, f, x, dy)
+    _, dx = value_and_pullback!(dx, backend, f, x, dy)
     return dx
 end

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -13,7 +13,9 @@ Compute a vector-Jacobian product inside `dx` and return it and the primal outpu
 - `dy`: cotangent
 - `stuff`: optional backend-specific storage (cache, config), might be modified
 """
-function value_and_pullback! end
+function value_and_pullback!(dx, backend, f, x, dy)
+    return error("No package extension loaded for backend $backend.")
+end
 
 """
     pullback!(dx, backend, f, x, dy[, stuff])

--- a/src/reverse.jl
+++ b/src/reverse.jl
@@ -13,7 +13,7 @@ Compute a vector-Jacobian product inside `dx` and return it and the primal outpu
 - `dy`: cotangent
 - `stuff`: optional backend-specific storage (cache, config), might be modified
 """
-function value_and_pullback!(dx, backend, f, x, dy)
+function value_and_pullback!(dx::X, backend::AbstractBackend, f, x::X, dy::Y) where {X,Y}
     return error("No package extension loaded for backend $backend.")
 end
 

--- a/src/unitvector.jl
+++ b/src/unitvector.jl
@@ -1,0 +1,15 @@
+"""
+    unitvector(backend, v::AbstractVector, i)
+    unitvector(backend, v::Real, i)
+
+Construct `i`-th stardard basis vector in the vector space of `v` with element type `eltype(v)`.
+If `v` is a real number, one is returned.
+
+## Note
+If an AD backend benefits from a more specialized unit vector implementation,
+this function can be extended on the backend type.
+"""
+function unitvector(::AbstractBackend, v::AbstractVector{T}, i) where {T}
+    return OneElement(one(T), i, length(v))
+end
+unitvector(::AbstractBackend, v::T, i) where {T<:Real} = one(v)

--- a/test/diffractor.jl
+++ b/test/diffractor.jl
@@ -4,3 +4,6 @@ using DifferentiationInterface
 test_pushforward(
     ChainRulesForwardBackend(Diffractor.DiffractorRuleConfig()); type_stability=false
 )
+test_jacobian(
+    ChainRulesForwardBackend(Diffractor.DiffractorRuleConfig()); type_stability=false
+)

--- a/test/enzyme.jl
+++ b/test/enzyme.jl
@@ -1,5 +1,11 @@
 using DifferentiationInterface
 using Enzyme
 
-test_pushforward(EnzymeForwardBackend(); type_stability=true)
-test_pullback(EnzymeReverseBackend(); output_type=Number, type_stability=true)
+@testset "EnzymeForwardBackend" begin
+    test_pushforward(EnzymeForwardBackend(); type_stability=true)
+    test_jacobian(EnzymeForwardBackend(); type_stability=true)
+end
+@testset "EnzymeReverseBackend" begin
+    test_pullback(EnzymeReverseBackend(); output_type=Number, type_stability=true)
+    test_jacobian(EnzymeReverseBackend(); output_type=Number, type_stability=true)
+end

--- a/test/finitediff.jl
+++ b/test/finitediff.jl
@@ -2,3 +2,4 @@ using DifferentiationInterface
 using FiniteDiff
 
 test_pushforward(FiniteDiffBackend(); type_stability=false)
+test_jacobian(FiniteDiffBackend(); type_stability=false)

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -2,3 +2,4 @@ using DifferentiationInterface
 using ForwardDiff
 
 test_pushforward(ForwardDiffBackend(); type_stability=false)
+test_jacobian(ForwardDiffBackend(); type_stability=false)

--- a/test/reversediff.jl
+++ b/test/reversediff.jl
@@ -2,3 +2,4 @@ using DifferentiationInterface
 using ReverseDiff
 
 test_pullback(ReverseDiffBackend(); input_type=AbstractArray, type_stability=false)
+test_jacobian(ReverseDiffBackend(); input_type=AbstractArray, type_stability=false)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -9,7 +9,7 @@ using Test
 
 ## Test scenarios
 
-struct Scenario{F,X,Y}
+struct Scenario{F,X,Y,J}
     "function"
     f::F
     "argument"
@@ -24,6 +24,8 @@ struct Scenario{F,X,Y}
     dx_true::X
     "pushforward result"
     dy_true::Y
+    "Jacobian result"
+    jac_true::J
 end
 
 ## Constructors
@@ -39,7 +41,8 @@ function Scenario(rng::AbstractRNG, f::F, x::X, y::Y) where {F,X<:Number,Y<:Numb
     der = ForwardDiff.derivative(f, x)
     dx_true = der * dy
     dy_true = der * dx
-    return Scenario(f, x, y, dx, dy, dx_true, dy_true)
+    jac_true = [der;;]
+    return Scenario(f, x, y, dx, dy, dx_true, dy_true, jac_true)
 end
 
 function Scenario(rng::AbstractRNG, f::F, x::X, y::Y) where {F,X<:Number,Y<:AbstractArray}
@@ -49,7 +52,8 @@ function Scenario(rng::AbstractRNG, f::F, x::X, y::Y) where {F,X<:Number,Y<:Abst
     der_array = ForwardDiff.derivative(f, x)
     dx_true = dot(der_array, dy)
     dy_true = der_array .* dx
-    return Scenario(f, x, y, dx, dy, dx_true, dy_true)
+    jac_true = reshape(der_array, :, 1)
+    return Scenario(f, x, y, dx, dy, dx_true, dy_true, jac_true)
 end
 
 function Scenario(rng::AbstractRNG, f::F, x::X, y::Y) where {F,X<:AbstractArray,Y<:Number}
@@ -59,7 +63,8 @@ function Scenario(rng::AbstractRNG, f::F, x::X, y::Y) where {F,X<:AbstractArray,
     grad = ForwardDiff.gradient(f, x)
     dx_true = grad .* dy
     dy_true = dot(grad, dx)
-    return Scenario(f, x, y, dx, dy, dx_true, dy_true)
+    jac_true = reshape(grad, 1, :)
+    return Scenario(f, x, y, dx, dy, dx_true, dy_true, jac_true)
 end
 
 function Scenario(
@@ -72,7 +77,7 @@ function Scenario(
     jac = ForwardDiff.jacobian(f, x)
     dx_true = transpose(jac) * dy
     dy_true = jac * dx
-    return Scenario(f, x, y, dx, dy, dx_true, dy_true)
+    return Scenario(f, x, y, dx, dy, dx_true, dy_true, jac)
 end
 
 ## Access

--- a/test/zygote.jl
+++ b/test/zygote.jl
@@ -2,3 +2,4 @@ using DifferentiationInterface
 using Zygote
 
 test_pullback(ChainRulesReverseBackend(Zygote.ZygoteRuleConfig()); type_stability=false)
+test_jacobian(ChainRulesReverseBackend(Zygote.ZygoteRuleConfig()); type_stability=false)


### PR DESCRIPTION
This PR adds fallback implementatios for `value_and_jacobian!`, `value_and_jacobian`, `jacobian!`, and `jacobian`.

The implementation dispatches on `AbstractForwardBackend` and `AbstractReverseBackend`:
* `AbstractForwardBackend`: Makes use of `value_and_pushforward!`, which computes JVPs. The pushforward of a standard basis vector $e_i$ computes the $i$-th column of a Jacobian. The Jacobian is therefore assembled column-wise.
* `AbstractReverseBackend`: Makes use of `value_and_pullback!`, which compute VJPs. The pullback of a standard basis vector $e_i$ computes the $i$-th row of a Jacobian. The Jacobian is therefore assembled row-wise.

This requires the implementation of a standard basis vector in `src/unitvector`.
This implementation can be replaced with more performant implementations in the future by specializing on backend types.

To write into pre-allocated Jacobians, type annotations of pullbacks and pushforwards had to be loosened.

Towards #6.