### PR TITLE
Fake pushforwards and pullbacks

### DIFF
--- a/src/DifferentiationInterface.jl
+++ b/src/DifferentiationInterface.jl
@@ -84,31 +84,4 @@ export prepare_hessian_vector_product
 # submodules
 include("DifferentiationTest/DifferentiationTest.jl")
 
-function __init__()
-    Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
-        f_name = string(exc.f)
-        if (
-            f_name == "mode" ||
-            contains(f_name, "pushforward") ||
-            contains(f_name, "pullback") ||
-            contains(f_name, "derivative") ||
-            contains(f_name, "gradient") ||
-            contains(f_name, "jacobian") ||
-            contains(f_name, "hessian")
-        )
-            for T in argtypes
-                if T <: AbstractADType
-                    print(
-                        io,
-                        """\n
-                        HINT: To use `DifferentiationInterface` with backend `$T`, you need to load the corresponding package extension.
-                        """,
-                    )
-                    return nothing
-                end
-            end
-        end
-    end
-end
-
 end # module

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -10,23 +10,6 @@ function value_and_gradient!(
     x::AbstractArray,
     extras=prepare_gradient(backend, f, x),
 )
-    return value_and_gradient_aux!(grad, backend, f, x, extras, mode(backend))
-end
-
-function value_and_gradient_aux!(
-    grad::AbstractArray, backend::AbstractADType, f, x::AbstractArray, extras, ::ForwardMode
-)
-    y = f(x)
-    for j in eachindex(IndexCartesian(), grad)
-        dx_j = basisarray(backend, grad, j)
-        grad[j] = pushforward(backend, f, x, dx_j, extras)
-    end
-    return y, grad
-end
-
-function value_and_gradient_aux!(
-    grad::AbstractArray, backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode
-)
     return value_and_pullback!(grad, backend, f, x, one(eltype(x)), extras)
 end
 
