### PR TITLE
Even more modular tests, add allocs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -81,16 +81,16 @@ Pages = ["prepare.jl"]
 
 ## Internals
 
-These are not part of the public API.
+This is not part of the public API.
 
 ```@autodocs
 Modules = [DifferentiationInterface]
 Public = false
 ```
 
-## Submodules
+## Testing
 
-These are not part of the public API.
+This is not part of the public API.
 
 ```@autodocs
 Modules = [DifferentiationTest]

--- a/docs/src/backends.md
+++ b/docs/src/backends.md
@@ -31,7 +31,7 @@ AutoFastDifferentiation
 SecondOrder
 ```
 
-## [Mutation support](@id backend_support_mutation)
+## [Mutation support](@id backend_mutation_behavior)
 
 All backends are compatible with allocating functions `f(x) = y`. Only some are compatible with mutating functions `f!(y, x) = nothing`:
 

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -85,7 +85,7 @@ Since `f!` operates in-place and the primal is computed every time, only four op
 
 Furthermore, the preparation function takes an additional argument: `prepare_operator(backend, f!, x, y)`.
 
-Check out the list of [backends that support mutating functions](@ref backend_support_mutation).
+Check out the list of [backends that support mutating functions](@ref backend_mutation_behavior).
 
 ## Multiple inputs/outputs
 

--- a/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -12,6 +12,7 @@ ruleconfig(backend::AutoChainRules) = backend.ruleconfig
 const AutoForwardChainRules = AutoChainRules{<:RuleConfig{>:HasForwardsMode}}
 const AutoReverseChainRules = AutoChainRules{<:RuleConfig{>:HasReverseMode}}
 
+DI.mutation_behavior(::AutoChainRules) = DI.MutationNotSupported()
 DI.mode(::AutoForwardChainRules) = DI.ForwardMode()
 DI.mode(::AutoReverseChainRules) = DI.ReverseMode()
 

--- a/ext/DifferentiationInterfaceChairmarksExt/DifferentiationInterfaceChairmarksExt.jl
+++ b/ext/DifferentiationInterfaceChairmarksExt/DifferentiationInterfaceChairmarksExt.jl
@@ -1,3 +1,238 @@
 module DifferentiationInterfaceChairmarksExt
 
