### PR TITLE
Preparation for ForwardDiff

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -11,10 +11,6 @@ using PolyesterForwardDiff: PolyesterForwardDiff
 using ReverseDiff: ReverseDiff
 using Zygote: Zygote, ZygoteRuleConfig
 
-## Settings
-
-BenchmarkTools.DEFAULT_PARAMETERS.evals = 1
-BenchmarkTools.DEFAULT_PARAMETERS.samples = 100
 BenchmarkTools.DEFAULT_PARAMETERS.seconds = 1
 
 ## Functions
@@ -49,8 +45,8 @@ all_backends = [
     AutoEnzyme(Val(:forward)),
     AutoEnzyme(Val(:reverse)),
     AutoFiniteDiff(),
-    AutoForwardDiff(),
-    AutoPolyesterForwardDiff(; chunksize=4),
+    AutoForwardDiff(; chunksize=2),
+    AutoPolyesterForwardDiff(; chunksize=2),
     AutoReverseDiff(),
     AutoZygote(),
 ]

--- a/benchmark/dataframe.jl
+++ b/benchmark/dataframe.jl
@@ -4,20 +4,19 @@ using DataFrames
 using Statistics
 
 function parse_benchmark_results_aux(
-    result::BenchmarkTools.Trial, level=nothing; aggregators=[median, minimum]
+    result::BenchmarkTools.Trial, level=nothing; aggregators=[minimum, median]
 )
-    data = DataFrame(
-        :samples => [length(result.times)],
-        :params_evals => [result.params.evals],
-        :params_samples => [result.params.samples],
-        :params_seconds => [result.params.seconds],
-    )
+    data = DataFrame()
     for agg in aggregators
         data[!, Symbol("time_$agg")] = [agg(result.times)]
         data[!, Symbol("memory_$agg")] = [agg(result.memory)]
         data[!, Symbol("allocs_$agg")] = [agg(result.allocs)]
         data[!, Symbol("gctime_$agg")] = [agg(result.gctimes)]
     end
+    data[!, :samples] = [length(result.times)]
+    data[!, :params_evals] = [result.params.evals]
+    data[!, :params_samples] = [result.params.samples]
+    data[!, :params_seconds] = [result.params.seconds]
     return data
 end
 

--- a/benchmark/run.jl
+++ b/benchmark/run.jl
@@ -3,6 +3,7 @@ using BenchmarkTools
 include("benchmarks.jl")
 
 # Run benchmarks locally
+# BenchmarkTools.tune!(SUITE; verbose=true)
 results = BenchmarkTools.run(SUITE; verbose=true)
 
 # Parse into dataframe