@@ -37,19 +20,6 @@ Compute the primal value `y = f(x)` and the gradient `grad = ∇f(x)` of an arra
 """
 function value_and_gradient(
     backend::AbstractADType, f, x::AbstractArray, extras=prepare_gradient(backend, f, x)
-)
-    return value_and_gradient_aux(backend, f, x, extras, mode(backend))
-end
-
-function value_and_gradient_aux(
-    backend::AbstractADType, f, x::AbstractArray, extras, ::AbstractMode
-)
-    grad = similar(x)
-    return value_and_gradient!(grad, backend, f, x, extras)
-end
-
-function value_and_gradient_aux(
-    backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode
 )
     return value_and_pullback(backend, f, x, one(eltype(x)), extras)
 end
@@ -66,23 +36,6 @@ function gradient!(
     x::AbstractArray,
     extras=prepare_gradient(backend, f, x),
 )
-    return gradient_aux!(grad, backend, f, x, extras, mode(backend))
-end
-
-function gradient_aux!(
-    grad::AbstractArray,
-    backend::AbstractADType,
-    f,
-    x::AbstractArray,
-    extras,
-    ::AbstractMode,
-)
-    return last(value_and_gradient!(grad, backend, f, x, extras))
-end
-
-function gradient_aux!(
-    grad::AbstractArray, backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode
-)
     return pullback!(grad, backend, f, x, one(eltype(x)), extras)
 end
 
@@ -94,13 +47,5 @@ Compute the gradient `grad = ∇f(x)` of an array-to-scalar function.
 function gradient(
     backend::AbstractADType, f, x::AbstractArray, extras=prepare_gradient(backend, f, x)
 )
-    return gradient_aux(backend, f, x, extras, mode(backend))
-end
-
-function gradient_aux(backend::AbstractADType, f, x::AbstractArray, extras, ::AbstractMode)
-    return last(value_and_gradient(backend, f, x, extras))
-end
-
-function gradient_aux(backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode)
     return pullback(backend, f, x, one(eltype(x)), extras)
 end

--- a/src/multiderivative.jl
+++ b/src/multiderivative.jl
@@ -11,63 +11,18 @@ function value_and_multiderivative!(
     x::Number,
     extras=prepare_multiderivative(backend, f, x),
 )
-    return value_and_multiderivative_aux!(multider, backend, f, x, extras, mode(backend))
+    return value_and_pushforward!(multider, backend, f, x, one(x), extras)
 end
 
 function value_and_multiderivative!(
     y::AbstractArray,
     multider::AbstractArray,
     backend::AbstractADType,
-    f,
-    x::Number,
-    extras=prepare_multiderivative(backend, f, x, y),
-)
-    return value_and_multiderivative_aux!(y, multider, backend, f, x, extras, mode(backend))
-end
-
-function value_and_multiderivative_aux!(
-    multider::AbstractArray, backend::AbstractADType, f, x::Number, extras, ::ForwardMode
-)
-    return value_and_pushforward!(multider, backend, f, x, one(x), extras)
-end
-
-function value_and_multiderivative_aux!(
-    y::AbstractArray,
-    multider::AbstractArray,
-    backend::AbstractADType,
     f!,
     x::Number,
-    extras,
-    ::ForwardMode,
+    extras=prepare_multiderivative(backend, f!, x, y),
 )
     return value_and_pushforward!(y, multider, backend, f!, x, one(x), extras)
-end
-
-function value_and_multiderivative_aux!(
-    multider::AbstractArray, backend::AbstractADType, f, x::Number, extras, ::ReverseMode
-)
-    y = f(x)
-    for i in eachindex(IndexCartesian(), multider)
-        dy_i = basisarray(backend, multider, i)
-        multider[i] = pullback(backend, f, x, dy_i, extras)
-    end
-    return y, multider
-end
-
-function value_and_multiderivative_aux!(
-    y::AbstractArray,
-    multider::AbstractArray,
-    backend::AbstractADType,
-    f!,
-    x::Number,
-    extras,
-    ::ReverseMode,
-)
-    for i in eachindex(IndexCartesian(), multider)
-        dy_i = basisarray(backend, multider, i)
-        y, multider[i] = value_and_pullback!(y, multider[i], backend, f!, x, dy_i, extras)
-    end
-    return y, multider
 end
 
 """
@@ -78,20 +33,7 @@ Compute the primal value `y = f(x)` and the (array-valued) derivative `multider 
 function value_and_multiderivative(
     backend::AbstractADType, f, x::Number, extras=prepare_multiderivative(backend, f, x)
 )
-    return value_and_multiderivative_aux(backend, f, x, extras, mode(backend))
-end
-
-function value_and_multiderivative_aux(
-    backend::AbstractADType, f, x::Number, extras, ::ForwardMode
-)
     return value_and_pushforward(backend, f, x, one(x), extras)
-end
-
-function value_and_multiderivative_aux(
-    backend::AbstractADType, f, x::Number, extras, ::AbstractMode
-)
-    multider = similar(f(x))
-    return value_and_multiderivative!(multider, backend, f, x, extras)
 end
 
 """
@@ -106,19 +48,7 @@ function multiderivative!(
     x::Number,
     extras=prepare_multiderivative(backend, f, x),
 )
-    return multiderivative_aux!(multider, backend, f, x, extras, mode(backend))
-end
-
-function multiderivative_aux!(
-    multider::AbstractArray, backend::AbstractADType, f, x::Number, extras, ::ForwardMode
-)
     return pushforward!(multider, backend, f, x, one(x), extras)
-end
-
-function multiderivative_aux!(
-    multider::AbstractArray, backend::AbstractADType, f, x::Number, extras, ::AbstractMode
-)
-    return last(value_and_multiderivative!(multider, backend, f, x, extras))
 end
 
 """
@@ -129,13 +59,5 @@ Compute the (array-valued) derivative `multider = f'(x)` of a scalar-to-array fu
 function multiderivative(
     backend::AbstractADType, f, x::Number, extras=prepare_multiderivative(backend, f, x)
 )