+using ADTypes: AbstractADType
+using Chairmarks: @be
+using DifferentiationInterface
+using DifferentiationInterface:
+    ForwardMode,
+    ReverseMode,
+    MutationSupported,
+    MutationNotSupported,
+    mode,
+    mutation_behavior
+using DifferentiationInterface.DifferentiationTest
+import DifferentiationInterface.DifferentiationTest as DT
+using Test
+
+function soft_test_zero(v::Number)
+    if iszero(v)
+        @test v == zero(v)
+    else
+        @test_broken v == zero(v)
+    end
+end
+
+## Selector
+
+function DT.test_allocations(
+    backends::Vector{<:AbstractADType},
+    operators::Vector{Symbol},
+    scenarios::Vector{<:Scenario};
+)
+    @testset verbose = true "Allocations" begin
+        @testset "$op - $(backend_string(backend))" for op in operators, backend in backends
+            if op == :pushforward_allocating
+                @testset "$(typeof(s))" for s in allocating(
+                    vcat(scalar_scalar(scenarios), array_scalar(scenarios))
+                )
+                    test_allocations_pushforward_allocating(backend, s)
+                end
+            elseif op == :pushforward_mutating
+                @testset "$(typeof(s))" for s in mutating(scenarios)
+                    test_allocations_pushforward_mutating(backend, s)
+                end
+
+            elseif op == :pullback_allocating
+                @testset "$(typeof(s))" for s in allocating(
+                    vcat(scalar_scalar(scenarios), array_scalar(scenarios))
+                )
+                    test_allocations_pullback_allocating(backend, s)
+                end
+            elseif op == :pullback_mutating
+                @testset "$(typeof(s))" for s in mutating(scenarios)
+                    test_allocations_pullback_mutating(backend, s)
+                end
+
+            elseif op == :derivative_allocating
+                @testset "$(typeof(s))" for s in allocating(scalar_scalar(scenarios))
+                    test_allocations_derivative_allocating(backend, s)
+                end
+
+            elseif op == :multiderivative_allocating
+                nothing
+            elseif op == :multiderivative_mutating
+                @testset "$(typeof(s))" for s in mutating(scalar_array(scenarios))
+                    test_allocations_multiderivative_mutating(backend, s)
+                end
+
+            elseif op == :gradient_allocating
+                @testset "$(typeof(s))" for s in allocating(array_scalar(scenarios))
+                    test_allocations_gradient_allocating(backend, s)
+                end
+
+            elseif op == :jacobian_allocating
+                nothing
+            elseif op == :jacobian_mutating
+                @testset "$(typeof(s))" for s in mutating(array_array(scenarios))
+                    test_allocations_jacobian_mutating(backend, s)
+                end
+
+            elseif op == :second_derivative_allocating
+                @testset "$(typeof(s))" for s in allocating(scalar_scalar(scenarios))
+                    test_allocations_second_derivative_allocating(backend, s)
+                end
+
+            elseif op == :hessian_vector_product_allocating
+                @testset "$(typeof(s))" for s in allocating(array_scalar(scenarios))
+                    test_allocations_hessian_vector_product_allocating(backend, s)
+                end
+            elseif op == :hessian_allocating
+                @testset "$(typeof(s))" for s in allocating(array_scalar(scenarios))
+                    test_allocations_hessian_allocating(backend, s)
+                end
+
+            else
+                throw(ArgumentError("Invalid operator to test: `:$op`"))
+            end
+        end
+    end
+end
+
+## Pushforward
+
+function test_allocations_pushforward_allocating(ba::AbstractADType, scenario::Scenario)
+    isa(mode(ba), ReverseMode) && return nothing
+    (; f, x, dx, dy) = deepcopy(scenario)
+    extras = prepare_pushforward(ba, f, x)
+    bench1 = @be zero(dy) value_and_pushforward!(_, ba, f, x, dx, extras)
+    bench2 = @be zero(dy) pushforward!(_, ba, f, x, dx, extras)
+    soft_test_zero(minimum(bench1).allocs)
+    soft_test_zero(minimum(bench2).allocs)
+    return nothing
+end
+
+function test_allocations_pushforward_mutating(ba::AbstractADType, scenario::Scenario)
+    isa(mode(ba), ReverseMode) && return nothing
+    (; f, x, y, dx, dy) = deepcopy(scenario)
+    f! = f
+    extras = prepare_pushforward(ba, f!, x, y)
+    bench1 = @be (zero(y), zero(dy)) value_and_pushforward!(
+        _[1], _[2], ba, f!, x, dx, extras
+    )
+    soft_test_zero(minimum(bench1).allocs)
+    return nothing
+end
+
+## Pullback
+
+function test_allocations_pullback_allocating(ba::AbstractADType, scenario::Scenario)
+    isa(mode(ba), ForwardMode) && return nothing
+    (; f, x, dx, dy) = deepcopy(scenario)
+    extras = prepare_pullback(ba, f, x)
+    bench1 = @be zero(dx) value_and_pullback!(_, ba, f, x, dy, extras)
+    bench2 = @be zero(dx) pullback!(_, ba, f, x, dy, extras)
+    soft_test_zero(minimum(bench1).allocs)
+    soft_test_zero(minimum(bench2).allocs)
+    return nothing
+end
+
+function test_allocations_pullback_mutating(ba::AbstractADType, scenario::Scenario)
+    isa(mode(ba), ForwardMode) && return nothing
+    (; f, x, y, dx, dy) = deepcopy(scenario)
+    f! = f
+    extras = prepare_pullback(ba, f!, x, y)
+    bench1 = @be (zero(y), zero(dx)) value_and_pullback!(_[1], _[2], ba, f!, x, dy, extras)
+    soft_test_zero(minimum(bench1).allocs)
+    return nothing
+end
+
+## Derivative
+
+function test_allocations_derivative_allocating(ba::AbstractADType, scenario::Scenario)
+    (; f, x) = deepcopy(scenario)
+    extras = prepare_derivative(ba, f, x)
+    bench1 = @be value_and_derivative(ba, f, x, extras)
+    soft_test_zero(minimum(bench1).allocs)
+    return nothing
+end
+
+## Multiderivative
+
+function test_allocations_multiderivative_mutating(ba::AbstractADType, scenario::Scenario)
+    (; f, x, y, dy) = deepcopy(scenario)
+    f! = f
+    extras = prepare_multiderivative(ba, f!, x, y)
+    bench1 = @be (zero(y), zero(dy)) value_and_multiderivative!(
+        _[1], _[2], ba, f!, x, extras
+    )
+    soft_test_zero(minimum(bench1).allocs)
+    return nothing
+end
+
+## Gradient
+
+function test_allocations_gradient_allocating(ba::AbstractADType, scenario::Scenario)
+    (; f, x, dx) = deepcopy(scenario)
+    extras = prepare_gradient(ba, f, x)
+    bench1 = @be zero(dx) value_and_gradient!(_, ba, f, x, extras)
+    bench2 = @be zero(dx) gradient!(_, ba, f, x, extras)
+    soft_test_zero(minimum(bench1).allocs)
+    soft_test_zero(minimum(bench2).allocs)
+    return nothing
+end
+
+## Jacobian
+
+function test_allocations_jacobian_mutating(ba::AbstractADType, scenario::Scenario)
+    (; f, x, y) = deepcopy(scenario)
+    f! = f
+    jac_template = zeros(eltype(y), length(y), length(x))
+    extras = prepare_jacobian(ba, f!, x, y)
+    bench1 = @be (zero(y), zero(jac_template)) value_and_jacobian!(
+        _[1], _[2], ba, f!, x, extras
+    )
+    soft_test_zero(minimum(bench1).allocs)
+    return nothing
+end
+
+## Second derivative
+
+function test_allocations_second_derivative_allocating(
+    ba::AbstractADType, scenario::Scenario
+)
+    (; f, x) = deepcopy(scenario)
+    extras = prepare_second_derivative(ba, f, x)
+    bench1 = @be value_derivative_and_second_derivative(ba, f, x, extras)
+    soft_test_zero(minimum(bench1).allocs)
+    return nothing
+end
+
+## Hessian-vector product
+
+function test_allocations_hessian_vector_product_allocating(
+    ba::AbstractADType, scenario::Scenario
+)
+    (; f, x, dx) = deepcopy(scenario)
+    extras = prepare_hessian_vector_product(ba, f, x)
+    bench1 = @be zero(dx) hessian_vector_product!(_, ba, f, x, dx, extras)
+    soft_test_zero(minimum(bench1).allocs)
+    # TODO: add gradient
+    return nothing
+end
+
+## Hessian
+
+function test_allocations_hessian_allocating(ba::AbstractADType, scenario::Scenario)
+    (; f, x, y, dx) = deepcopy(scenario)
+    extras = prepare_hessian(ba, f, x)
+    hess_template = zeros(eltype(y), length(x), length(x))
+    bench1 = @be (zero(dx), zero(hess_template)) value_gradient_and_hessian!(
+        _[1], _[2], ba, f, x, extras
+    )
+    bench2 = @be (zero(hess_template)) hessian!(_, ba, f, x, extras)
+    soft_test_zero(minimum(bench1).allocs)
+    soft_test_zero(minimum(bench2).allocs)
+    return nothing
+end
+
 end

