### PR TITLE
Default to three-argument `similar` for pre-allocations

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,7 +15,7 @@ function basisarray(a::AbstractArray{T,N}, i::CartesianIndex{N}) where {T,N}
 end
 
 mysimilar(x::Number) = zero(x)
-mysimilar(x::AbstractArray) = similar(x)
+mysimilar(x::AbstractArray{T}) where {T} = similar(x, T, axes(x)) # strip structure (issue #35)
 
 update!(_old::Number, new::Number) = new
 update!(old, new) = old .= new


### PR DESCRIPTION
As discussed in #35, this can be used to strip array structure.
`mysimilar` is only used in the fallbacks for `value_and_pushforward` and `value_and_pullback` to allocate pushforward and pullback arrays in memory, so this doesn't solve existing issues with ForwardDiff's `gradient!` implementation.