--- a/benchmark/utils.jl
+++ b/benchmark/utils.jl
@@ -38,17 +38,17 @@ function add_pushforward_benchmarks!(
 
         subgroup["value_and_pushforward"] = @benchmarkable begin
             value_and_pushforward($backend, $f, $x, $dx, $extras)
-        end evals = 1
+        end
         subgroup["value_and_pushforward!"] = @benchmarkable begin
             value_and_pushforward!($dy, $backend, $f, $x, $dx, $extras)
-        end evals = 1
+        end
 
         subgroup["pushforward"] = @benchmarkable begin
             pushforward($backend, $f, $x, $dx, $extras)
-        end evals = 1
+        end
         subgroup["pushforward!"] = @benchmarkable begin
             pushforward!($dy, $backend, $f, $x, $dx, $extras)
-        end evals = 1
+        end
     end
 
     return nothing
@@ -73,17 +73,17 @@ function add_pullback_benchmarks!(
 
         subgroup["value_and_pullback"] = @benchmarkable begin
             value_and_pullback($backend, $f, $x, $dy, $extras)
-        end evals = 1
+        end
         subgroup["value_and_pullback!"] = @benchmarkable begin
             value_and_pullback!($dx, $backend, $f, $x, $dy, $extras)
-        end evals = 1
+        end
 
         subgroup["pullback"] = @benchmarkable begin
             pullback($backend, $f, $x, $dy, $extras)
-        end evals = 1
+        end
         subgroup["pullback!"] = @benchmarkable begin
             pullback!($dx, $backend, $f, $x, $dy, $extras)
-        end evals = 1
+        end
     end
 
     return nothing
@@ -104,11 +104,11 @@ function add_derivative_benchmarks!(
 
         subgroup["value_and_derivative"] = @benchmarkable begin
             value_and_derivative($backend, $f, $x, $extras)
-        end evals = 1
+        end
 
         subgroup["derivative"] = @benchmarkable begin
             derivative($backend, $f, $x, $extras)
-        end evals = 1
+        end
     end
 
     return nothing
@@ -130,17 +130,17 @@ function add_multiderivative_benchmarks!(
 
         subgroup["value_and_multiderivative"] = @benchmarkable begin
             value_and_multiderivative($backend, $f, $x, $extras)
-        end evals = 1
+        end
         subgroup["value_and_multiderivative!"] = @benchmarkable begin
             value_and_multiderivative!($multider, $backend, $f, $x, $extras)
-        end evals = 1
+        end
 
         subgroup["multiderivative"] = @benchmarkable begin
             multiderivative($backend, $f, $x, $extras)
-        end evals = 1
+        end
         subgroup["multiderivative!"] = @benchmarkable begin
             multiderivative!($multider, $backend, $f, $x, $extras)
-        end evals = 1
+        end
     end
 
     return nothing
@@ -162,17 +162,17 @@ function add_gradient_benchmarks!(
 
         subgroup["value_and_gradient"] = @benchmarkable begin
             value_and_gradient($backend, $f, $x, $extras)
-        end evals = 1
+        end
         subgroup["value_and_gradient!"] = @benchmarkable begin
             value_and_gradient!($grad, $backend, $f, $x, $extras)
-        end evals = 1
+        end
 
         subgroup["gradient"] = @benchmarkable begin
             gradient($backend, $f, $x, $extras)
-        end evals = 1
+        end
         subgroup["gradient!"] = @benchmarkable begin
             gradient!($grad, $backend, $f, $x, $extras)
-        end evals = 1
+        end
     end
 
     return nothing
@@ -193,17 +193,17 @@ function add_jacobian_benchmarks!(
 
         subgroup["value_and_jacobian"] = @benchmarkable begin
             value_and_jacobian($backend, $f, $x, $extras)
-        end evals = 1
+        end
         subgroup["value_and_jacobian!"] = @benchmarkable begin
             value_and_jacobian!($jac, $backend, $f, $x, $extras)
-        end evals = 1
+        end
 
         subgroup["jacobian"] = @benchmarkable begin
             jacobian($backend, $f, $x, $extras)
-        end evals = 1
+        end
         subgroup["jacobian!"] = @benchmarkable begin
             jacobian!($jac, $backend, $f, $x, $extras)
-        end evals = 1
+        end
     end
 
     return nothing

--- a/ext/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt.jl
@@ -191,17 +191,19 @@ end
 
 ## Preparation
 
+function DI.prepare_gradient(::AutoForwardDiff{nothing}, f, x::AbstractArray)
+    return GradientConfig(f, x, Chunk(x))
+end
+
 function DI.prepare_gradient(::AutoForwardDiff{C}, f, x::AbstractArray) where {C}
-    if isnothing(C)
-        error("Chunk size was not set in `AutoForwardDiff(; chunksize)`")
-    end
     return GradientConfig(f, x, Chunk{C}())
 end
 
+function DI.prepare_jacobian(::AutoForwardDiff{nothing}, f, x::AbstractArray)
+    return JacobianConfig(f, x, Chunk(x))
+end
+
 function DI.prepare_jacobian(::AutoForwardDiff{C}, f, x::AbstractArray) where {C}
-    if isnothing(C)
-        error("Chunk size was not set in `AutoForwardDiff(; chunksize)`")
-    end
     return JacobianConfig(f, x, Chunk{C}())
 end
 

--- a/ext/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt.jl
@@ -5,7 +5,10 @@ import DifferentiationInterface as DI
 using DiffResults: DiffResults
 using DocStringExtensions
 using ForwardDiff:
+    Chunk,
     Dual,
+    GradientConfig,
+    JacobianConfig,
     Tag,
     derivative,
     derivative!,
@@ -18,7 +21,7 @@ using ForwardDiff:
     value
 using LinearAlgebra: mul!
 
-## Primitives
+## Pushforward
 
 function DI.value_and_pushforward!(
     _dy::Y, ::AutoForwardDiff, f, x::X, dx, extras::Nothing=nothing
@@ -45,8 +48,8 @@ end
 function DI.value_and_pushforward!(
     _dy::Y, ::AutoForwardDiff, f, x::X, dx, extras::Nothing=nothing
 ) where {X<:AbstractArray,Y<:Real}
-    T = typeof(Tag(f, X))  # TODO: unsure
-    xdual = Dual{T}.(x, dx)  # TODO: allocation
+    T = typeof(Tag(f, eltype(X)))
+    xdual = Dual{T}.(x, dx)
     ydual = f(xdual)
     y = value(T, ydual)
     new_dy = extract_derivative(T, ydual)
@@ -56,62 +59,150 @@ end
 function DI.value_and_pushforward!(
     dy::Y, ::AutoForwardDiff, f, x::X, dx, extras::Nothing=nothing
 ) where {X<:AbstractArray,Y<:AbstractArray}
-    T = typeof(Tag(f, X))  # TODO: unsure
-    xdual = Dual{T}.(x, dx)  # TODO: allocation
+    T = typeof(Tag(f, eltype(X)))
+    xdual = Dual{T}.(x, dx)
     ydual = f(xdual)
     y = value.(T, ydual)
     dy = extract_derivative!(T, dy, ydual)
     return y, dy
 end
 
-## Utilities (TODO: use DiffResults)
+## Derivative
 
-function DI.value_and_derivative(::AutoForwardDiff, f, x::Number, extras::Nothing)
-    y = f(x)
-    der = derivative(f, x)
-    return y, der
+function DI.derivative(::AutoForwardDiff, f, x::Number, extras::Nothing)
+    return derivative(f, x)
 end
 
-function DI.value_and_multiderivative(::AutoForwardDiff, f, x::Number, extras::Nothing)
-    y = f(x)
-    multider = derivative(f, x)
-    return y, multider
-end
+## Multiderivative
 
-function DI.value_and_multiderivative!(
+function DI.multiderivative!(
     multider::AbstractArray, ::AutoForwardDiff, f, x::Number, extras::Nothing
 )
-    y = f(x)
     derivative!(multider, f, x)
-    return y, multider
+    return multider
 end
 
-function DI.value_and_gradient(::AutoForwardDiff, f, x::AbstractArray, extras::Nothing)
-    y = f(x)
-    grad = gradient(f, x)
-    return y, grad
+function DI.multiderivative(::AutoForwardDiff, f, x::Number, extras::Nothing)
+    return derivative(f, x)
+end
+
+## Gradient
+
+function DI.value_and_gradient!(
+    grad::AbstractArray, backend::AutoForwardDiff, f, x::AbstractArray, extras::Nothing
+)
+    return DI.value_and_gradient!(grad, backend, f, x, DI.prepare_gradient(backend, f, x))
 end
 
 function DI.value_and_gradient!(
-    grad::AbstractArray, ::AutoForwardDiff, f, x::AbstractArray, extras::Nothing
+    grad::AbstractArray, ::AutoForwardDiff, f, x::AbstractArray, extras::GradientConfig
 )
-    y = f(x)
-    gradient!(grad, f, x)
-    return y, grad
+    result = DiffResults.DiffResult(zero(eltype(x)), grad)
+    result = gradient!(result, f, x, extras)
+    return DiffResults.value(result), DiffResults.gradient(result)
 end
 
-function DI.value_and_jacobian(::AutoForwardDiff, f, x::AbstractArray, extras::Nothing)
-    y = f(x)
-    jac = jacobian(f, x)
-    return y, jac
+function DI.value_and_gradient(
+    backend::AutoForwardDiff, f, x::AbstractArray, extras::Nothing
+)
+    return DI.value_and_gradient(backend, f, x, DI.prepare_gradient(backend, f, x))
+end
+
+function DI.value_and_gradient(
+    ::AutoForwardDiff, f, x::AbstractArray, extras::GradientConfig
+)
+    result = DiffResults.GradientResult(x)
+    result = gradient!(result, f, x, extras)
+    return DiffResults.value(result), DiffResults.gradient(result)
+end
+
+function DI.gradient!(
+    grad::AbstractArray, backend::AutoForwardDiff, f, x::AbstractArray, extras::Nothing
+)
+    return DI.gradient!(grad, backend, f, x, DI.prepare_gradient(backend, f, x))
+end
+
+function DI.gradient!(
+    grad::AbstractArray, ::AutoForwardDiff, f, x::AbstractArray, extras::GradientConfig
+)
+    gradient!(grad, f, x, extras)
+    return grad
+end
+
+function DI.gradient(backend::AutoForwardDiff, f, x::AbstractArray, extras::Nothing)
+    return DI.gradient(backend, f, x, DI.prepare_gradient(backend, f, x))
+end
+
+function DI.gradient(
+    ::AutoForwardDiff, f, x::AbstractArray, extras::Union{Nothing,GradientConfig}
+)
+    return gradient(f, x, extras)
+end
+
+## Jacobian
+
+function DI.value_and_jacobian!(
+    jac::AbstractMatrix, backend::AutoForwardDiff, f, x::AbstractArray, extras::Nothing
+)
+    return DI.value_and_jacobian!(jac, backend, f, x, DI.prepare_jacobian(backend, f, x))
 end
 
 function DI.value_and_jacobian!(
-    jac::AbstractMatrix, ::AutoForwardDiff, f, x::AbstractArray, extras::Nothing
+    jac::AbstractMatrix, ::AutoForwardDiff, f, x::AbstractArray, extras::JacobianConfig
 )
     y = f(x)
-    jacobian!(jac, f, x)
-    return y, jac
+    result = DiffResults.DiffResult(y, jac)
+    result = jacobian!(result, f, x, extras)
+    return DiffResults.value(result), DiffResults.jacobian(result)
+end
+
+function DI.value_and_jacobian(
+    backend::AutoForwardDiff, f, x::AbstractArray, extras::Nothing
+)
+    return DI.value_and_jacobian(backend, f, x, DI.prepare_jacobian(backend, f, x))
+end
+
+function DI.value_and_jacobian(
+    ::AutoForwardDiff, f, x::AbstractArray, extras::JacobianConfig
+)
+    return f(x), jacobian(f, x, extras)
+end
+
+function DI.jacobian!(
+    jac::AbstractMatrix, backend::AutoForwardDiff, f, x::AbstractArray, extras::Nothing
+)
+    return DI.jacobian!(jac, backend, f, x, DI.prepare_jacobian(backend, f, x))
+end
+
+function DI.jacobian!(
+    jac::AbstractMatrix, ::AutoForwardDiff, f, x::AbstractArray, extras::JacobianConfig
+)
+    jacobian!(jac, f, x, extras)
+    return jac
+end
+
+function DI.jacobian(backend::AutoForwardDiff, f, x::AbstractArray, extras::Nothing)
+    return DI.jacobian(backend, f, x, DI.prepare_jacobian(backend, f, x))
+end
+
+function DI.jacobian(::AutoForwardDiff, f, x::AbstractArray, extras::JacobianConfig)
+    return jacobian(f, x, extras)
+end
+
+## Preparation
+
+function DI.prepare_gradient(::AutoForwardDiff{C}, f, x::AbstractArray) where {C}
+    if isnothing(C)
+        error("Chunk size was not set in `AutoForwardDiff(; chunksize)`")
+    end
+    return GradientConfig(f, x, Chunk{C}())
+end
+
+function DI.prepare_jacobian(::AutoForwardDiff{C}, f, x::AbstractArray) where {C}
+    if isnothing(C)
+        error("Chunk size was not set in `AutoForwardDiff(; chunksize)`")
+    end
+    return JacobianConfig(f, x, Chunk{C}())
 end
 
 end # module

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -1,5 +1,10 @@
 using ADTypes: AutoForwardDiff
 using ForwardDiff: ForwardDiff
 
-test_pushforward(AutoForwardDiff(), scenarios; type_stability=true);
-test_jacobian_and_friends(AutoForwardDiff(), scenarios; type_stability=false);
+forwarddiff_backend = AutoForwardDiff(; chunksize=2)
+
+test_pushforward(forwarddiff_backend, scenarios; type_stability=true);
+test_derivative(forwarddiff_backend, scenarios; type_stability=true);
+test_multiderivative(forwarddiff_backend, scenarios; type_stability=true);
+test_gradient(forwarddiff_backend, scenarios; type_stability=true);
+test_jacobian(forwarddiff_backend, scenarios; type_stability=false);

--- a/test/polyesterforwarddiff.jl
+++ b/test/polyesterforwarddiff.jl
@@ -1,12 +1,12 @@
 using ADTypes: AutoPolyesterForwardDiff
 using PolyesterForwardDiff: PolyesterForwardDiff
 
-# see https://github.com/JuliaDiff/PolyesterForwardDiff.jl/issues/17
+polyesterforwarddiff_backend = AutoPolyesterForwardDiff(; chunksize=2)
 
-test_pushforward(AutoPolyesterForwardDiff(; chunksize=4), scenarios; type_stability=false);
+test_pushforward(polyesterforwarddiff_backend, scenarios; type_stability=false);
 
 test_jacobian_and_friends(
-    AutoPolyesterForwardDiff(; chunksize=4),
+    polyesterforwarddiff_backend,
     scenarios;
     input_type=Union{Number,AbstractVector},
     output_type=Union{Number,AbstractVector},


### PR DESCRIPTION
- Use [work buffers](https://juliadiff.org/ForwardDiff.jl/stable/user/api/#Preallocating/Configuring-Work-Buffers) to prepare gradient and jacobian computations
- Remove `evals = 1` to allow for benchmark tuning