### PR TITLE
Make all backends compatible with all input/output pairs

### DIFF
--- a/benchmark/utils.jl
+++ b/benchmark/utils.jl
@@ -2,7 +2,7 @@ using ADTypes
 using ADTypes: AbstractADType
 using BenchmarkTools
 using DifferentiationInterface
-using DifferentiationInterface: ForwardMode, ReverseMode, autodiff_mode, handles_types
+using DifferentiationInterface: ForwardMode, ReverseMode, autodiff_mode
 
 ## Pretty printing
 
@@ -28,8 +28,7 @@ function add_pushforward_benchmarks!(
     dx = n == 1 ? randn() : randn(n)
     dy = m == 1 ? 0.0 : zeros(m)
 
-    if !isa(autodiff_mode(backend), ForwardMode) ||
-        !handles_types(backend, typeof(x), typeof(dy))
+    if !isa(autodiff_mode(backend), ForwardMode)
         return nothing
     end
 
@@ -61,8 +60,7 @@ function add_pullback_benchmarks!(
     dx = n == 1 ? 0.0 : zeros(n)
     dy = m == 1 ? randn() : randn(m)
 
-    if !isa(autodiff_mode(backend), ReverseMode) ||
-        !handles_types(backend, typeof(x), typeof(dy))
+    if !isa(autodiff_mode(backend), ReverseMode)
         return nothing
     end
 
@@ -93,9 +91,6 @@ function add_derivative_benchmarks!(
     suite::BenchmarkGroup, backend::AbstractADType, f::F, n::Integer, m::Integer
 ) where {F}
     @assert n == m == 1
-    if !handles_types(backend, Number, Number)
-        return nothing
-    end
 
     x = randn()
 
@@ -118,9 +113,6 @@ function add_multiderivative_benchmarks!(
     suite::BenchmarkGroup, backend::AbstractADType, f::F, n::Integer, m::Integer
 ) where {F}
     @assert n == 1
-    if !handles_types(backend, Number, Vector)
-        return nothing
-    end
 
     x = randn()
     multider = zeros(m)
@@ -150,9 +142,6 @@ function add_gradient_benchmarks!(
     suite::BenchmarkGroup, backend::AbstractADType, f::F, n::Integer, m::Integer
 ) where {F}
     @assert m == 1
-    if !handles_types(backend, Vector, Number)
-        return nothing
-    end
 
     x = randn(n)
     grad = zeros(n)
@@ -181,10 +170,6 @@ end
 function add_jacobian_benchmarks!(
     suite::BenchmarkGroup, backend::AbstractADType, f::F, n::Integer, m::Integer
 ) where {F}
-    if !handles_types(backend, Vector, Vector)
-        return nothing
-    end
-
     x = randn(n)
     jac = zeros(m, n)
 

--- a/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -5,6 +5,7 @@ import DifferentiationInterface as DI
 using DocStringExtensions
 using Enzyme:
     Active,
+    Const,
     Duplicated,
     Forward,
     Reverse,

--- a/ext/DifferentiationInterfaceEnzymeExt/reverse.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt/reverse.jl
@@ -35,7 +35,7 @@ function DI.value_and_pullback!(
 ) where {X<:Number,Y<:AbstractArray}
     y = f(x)
     mf = Mutating(f)
-    _, new_dx = autodiff(Reverse, mf, Const, Duplicated(y, dy), Active(x))
+    _, new_dx = only(autodiff(Reverse, mf, Const, Duplicated(y, copy(dy)), Active(x)))
     return y, new_dx
 end
 
@@ -43,9 +43,11 @@ function DI.value_and_pullback!(
     dx, ::AutoReverseEnzyme, f, x::X, dy::Y, extras::Nothing=nothing
 ) where {X<:AbstractArray,Y<:AbstractArray}
     y = f(x)
-    dx .= zero(eltype(dx))
+    dx_righttype = similar(x)
+    dx_righttype .= zero(eltype(dx_righttype))
     mf = Mutating(f)
-    autodiff(Reverse, mf, Const, Duplicated(y, dy), Duplicated(x, dx))
+    autodiff(Reverse, mf, Const, Duplicated(y, copy(dy)), Duplicated(x, dx_righttype))
+    dx .= dx_righttype
     return y, dx
 end
 

--- a/ext/DifferentiationInterfaceReverseDiffExt.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt.jl
@@ -34,7 +34,7 @@ function DI.value_and_pullback!(
     _dx, backend::AutoReverseDiff, f, x::X, dy::Y, extras::Nothing=nothing
 ) where {X<:Number,Y}
     x_array = [x]
-    dx_array = [zero(x)]
+    dx_array = similar(x_array)
     y, dx_array = DI.value_and_pullback!(dx_array, backend, f ∘ only, x_array, dy, extras)
     return y, only(dx_array)
 end

--- a/ext/DifferentiationInterfaceReverseDiffExt.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt.jl
@@ -7,10 +7,6 @@ using DocStringExtensions
 using LinearAlgebra: mul!
 using ReverseDiff: gradient, gradient!, jacobian, jacobian!
 
-## Limitations
-
-DI.handles_input_type(::AutoReverseDiff, ::Type{<:Number}) = false
-
 ## Primitives
 
 function DI.value_and_pullback!(
@@ -32,6 +28,15 @@ function DI.value_and_pullback!(
     J = DiffResults.jacobian(res)
     mul!(vec(dx), transpose(J), vec(dy))
     return y, dx
+end
+
+function DI.value_and_pullback!(
+    _dx, backend::AutoReverseDiff, f, x::X, dy::Y, extras::Nothing=nothing
+) where {X<:Number,Y}
+    x_array = [x]
+    dx_array = [zero(x)]
+    y, dx_array = DI.value_and_pullback!(dx_array, backend, f ∘ only, x_array, dy, extras)
+    return y, only(dx_array)
 end
 
 ## Utilities (TODO: use DiffResults)

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -12,28 +12,3 @@ We classify `ADTypes.AbstractFiniteDifferencesMode` as forward mode.
 autodiff_mode(::AbstractForwardMode) = ForwardMode()
 autodiff_mode(::AbstractFiniteDifferencesMode) = ForwardMode()
 autodiff_mode(::AbstractReverseMode) = ReverseMode()
-
-"""
-    handles_input_type(backend, ::Type{X})
-
-Check if `backend` can differentiate functions with input type `X`.
-"""
-handles_input_type(::AbstractADType, ::Type{<:Number}) = true
-handles_input_type(::AbstractADType, ::Type{<:AbstractArray}) = true
-
-"""
-    handles_output_type(backend, ::Type{Y})
-
-Check if `backend` can differentiate functions with output type `Y`.
-"""
-handles_output_type(::AbstractADType, ::Type{<:Number}) = true
-handles_output_type(::AbstractADType, ::Type{<:AbstractArray}) = true
-
-"""
-    handles_types(backend, ::Type{X}, ::Type{Y})
-
-Check if `backend` can differentiate functions with input type `X` and output type `Y`.
-"""
-function handles_types(backend::AbstractADType, ::Type{X}, ::Type{Y}) where {X,Y}
-    return handles_input_type(backend, X) && handles_output_type(backend, Y)
-end

--- a/test/enzyme_reverse.jl
+++ b/test/enzyme_reverse.jl
@@ -2,4 +2,4 @@ using ADTypes: AutoEnzyme
 using Enzyme: Enzyme
 
 test_pullback(AutoEnzyme(Val(:reverse)), scenarios; type_stability=true);
-test_jacobian_and_friends(AutoEnzyme(Val(:reverse)), scenarios; type_stability=true)
+test_jacobian_and_friends(AutoEnzyme(Val(:reverse)), scenarios; type_stability=true);

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,6 +1,6 @@
 using ADTypes: AbstractADType
 using DifferentiationInterface
-using DifferentiationInterface: ForwardMode, ReverseMode, autodiff_mode, handles_types
+using DifferentiationInterface: ForwardMode, ReverseMode, autodiff_mode
 using JET
 using Test
 
@@ -23,7 +23,6 @@ function test_pushforward(
     @testset "Pushforward" begin
         for scenario in scenarios
             X, Y = get_input_type(scenario), get_output_type(scenario)
-            handles_types(backend, X, Y) || continue
 
             @testset "$X -> $Y" begin
                 (; f, x, y, dx, dy_true) = scenario
@@ -104,7 +103,6 @@ function test_pullback(
     @testset "Pullback" begin
         for scenario in scenarios
             X, Y = get_input_type(scenario), get_output_type(scenario)
-            handles_types(backend, X, Y) || continue
 
             @testset "$X -> $Y" begin
                 (; f, x, y, dy, dx_true) = scenario
@@ -178,7 +176,6 @@ function test_derivative(
     @testset "Derivative" begin
         for scenario in scenarios
             X, Y = get_input_type(scenario), get_output_type(scenario)
-            handles_types(backend, X, Y) || continue
 
             @testset "$X -> $Y" begin
                 (; f, x, y, der_true) = scenario
@@ -231,7 +228,6 @@ function test_multiderivative(
     @testset "Multiderivative" begin
         for scenario in scenarios
             X, Y = get_input_type(scenario), get_output_type(scenario)
-            handles_types(backend, X, Y) || continue
 
             @testset "$X -> $Y" begin
                 (; f, x, y, multider_true) = scenario
@@ -307,7 +303,6 @@ function test_gradient(
     @testset "Gradient" begin
         for scenario in scenarios
             X, Y = get_input_type(scenario), get_output_type(scenario)
-            handles_types(backend, X, Y) || continue
 
             @testset "$X -> $Y" begin
                 (; f, x, y, grad_true) = scenario
@@ -379,7 +374,6 @@ function test_jacobian(
     @testset "Jacobian" begin
         for scenario in scenarios
             X, Y = get_input_type(scenario), get_output_type(scenario)
-            handles_types(backend, X, Y) || continue
 
             @testset "$X -> $Y" begin
                 (; f, x, y, jac_true) = scenario


### PR DESCRIPTION
## Problem

We want all backends to support scalar or array inputs and outputs, but

- Reverse mode Enzyme only supports [scalar or `nothing` output](https://enzymead.github.io/Enzyme.jl/stable/api/#EnzymeCore.autodiff-Union{Tuple{RABI},%20Tuple{ReturnPrimal},%20Tuple{A},%20Tuple{FA},%20Tuple{ReverseMode{ReturnPrimal,%20RABI},%20FA,%20Type{A},%20Vararg{Any}}}%20where%20{FA%3C:Annotation,%20A%3C:Annotation,%20ReturnPrimal,%20RABI%3C:EnzymeCore.ABI})
- ReverseDiff API only supports [array input](https://juliadiff.org/ReverseDiff.jl/api/)

## Solution

- For Enzyme, wrap `f(x)::AbstractArray` into a callable struct `mf!` that does `mf!(y, x) = y .= f(x)`, and differentiate through this struct
- For ReverseDiff, compose `f(x::Number)` with `x -> [x]` and differentiate the result
- Remove `handles_types` machinery

@adrhill is it a good idea?