--- a/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
+++ b/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
@@ -7,6 +7,7 @@ import DifferentiationInterface as DI
 using Diffractor: DiffractorForwardBackend, DiffractorRuleConfig
 using DocStringExtensions
 
+DI.mutation_behavior(::AutoDiffractor) = DI.MutationNotSupported()
 DI.mode(::AutoDiffractor) = DI.ForwardMode()
 DI.mode(::AutoChainRules{<:DiffractorRuleConfig}) = DI.ForwardMode()
 

--- a/ext/DifferentiationInterfaceFastDifferentiationExt/DifferentiationInterfaceFastDifferentiationExt.jl
+++ b/ext/DifferentiationInterfaceFastDifferentiationExt/DifferentiationInterfaceFastDifferentiationExt.jl
@@ -13,6 +13,8 @@ using FastDifferentiation:
 using LinearAlgebra: dot
 using RuntimeGeneratedFunctions: RuntimeGeneratedFunction
 
+DI.mutation_behavior(::AutoFastDifferentiation) = DI.MutationNotSupported()
+
 include("allocating.jl")
 
 end

--- a/ext/DifferentiationInterfaceFiniteDiffExt/DifferentiationInterfaceFiniteDiffExt.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt/DifferentiationInterfaceFiniteDiffExt.jl
@@ -10,6 +10,8 @@ using FiniteDiff:
     finite_difference_jacobian
 using LinearAlgebra: dot, mul!
 
+DI.mutation_behavior(::AutoFiniteDiff) = DI.MutationNotSupported()  # TODO
+
 # see https://docs.sciml.ai/FiniteDiff/stable/#f-Definitions
 const FUNCTION_INPLACE = Val{true}
 const FUNCTION_NOT_INPLACE = Val{false}