-    return multiderivative_aux(backend, f, x, extras, mode(backend))
-end
-
-function multiderivative_aux(backend::AbstractADType, f, x::Number, extras, ::ForwardMode)
     return pushforward(backend, f, x, one(x), extras)
-end
-
-function multiderivative_aux(backend::AbstractADType, f, x::Number, extras, ::AbstractMode)
-    return last(value_and_multiderivative(backend, f, x, extras))
 end

--- a/src/pullback.jl
+++ b/src/pullback.jl
@@ -7,12 +7,87 @@ Compute the primal value `y = f(x)` and the vector-Jacobian product `dx = ∂f(x
 !!! info "Interface requirement"
     This is the only required implementation for a reverse mode backend.
 """
-function value_and_pullback!(dx, backend::AbstractADType, f, x, dy)
-    return value_and_pullback!(dx, backend, f, x, dy, prepare_pullback(backend, f, x))
+function value_and_pullback!(
+    dx, backend::AbstractADType, f, x, dy, extras=prepare_pullback(backend, f, x)
+)
+    return value_and_pullback_aux!(dx, backend, f, x, dy, extras, mode(backend))
 end
 
-function value_and_pullback!(y, dx, backend::AbstractADType, f, x, dy)
-    return value_and_pullback!(y, dx, backend, f, x, dy, prepare_pullback(backend, f, x, y))
+function value_and_pullback!(
+    y, dx, backend::AbstractADType, f!, x, dy, extras=prepare_pullback(backend, f!, x, y)
+)
+    return value_and_pullback_aux!(y, dx, backend, f!, x, dy, extras, mode(backend))
+end
+
+## Reverse mode (true pullback)
+
+function value_and_pullback_aux!(
+    dx, backend::AbstractADType, f, x, dy, extras, ::ReverseMode
+)
+    return error(
+        "You need to load the package for `$backend` or implement `DifferentiationInterface.value_and_pullback!` in reverse mode",
+    )
+end
+
+function value_and_pullback_aux!(
+    y, dx, backend::AbstractADType, f!, x, dy, extras, ::ReverseMode
+)
+    return error(
+        "You need to load the package for `$backend` or implement `DifferentiationInterface.value_and_pullback!` in reverse mode",
+    )
+end
+
+## Forward mode (fake pullback based on pushforward)
+
+function value_and_pullback_aux!(
+    _dx::Number, backend::AbstractADType, f, x::Number, dy::Number, extras, ::ForwardMode
+)
+    return value_and_pushforward(backend, f, x, dy, extras)
+end
+
+function value_and_pullback_aux!(
+    dx::Number,
+    backend::AbstractADType,
+    f,
+    x::Number,
+    dy::AbstractArray,
+    extras,
+    ::ForwardMode,
+)
+    y, multider = value_and_pushforward(backend, f, x, one(dx), extras)
+    return y, dot(multider, dy)
+end
+
+function value_and_pullback_aux!(
+    y::AbstractArray,
+    dx::Number,
+    backend::AbstractADType,
+    f!,
+    x::Number,
+    dy::AbstractArray,
+    extras,
+    ::ForwardMode,
+)
+    multider = similar(y)
+    y, multider = value_and_pushforward!(y, multider, backend, f!, x, one(dx), extras)
+    return y, dot(multider, dy)
+end
+
+function value_and_pullback_aux!(
+    dx::AbstractArray,
+    backend::AbstractADType,
+    f,
+    x::AbstractArray,
+    dy::Number,
+    extras,
+    ::ForwardMode,
+)
+    y = f(x)
+    for j in eachindex(IndexCartesian(), dx)
+        v_j = dy * basisarray(backend, dx, j)
+        dx[j] = pushforward!(dx[j], backend, f, x, v_j, extras)
+    end
+    return y, dx
 end
 
 """

--- a/src/pushforward.jl
+++ b/src/pushforward.jl
@@ -7,14 +7,89 @@ Compute the primal value `y = f(x)` and the Jacobian-vector product `dy = ∂f(x
 !!! info "Interface requirement"
     This is the only required implementation for a forward mode backend.
 """
-function value_and_pushforward!(dy, backend::AbstractADType, f, x, dx)
-    return value_and_pushforward!(dy, backend, f, x, dx, prepare_pushforward(backend, f, x))
+function value_and_pushforward!(
+    dy, backend::AbstractADType, f, x, dx, extras=prepare_pushforward(backend, f, x)
+)
+    return value_and_pushforward_aux!(dy, backend, f, x, dx, extras, mode(backend))
 end
 
-function value_and_pushforward!(y, dy, backend::AbstractADType, f, x, dx)
-    return value_and_pushforward!(
-        y, dy, backend, f, x, dx, prepare_pushforward(backend, f, x, y)
+function value_and_pushforward!(
+    y, dy, backend::AbstractADType, f!, x, dx, extras=prepare_pushforward(backend, f!, x, y)
+)
+    return value_and_pushforward_aux!(y, dy, backend, f!, x, dx, extras, mode(backend))
+end
+
+## Forward mode (true pushforward)
+
+function value_and_pushforward_aux!(
+    dy, backend::AbstractADType, f, x, dx, extras, ::ForwardMode
+)
+    return error(
+        "You need to load the package for `$backend` or implement `DifferentiationInterface.value_and_pushforward!` in forward mode",
     )
+end
+
+function value_and_pushforward_aux!(
+    y, dy, backend::AbstractADType, f, x, dx, extras, ::ForwardMode
+)
+    return error(
+        "You need to load the package for `$backend` or implement `DifferentiationInterface.value_and_pushforward!` in forward mode",
+    )
+end
+
+## Reverse mode (fake pushforward based on pullback)
+
+function value_and_pushforward_aux!(
+    _dy::Number, backend::AbstractADType, f, x::Number, dx::Number, extras, ::ReverseMode
+)
+    return value_and_pullback(backend, f, x, dx, extras)
+end
+
+function value_and_pushforward_aux!(
+    dy::AbstractArray,
+    backend::AbstractADType,
+    f,
+    x::Number,
+    dx::Number,
+    extras,
+    ::ReverseMode,
+)
+    y = f(x)
+    for i in eachindex(IndexCartesian(), dy)
+        v_i = dx * basisarray(backend, dy, i)
+        dy[i] = pullback!(dy[i], backend, f, x, v_i, extras)
+    end
+    return y, dy
+end
+
+function value_and_pushforward_aux!(
+    y::AbstractArray,
+    dy::AbstractArray,
+    backend::AbstractADType,
+    f!,
+    x::Number,
+    dx::Number,
+    extras,
+    ::ReverseMode,
+)
+    for i in eachindex(IndexCartesian(), dy)
+        v_i = dx * basisarray(backend, dy, i)
+        y, dy[i] = value_and_pullback!(y, dy[i], backend, f!, x, v_i, extras)
+    end
+    return y, dy
+end
+
+function value_and_pushforward_aux!(
+    dy::Number,
+    backend::AbstractADType,
+    f,
+    x::AbstractArray,
+    dx::AbstractArray,
+    extras,
+    ::ReverseMode,
+)
+    y, grad = value_and_pullback(backend, f, x, one(dy), extras)  # allocates
+    return y, dot(grad, dx)
 end
 
 """


### PR DESCRIPTION
Pros:

- makes `gradient` and `multiderivative` dead simple

Cons:

- makes `pushforward` and `pullback` more complicated and type-dependent

Still to do:

- the array-to-array cases

I don't think I like this. I would prefer `pushforward` and `pullback` to be completely type-agnostic, and our four utilities to depend on types. Let's keep what we had before @adrhill ?