### PR TITLE
Remove type annotations from aux calls

### DIFF
--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -9,15 +9,11 @@ function value_and_derivative(
     return value_and_derivative_aux(backend, f, x, extras, mode(backend))
 end
 
-function value_and_derivative_aux(
-    backend::AbstractADType, f, x::Number, extras, ::ForwardMode
-)
+function value_and_derivative_aux(backend, f, x, extras, ::ForwardMode)
     return value_and_pushforward(backend, f, x, one(x), extras)
 end
 
-function value_and_derivative_aux(
-    backend::AbstractADType, f, x::Number, extras, ::ReverseMode
-)
+function value_and_derivative_aux(backend, f, x, extras, ::ReverseMode)
     return value_and_pullback(backend, f, x, one(x), extras)
 end
 
@@ -32,10 +28,10 @@ function derivative(
     return derivative_aux(backend, f, x, extras, mode(backend))
 end
 
-function derivative_aux(backend::AbstractADType, f, x::Number, extras, ::ForwardMode)
+function derivative_aux(backend, f, x, extras, ::ForwardMode)
     return pushforward(backend, f, x, one(x), extras)
 end
 
-function derivative_aux(backend::AbstractADType, f, x::Number, extras, ::ReverseMode)
+function derivative_aux(backend, f, x, extras, ::ReverseMode)
     return pullback(backend, f, x, one(x), extras)
 end

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -13,9 +13,7 @@ function value_and_gradient!(
     return value_and_gradient_aux!(grad, backend, f, x, extras, mode(backend))
 end
 
-function value_and_gradient_aux!(
-    grad::AbstractArray, backend::AbstractADType, f, x::AbstractArray, extras, ::ForwardMode
-)
+function value_and_gradient_aux!(grad, backend::AbstractADType, f, x, extras, ::ForwardMode)
     y = f(x)
     for j in eachindex(IndexCartesian(), grad)
         dx_j = basisarray(backend, grad, j)
@@ -24,9 +22,7 @@ function value_and_gradient_aux!(
     return y, grad
 end
 
-function value_and_gradient_aux!(
-    grad::AbstractArray, backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode
-)
+function value_and_gradient_aux!(grad, backend, f, x, extras, ::ReverseMode)
     return value_and_pullback!(grad, backend, f, x, one(eltype(x)), extras)
 end
 
@@ -41,16 +37,12 @@ function value_and_gradient(
     return value_and_gradient_aux(backend, f, x, extras, mode(backend))
 end
 
-function value_and_gradient_aux(
-    backend::AbstractADType, f, x::AbstractArray, extras, ::AbstractMode
-)
+function value_and_gradient_aux(backend, f, x, extras, ::AbstractMode)
     grad = similar(x)
     return value_and_gradient!(grad, backend, f, x, extras)
 end
 
-function value_and_gradient_aux(
-    backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode
-)
+function value_and_gradient_aux(backend, f, x, extras, ::ReverseMode)
     return value_and_pullback(backend, f, x, one(eltype(x)), extras)
 end
 
@@ -69,20 +61,11 @@ function gradient!(
     return gradient_aux!(grad, backend, f, x, extras, mode(backend))
 end
 
-function gradient_aux!(
-    grad::AbstractArray,
-    backend::AbstractADType,
-    f,
-    x::AbstractArray,
-    extras,
-    ::AbstractMode,
-)
+function gradient_aux!(grad, backend, f, x, extras, ::AbstractMode)
     return last(value_and_gradient!(grad, backend, f, x, extras))
 end
 
-function gradient_aux!(
-    grad::AbstractArray, backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode
-)
+function gradient_aux!(grad, backend, f, x, extras, ::ReverseMode)
     return pullback!(grad, backend, f, x, one(eltype(x)), extras)
 end
 
@@ -97,10 +80,10 @@ function gradient(
     return gradient_aux(backend, f, x, extras, mode(backend))
 end
 
-function gradient_aux(backend::AbstractADType, f, x::AbstractArray, extras, ::AbstractMode)
+function gradient_aux(backend, f, x, extras, ::AbstractMode)
     return last(value_and_gradient(backend, f, x, extras))
 end
 
-function gradient_aux(backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode)
+function gradient_aux(backend, f, x, extras, ::ReverseMode)
     return pullback(backend, f, x, one(eltype(x)), extras)
 end

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -48,14 +48,7 @@ function value_gradient_and_hessian!(
 end
 
 function value_gradient_and_hessian_aux!(
-    grad::AbstractArray,
-    hess::AbstractMatrix,
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    extras,
-    ::AbstractMode,
-    ::ForwardMode,
+    grad, hess, backend, f, x, extras, ::AbstractMode, ::ForwardMode
 )
     y = f(x)
     check_hess(hess, x)
@@ -68,14 +61,7 @@ function value_gradient_and_hessian_aux!(
 end
 
 function value_gradient_and_hessian_aux!(
-    grad::AbstractArray,
-    hess::AbstractMatrix,
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    extras,
-    ::AbstractMode,
-    ::ReverseMode,
+    grad, hess, backend, f, x, extras, ::AbstractMode, ::ReverseMode
 )
     y, _ = value_and_gradient!(grad, inner(backend), f, x, extras)
     check_hess(hess, x)

--- a/src/hessian_vector_product.jl
+++ b/src/hessian_vector_product.jl
@@ -41,26 +41,14 @@ function gradient_and_hessian_vector_product(
 end
 
 function gradient_and_hessian_vector_product_aux(
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::AbstractMode,
-    ::ForwardMode,
+    backend, f, x, v, extras, ::AbstractMode, ::ForwardMode
 )
     grad_aux(z) = gradient(inner(backend), f, z, extras)
     return value_and_pushforward(outer(backend), grad_aux, x, v, extras)
 end
 
 function gradient_and_hessian_vector_product_aux(
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::AbstractMode,
-    ::ReverseMode,
+    backend, f, x, v, extras, ::AbstractMode, ::ReverseMode
 )
     throw(ArgumentError("HVP must be computed without gradient for reverse-over-something"))
 end
@@ -102,15 +90,7 @@ function gradient_and_hessian_vector_product!(
 end
 
 function gradient_and_hessian_vector_product_aux!(
-    grad::AbstractArray,
-    hvp::AbstractArray,
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::AbstractMode,
-    ::ForwardMode,
+    grad, hvp, backend, f, x, v, extras, ::AbstractMode, ::ForwardMode
 )
     function grad_aux!(storage, z)
         gradient!(storage, inner(backend), f, z, extras)
@@ -120,15 +100,7 @@ function gradient_and_hessian_vector_product_aux!(
 end
 
 function gradient_and_hessian_vector_product_aux!(
-    grad::AbstractArray,
-    hvp::AbstractArray,
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::AbstractMode,
-    ::ReverseMode,
+    grad, hvp, backend, f, x, v, extras, ::AbstractMode, ::ReverseMode
 )
     throw(ArgumentError("HVP must be computed without gradient for reverse-over-something"))
 end
@@ -162,41 +134,17 @@ function hessian_vector_product(
     )
 end
 
-function hessian_vector_product_aux(
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::ReverseMode,
-    ::ReverseMode,
-)
+function hessian_vector_product_aux(backend, f, x, v, extras, ::ReverseMode, ::ReverseMode)
     dotgrad_aux(z) = dot(gradient(inner(backend), f, z, extras), v)
     return gradient(outer(backend), dotgrad_aux, x, extras)
 end
 
-function hessian_vector_product_aux(
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::ForwardMode,
-    ::ReverseMode,
-)
+function hessian_vector_product_aux(backend, f, x, v, extras, ::ForwardMode, ::ReverseMode)
     jvp_aux(z) = pushforward(inner(backend), f, z, v, extras)
     return gradient(outer(backend), jvp_aux, x, extras)
 end
 
-function hessian_vector_product_aux(
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::AbstractMode,
-    ::ForwardMode,
-)
+function hessian_vector_product_aux(backend, f, x, v, extras, ::AbstractMode, ::ForwardMode)
     _, hvp = gradient_and_hessian_vector_product(backend, f, x, v, extras)
     return hvp
 end
@@ -231,42 +179,21 @@ function hessian_vector_product!(
 end
 
 function hessian_vector_product_aux!(
-    hvp::AbstractArray,
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::ReverseMode,
-    ::ReverseMode,
+    hvp, backend, f, x, v, extras, ::ReverseMode, ::ReverseMode
 )
     dotgrad_aux(z) = dot(gradient(inner(backend), f, z, extras), v)  # allocates
     return gradient!(hvp, outer(backend), dotgrad_aux, x, extras)
 end
 
 function hessian_vector_product_aux!(
-    hvp::AbstractArray,
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::ForwardMode,
-    ::ReverseMode,
+    hvp, backend, f, x, v, extras, ::ForwardMode, ::ReverseMode
 )
     jvp_aux(z) = pushforward(inner(backend), f, z, v, extras)
     return gradient!(hvp, outer(backend), jvp_aux, x, extras)
 end
 
 function hessian_vector_product_aux!(
-    hvp::AbstractArray,
-    backend::SecondOrder,
-    f,
-    x::AbstractArray,
-    v::AbstractArray,
-    extras,
-    ::AbstractMode,
-    ::ForwardMode,
+    hvp, backend, f, x, v, extras, ::AbstractMode, ::ForwardMode
 )
     grad = similar(x)  # allocates
     _, hvp = gradient_and_hessian_vector_product!(grad, hvp, backend, f, x, v, extras)

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -42,9 +42,7 @@ function value_and_jacobian!(
     return value_and_jacobian_aux!(y, jac, backend, f, x, extras, mode(backend))
 end
 
-function value_and_jacobian_aux!(
-    jac::AbstractMatrix, backend::AbstractADType, f, x::AbstractArray, extras, ::ForwardMode
-)
+function value_and_jacobian_aux!(jac, backend, f, x, extras, ::ForwardMode)
     y = f(x)
     check_jac(jac, x, y)
     for (k, j) in enumerate(eachindex(IndexCartesian(), x))
@@ -55,15 +53,7 @@ function value_and_jacobian_aux!(
     return y, jac
 end
 
-function value_and_jacobian_aux!(
-    y::AbstractArray,
-    jac::AbstractMatrix,
-    backend::AbstractADType,
-    f!,
-    x::AbstractArray,
-    extras,
-    ::ForwardMode,
-)
+function value_and_jacobian_aux!(y, jac, backend, f!, x, extras, ::ForwardMode)
     check_jac(jac, x, y)
     for (k, j) in enumerate(eachindex(IndexCartesian(), x))
         dx_j = basisarray(backend, x, j)
@@ -73,9 +63,7 @@ function value_and_jacobian_aux!(
     return y, jac
 end
 
-function value_and_jacobian_aux!(
-    jac::AbstractMatrix, backend::AbstractADType, f, x::AbstractArray, extras, ::ReverseMode
-)
+function value_and_jacobian_aux!(jac, backend, f, x, extras, ::ReverseMode)
     y = f(x)
     check_jac(jac, x, y)
     for (k, i) in enumerate(eachindex(IndexCartesian(), y))
@@ -86,15 +74,7 @@ function value_and_jacobian_aux!(
     return y, jac
 end
 
-function value_and_jacobian_aux!(
-    y::AbstractArray,
-    jac::AbstractMatrix,
-    backend::AbstractADType,
-    f!,
-    x::AbstractArray,
-    extras,
-    ::ReverseMode,
-)
+function value_and_jacobian_aux!(y, jac, backend, f!, x, extras, ::ReverseMode)
     check_jac(jac, x, y)
     for (k, i) in enumerate(eachindex(IndexCartesian(), y))
         dy_i = basisarray(backend, y, i)

--- a/src/multiderivative.jl
+++ b/src/multiderivative.jl
@@ -25,27 +25,15 @@ function value_and_multiderivative!(
     return value_and_multiderivative_aux!(y, multider, backend, f, x, extras, mode(backend))
 end
 
-function value_and_multiderivative_aux!(
-    multider::AbstractArray, backend::AbstractADType, f, x::Number, extras, ::ForwardMode
-)
+function value_and_multiderivative_aux!(multider, backend, f, x, extras, ::ForwardMode)
     return value_and_pushforward!(multider, backend, f, x, one(x), extras)
 end
 
-function value_and_multiderivative_aux!(
-    y::AbstractArray,
-    multider::AbstractArray,
-    backend::AbstractADType,
-    f!,
-    x::Number,
-    extras,
-    ::ForwardMode,
-)
+function value_and_multiderivative_aux!(y, multider, backend, f!, x, extras, ::ForwardMode)
     return value_and_pushforward!(y, multider, backend, f!, x, one(x), extras)
 end
 
-function value_and_multiderivative_aux!(
-    multider::AbstractArray, backend::AbstractADType, f, x::Number, extras, ::ReverseMode
-)
+function value_and_multiderivative_aux!(multider, backend, f, x, extras, ::ReverseMode)
     y = f(x)
     for i in eachindex(IndexCartesian(), multider)
         dy_i = basisarray(backend, multider, i)
@@ -54,15 +42,7 @@ function value_and_multiderivative_aux!(
     return y, multider
 end
 
-function value_and_multiderivative_aux!(
-    y::AbstractArray,
-    multider::AbstractArray,
-    backend::AbstractADType,
-    f!,
-    x::Number,
-    extras,
-    ::ReverseMode,
-)
+function value_and_multiderivative_aux!(y, multider, backend, f!, x, extras, ::ReverseMode)
     for i in eachindex(IndexCartesian(), multider)
         dy_i = basisarray(backend, multider, i)
         y, multider[i] = value_and_pullback!(y, multider[i], backend, f!, x, dy_i, extras)
@@ -81,15 +61,11 @@ function value_and_multiderivative(
     return value_and_multiderivative_aux(backend, f, x, extras, mode(backend))
 end
 
-function value_and_multiderivative_aux(
-    backend::AbstractADType, f, x::Number, extras, ::ForwardMode
-)
+function value_and_multiderivative_aux(backend, f, x, extras, ::ForwardMode)
     return value_and_pushforward(backend, f, x, one(x), extras)
 end
 
-function value_and_multiderivative_aux(
-    backend::AbstractADType, f, x::Number, extras, ::AbstractMode
-)
+function value_and_multiderivative_aux(backend, f, x, extras, ::AbstractMode)
     multider = similar(f(x))
     return value_and_multiderivative!(multider, backend, f, x, extras)
 end
@@ -109,15 +85,11 @@ function multiderivative!(
     return multiderivative_aux!(multider, backend, f, x, extras, mode(backend))
 end
 
-function multiderivative_aux!(
-    multider::AbstractArray, backend::AbstractADType, f, x::Number, extras, ::ForwardMode
-)
+function multiderivative_aux!(multider, backend, f, x, extras, ::ForwardMode)
     return pushforward!(multider, backend, f, x, one(x), extras)
 end
 
-function multiderivative_aux!(
-    multider::AbstractArray, backend::AbstractADType, f, x::Number, extras, ::AbstractMode
-)
+function multiderivative_aux!(multider, backend, f, x, extras, ::AbstractMode)
     return last(value_and_multiderivative!(multider, backend, f, x, extras))
 end
 
@@ -132,10 +104,10 @@ function multiderivative(
     return multiderivative_aux(backend, f, x, extras, mode(backend))
 end
 
-function multiderivative_aux(backend::AbstractADType, f, x::Number, extras, ::ForwardMode)
+function multiderivative_aux(backend, f, x, extras, ::ForwardMode)
     return pushforward(backend, f, x, one(x), extras)
 end
 
-function multiderivative_aux(backend::AbstractADType, f, x::Number, extras, ::AbstractMode)
+function multiderivative_aux(backend, f, x, extras, ::AbstractMode)
     return last(value_and_multiderivative(backend, f, x, extras))
 end


### PR DESCRIPTION
This should make things a bit more readable.