--- a/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -1,7 +1,13 @@
 module DifferentiationInterfaceForwardDiffExt
 
 using ADTypes: AbstractADType, AutoForwardDiff
-using DifferentiationInterface: ReverseMode, ForwardMode, mode
+using DifferentiationInterface:
+    ForwardMode,
+    ReverseMode,
+    MutationSupported,
+    MutationNotSupported,
+    mode,
+    mutation_behavior
 import DifferentiationInterface as DI
 using DifferentiationInterface.DifferentiationTest
 import DifferentiationInterface.DifferentiationTest as DT

--- a/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -6,6 +6,8 @@ import DifferentiationInterface as DI
 using DocStringExtensions
 using Zygote: ZygoteRuleConfig, gradient, jacobian, pullback, withgradient, withjacobian
 
+DI.mutation_behavior(::AutoZygote) = DI.MutationNotSupported()
+
 ## Primitives
 
 function DI.value_and_pullback!(

--- a/src/DifferentiationInterface.jl
+++ b/src/DifferentiationInterface.jl
@@ -23,6 +23,7 @@ Chooses [FastDifferentiation.jl](https://github.com/brianguenter/FastDifferentia
 struct AutoFastDifferentiation <: ADTypes.AbstractSymbolicDifferentiationMode end
 
 include("mode.jl")
+include("mutation.jl")
 include("utils.jl")
 include("prepare.jl")
 
@@ -39,9 +40,6 @@ include("second_order.jl")
 include("second_derivative.jl")
 include("hessian_vector_product.jl")
 include("hessian.jl")
-
-# submodules
-include("DifferentiationTest/DifferentiationTest.jl")
 
 export AutoFastDifferentiation
 export SecondOrder
@@ -82,6 +80,9 @@ export prepare_jacobian
 export prepare_second_derivative
 export prepare_hessian
 export prepare_hessian_vector_product
+
+# submodules
+include("DifferentiationTest/DifferentiationTest.jl")
 
 function __init__()
     Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs

--- a/src/DifferentiationTest/DifferentiationTest.jl
+++ b/src/DifferentiationTest/DifferentiationTest.jl
@@ -5,6 +5,16 @@ Testing utilities for [`DifferentiationInterface`](@ref).
 """
 module DifferentiationTest
 
+using ..DifferentiationInterface:
+    AutoFastDifferentiation,
+    AutoZeroForward,
+    AutoZeroReverse,
+    ForwardMode,
+    ReverseMode,
+    SymbolicMode,
+    SecondOrder,
+    mode
+using ADTypes
 using ADTypes: AbstractADType
 using DocStringExtensions
 using Test: @testset
@@ -13,10 +23,12 @@ include("utils.jl")
 include("scenario.jl")
 include("default_scenarios.jl")
 include("test_operators.jl")
+include("pretty.jl")
 
 export Scenario, default_scenarios
 export allocating, mutating
 export scalar_scalar, scalar_array, array_scalar, array_array
 export test_operators
+export backend_string
 
 end

--- a/src/DifferentiationTest/default_scenarios.jl
+++ b/src/DifferentiationTest/default_scenarios.jl
@@ -40,16 +40,20 @@ end
 f_matrix_vector(x::AbstractMatrix)::AbstractVector = vcat(vec(sin.(x)), vec(cos.(x)))
 
 function f!_matrix_vector(y::AbstractVector, x::AbstractMatrix)
-    y[1:length(x)] .= sin.(vec(x))
-    y[(length(x) + 1):(2length(x))] .= cos.(vec(x))
+    for i in eachindex(IndexLinear(), x)
+        y[i] = sin(x[i])
+        y[length(x) + i] = cos(x[i])
+    end
     return nothing
 end
 
 f_matrix_matrix(x::AbstractMatrix)::AbstractMatrix = hcat(vec(sin.(x)), vec(cos.(x)))
 
 function f!_matrix_matrix(y::AbstractMatrix, x::AbstractMatrix)
-    y[:, 1] .= sin.(vec(x))
-    y[:, 2] .= cos.(vec(x))
+    for i in eachindex(IndexLinear(), x)
+        y[i, 1] = sin(x[i])
+        y[i, 2] = cos(x[i])
+    end
     return nothing
 end
 

--- a/src/DifferentiationTest/pretty.jl
+++ b/src/DifferentiationTest/pretty.jl
@@ -1,0 +1,36 @@
+
+pretty(::AutoZeroForward) = "ZeroForward"
+pretty(::AutoZeroReverse) = "ZeroReverse"
+pretty(::AutoChainRules) = "ChainRules"
+pretty(::AutoDiffractor) = "Diffractor"
+pretty(::AutoEnzyme) = "Enzyme"
+pretty(::AutoFastDifferentiation) = "FastDifferentiation"
+pretty(::AutoFiniteDiff) = "FiniteDiff"
+pretty(::AutoForwardDiff) = "ForwardDiff"
+pretty(::AutoPolyesterForwardDiff) = "PolyesterForwardDiff"
+pretty(b::AutoReverseDiff) = "ReverseDiff($(b.compile))"
+pretty(::AutoZygote) = "Zygote"
+pretty(b::AbstractADType) = string(b)
+
+"""
+    backend_string(backend)
+
+Return a shorter string than the full object printing from ADTypes.jl.
+Might be ambiguous.
+"""
+function backend_string(backend::AbstractADType)
+    bs = pretty(backend)
+    if isa(mode(backend), ForwardMode)
+        return "$bs (forward)"
+    elseif isa(mode(backend), ReverseMode)
+        return "$bs (reverse)"
+    elseif isa(mode(backend), SymbolicMode)
+        return "$bs (symbolic)"
+    else
+        error("Unknown mode")
+    end
+end
+
+function backend_string(backend::SecondOrder)
+    return "$(backend_string(backend.outer)) / $(backend_string(backend.inner))"
+end

--- a/src/hessian_vector_product.jl
+++ b/src/hessian_vector_product.jl
@@ -171,7 +171,7 @@ function hessian_vector_product_aux(
     ::ReverseMode,
     ::ReverseMode,
 )
-    dotgrad_aux(z) = dot(gradient(inner(backend), f, z), v, extras)
+    dotgrad_aux(z) = dot(gradient(inner(backend), f, z, extras), v)
     return gradient(outer(backend), dotgrad_aux, x, extras)
 end
 
@@ -240,7 +240,7 @@ function hessian_vector_product_aux!(
     ::ReverseMode,
     ::ReverseMode,
 )
-    dotgrad_aux(z) = dot(gradient(inner(backend), f, z), v, extras)  # allocates
+    dotgrad_aux(z) = dot(gradient(inner(backend), f, z, extras), v)  # allocates
     return gradient!(hvp, outer(backend), dotgrad_aux, x, extras)
 end
 

--- a/src/multiderivative.jl
+++ b/src/multiderivative.jl
@@ -65,7 +65,7 @@ function value_and_multiderivative_aux!(
 )
     for i in eachindex(IndexCartesian(), multider)
         dy_i = basisarray(backend, multider, i)
-        _, multider[i] = value_and_pullback!(y, multider[i], backend, f!, x, dy_i, extras)
+        y, multider[i] = value_and_pullback!(y, multider[i], backend, f!, x, dy_i, extras)
     end
     return y, multider
 end

--- a/src/mutation.jl
+++ b/src/mutation.jl
@@ -1,0 +1,22 @@
+abstract type MutationBehavior end
+
+"""
+    MutationSupported
+
+Trait identifying backends that support mutating functions `f!(y, x)`.
+"""
+struct MutationSupported <: MutationBehavior end
+
+"""
+    MutationNotSupported
+
+Trait identifying backends that do not support mutating functions `f!(y, x)`.
+"""
+struct MutationNotSupported <: MutationBehavior end
+
+"""
+    mutation_behavior(backend)
+
+Return the mutation behavior of a backend.
+"""
+mutation_behavior(::AbstractADType) = MutationSupported()

--- a/test/chainrules_reverse.jl
+++ b/test/chainrules_reverse.jl
@@ -2,9 +2,4 @@ using ADTypes: AutoChainRules
 using Zygote: ZygoteRuleConfig
 using DifferentiationInterface.DifferentiationTest
 
-test_operators(
-    AutoChainRules(ZygoteRuleConfig());
-    mutating=false,
-    excluded=[:hessian_allocating],
-    type_stability=false,
-);
+test_operators(AutoChainRules(ZygoteRuleConfig()); second_order=false, type_stability=false);

--- a/test/diffractor.jl
+++ b/test/diffractor.jl
@@ -2,6 +2,4 @@ using ADTypes: AutoDiffractor
 using Diffractor: Diffractor
 using DifferentiationInterface.DifferentiationTest
 
-test_operators(
-    AutoDiffractor(); mutating=false, excluded=[:hessian_allocating], type_stability=false
-);
+test_operators(AutoDiffractor(); second_order=false, type_stability=false);

--- a/test/enzyme_forward.jl
+++ b/test/enzyme_forward.jl
@@ -5,6 +5,4 @@ using DifferentiationInterface.DifferentiationTest
 test_operators(
     AutoEnzyme(Enzyme.Forward); second_order=false, excluded=[:jacobian_allocating]
 );
-test_operators(
-    AutoEnzyme(Enzyme.Forward); operators=[:jacobian_allocating], type_stability=false
-);
+test_operators(AutoEnzyme(Enzyme.Forward), [:jacobian_allocating]; type_stability=false);

--- a/test/fastdifferentiation.jl
+++ b/test/fastdifferentiation.jl
@@ -6,7 +6,6 @@ test_operators(
     AutoFastDifferentiation();
     input_type=Union{Number,AbstractVector},
     output_type=Union{Number,AbstractVector},
-    mutating=false,
     second_order=false,
     type_stability=false,
 );

--- a/test/finitediff.jl
+++ b/test/finitediff.jl
@@ -2,7 +2,5 @@ using ADTypes: AutoFiniteDiff
 using FiniteDiff: FiniteDiff
 using DifferentiationInterface.DifferentiationTest
 
-test_operators(
-    AutoFiniteDiff(); second_order=false, mutating=false, excluded=[:jacobian_allocating]
-);
-test_operators(AutoFiniteDiff(); operators=[:jacobian_allocating], type_stability=false);
+test_operators(AutoFiniteDiff(); second_order=false, excluded=[:jacobian_allocating]);
+test_operators(AutoFiniteDiff(), [:jacobian_allocating]; type_stability=false);

--- a/test/reversediff.jl
+++ b/test/reversediff.jl
@@ -2,7 +2,5 @@ using ADTypes: AutoReverseDiff
 using ReverseDiff: ReverseDiff
 using DifferentiationInterface.DifferentiationTest
 
-test_operators(AutoReverseDiff(); excluded=[:hessian_allocating], type_stability=false);
-test_operators(
-    AutoReverseDiff(; compile=true); excluded=[:hessian_allocating], type_stability=false
-);
+test_operators(AutoReverseDiff(); second_order=false, type_stability=false);
+test_operators(AutoReverseDiff(; compile=true); second_order=false, type_stability=false);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@
 
 using Aqua: Aqua
 using ChainRulesCore: ChainRulesCore
+using Chairmarks: Chairmarks
 using DifferentiationInterface
 using DifferentiationInterface.DifferentiationTest
 using Enzyme: Enzyme

--- a/test/second_order.jl
+++ b/test/second_order.jl
@@ -17,6 +17,6 @@ cross_backends = [
     SecondOrder(AutoForwardDiff(), AutoEnzyme(Enzyme.Reverse)),
 ]
 
-@testset "$(typeof(b.outer)) over $(typeof(b.inner))" for b in cross_backends
-    test_operators(b; first_order=false, mutating=false, type_stability=false)
+@testset "$(backend_string(backend))" for backend in cross_backends
+    test_operators(backend; first_order=false, mutating=false, type_stability=false)
 end;

--- a/test/zero.jl
+++ b/test/zero.jl
@@ -10,3 +10,12 @@ test_operators(
 test_operators(
     SecondOrder(AutoZeroReverse(), AutoZeroForward()); first_order=false, correctness=false
 );
+
+# allocs (experimental)
+
+test_operators(
+    [AutoZeroForward(), AutoZeroReverse()];
+    correctness=false,
+    type_stability=false,
+    allocations=true,
+);

--- a/test/zygote.jl
+++ b/test/zygote.jl
@@ -2,6 +2,4 @@ using ADTypes: AutoZygote
 using Zygote: Zygote
 using DifferentiationInterface.DifferentiationTest
 
-test_operators(
-    AutoZygote(); mutating=false, excluded=[:hessian_allocating], type_stability=false
-);
+test_operators(AutoZygote(); second_order=false, type_stability=false);


### PR DESCRIPTION
**Core**

- Add `mutation_behavior` trait
- Fix typo in hessian-vector product (still untested)

**Testing**

- Allow testing multiple backends at once
- Cleaner nesting and display for test sets
- Automatically skip tests that are incompatible with a backend (because of mode or mutation)
- Fully non-allocating functions `f!` (not sure why some operators still allocate with `AutoZero`, very strange)

**Extensions**

- Add `Chairmarks` extension where allocations are measured. By default the tests are reported as broken instead of failing
- Define `mutation_behavior` for backends not supporting mutation