### PR TITLE
Remove allocations by stronger function typing

### DIFF
--- a/ext/DifferentiationInterfaceChairmarksExt/DifferentiationInterfaceChairmarksExt.jl
+++ b/ext/DifferentiationInterfaceChairmarksExt/DifferentiationInterfaceChairmarksExt.jl
@@ -14,7 +14,7 @@ using DifferentiationInterface.DifferentiationTest
 import DifferentiationInterface.DifferentiationTest as DT
 using Test
 
-## Test allocations from dict of run_benchmarks
+## Dict of run_benchmarks
 
 struct BenchmarkDict{D}
     d::D
@@ -37,30 +37,11 @@ function Base.merge!(bd1::BenchmarkDict, d2::Dict)
     return bd
 end
 
-function test_allocations_aux(b::Benchmark, level)
-    allocs = minimum(b).allocs
-    if iszero(allocs)
-        @test allocs == 0
+function soft_test_zero(v)
+    if iszero(v)
+        @test v == 0
     else
-        @test_broken allocs == 0
-    end
-end
-
-function test_allocations_aux(d, level)
-    if level <= 1
-        @testset verbose = true "$k" for k in keys(d)
-            test_allocations_aux(d[k], level + 1)
-        end
-    else
-        @testset verbose = false "$k" for k in keys(d)
-            test_allocations_aux(d[k], level + 1)
-        end
-    end
-end
-
-function DT.test_allocations(d)
-    @testset verbose = true "Allocations" begin
-        test_allocations_aux(d, 1)
+        @test_broken v == 0
     end
 end
 
@@ -74,109 +55,129 @@ function DT.run_benchmark(
     backends::Vector{<:AbstractADType},
     operators::Vector{Symbol},
     scenarios::Vector{<:Scenario};
+    test_allocations=false,
 )
     all_results = BenchmarkDict()
-    for backend in backends
-        for op in operators
-            results = all_results[backend_string(backend)][op]
-            if op == :pushforward_allocating
-                for s in allocating(scenarios)
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_pushforward_allocating(backend, s),
-                    )
-                end
-            elseif op == :pushforward_mutating
-                for s in mutating(scenarios)
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_pushforward_mutating(backend, s),
-                    )
-                end
+    @testset verbose = true "Allocations" begin
+        @testset verbose = true "$(backend_string(backend))" for backend in backends
+            @testset "$op" for op in operators
+                results = all_results[backend_string(backend)][op]
+                if op == :pushforward_allocating
+                    for s in allocating(scenarios)
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_pushforward_allocating(
+                                backend, s; test_allocations
+                            ),
+                        )
+                    end
+                elseif op == :pushforward_mutating
+                    for s in mutating(scenarios)
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_pushforward_mutating(
+                                backend, s; test_allocations
+                            ),
+                        )
+                    end
 
-            elseif op == :pullback_allocating
-                for s in allocating(scenarios)
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_pullback_allocating(backend, s),
-                    )
-                end
-            elseif op == :pullback_mutating
-                for s in mutating(scenarios)
-                    merge!(
-                        results[scen_id(s)...], run_benchmark_pullback_mutating(backend, s)
-                    )
-                end
+                elseif op == :pullback_allocating
+                    for s in allocating(scenarios)
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_pullback_allocating(backend, s; test_allocations),
+                        )
+                    end
+                elseif op == :pullback_mutating
+                    for s in mutating(scenarios)
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_pullback_mutating(backend, s; test_allocations),
+                        )
+                    end
 
-            elseif op == :derivative_allocating
-                for s in allocating(scalar_scalar(scenarios))
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_derivative_allocating(backend, s),
-                    )
-                end
+                elseif op == :derivative_allocating
+                    for s in allocating(scalar_scalar(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_derivative_allocating(
+                                backend, s; test_allocations
+                            ),
+                        )
+                    end
 
-            elseif op == :multiderivative_allocating
-                for s in allocating(scalar_array(scenarios))
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_multiderivative_allocating(backend, s),
-                    )
-                end
-            elseif op == :multiderivative_mutating
-                for s in mutating(scalar_array(scenarios))
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_multiderivative_mutating(backend, s),
-                    )
-                end
+                elseif op == :multiderivative_allocating
+                    for s in allocating(scalar_array(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_multiderivative_allocating(
+                                backend, s; test_allocations
+                            ),
+                        )
+                    end
+                elseif op == :multiderivative_mutating
+                    for s in mutating(scalar_array(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_multiderivative_mutating(
+                                backend, s; test_allocations
+                            ),
+                        )
+                    end
 
-            elseif op == :gradient_allocating
-                for s in allocating(array_scalar(scenarios))
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_gradient_allocating(backend, s),
-                    )
-                end
+                elseif op == :gradient_allocating
+                    for s in allocating(array_scalar(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_gradient_allocating(backend, s; test_allocations),
+                        )
+                    end
 
-            elseif op == :jacobian_allocating
-                for s in allocating(array_array(scenarios))
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_jacobian_allocating(backend, s),
-                    )
-                end
-            elseif op == :jacobian_mutating
-                for s in mutating(array_array(scenarios))
-                    merge!(
-                        results[scen_id(s)...], run_benchmark_jacobian_mutating(backend, s)
-                    )
-                end
+                elseif op == :jacobian_allocating
+                    for s in allocating(array_array(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_jacobian_allocating(backend, s; test_allocations),
+                        )
+                    end
+                elseif op == :jacobian_mutating
+                    for s in mutating(array_array(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_jacobian_mutating(backend, s; test_allocations),
+                        )
+                    end
 
-            elseif op == :second_derivative_allocating
-                for s in allocating(scalar_scalar(scenarios))
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_second_derivative_allocating(backend, s),
-                    )
-                end
+                elseif op == :second_derivative_allocating
+                    for s in allocating(scalar_scalar(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_second_derivative_allocating(
+                                backend, s; test_allocations
+                            ),
+                        )
+                    end
 
-            elseif op == :hessian_vector_product_allocating
-                for s in allocating(array_scalar(scenarios))
-                    merge!(
-                        results[scen_id(s)...],
-                        run_benchmark_hessian_vector_product_allocating(backend, s),
-                    )
-                end
-            elseif op == :hessian_allocating
-                for s in allocating(array_scalar(scenarios))
-                    merge!(
-                        results[scen_id(s)...], run_benchmark_hessian_allocating(backend, s)
-                    )
-                end
+                elseif op == :hessian_vector_product_allocating
+                    for s in allocating(array_scalar(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_hessian_vector_product_allocating(
+                                backend, s; test_allocations
+                            ),
+                        )
+                    end
+                elseif op == :hessian_allocating
+                    for s in allocating(array_scalar(scenarios))
+                        merge!(
+                            results[scen_id(s)...],
+                            run_benchmark_hessian_allocating(backend, s; test_allocations),
+                        )
+                    end
 
-            else
-                throw(ArgumentError("Invalid operator to run_benchmark: `:$op`"))
+                else
+                    throw(ArgumentError("Invalid operator to run_benchmark: `:$op`"))
+                end
             end
         end
     end
@@ -185,177 +186,200 @@ end
 
 ## Pushforward
 
-function run_benchmark_pushforward_allocating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_pushforward_allocating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     isa(mode(ba), ReverseMode) && return Dict()
     (; f, x, dx, dy) = deepcopy(scenario)
+
     extras = prepare_pushforward(ba, f, x)
-    return Dict(
-        :value_and_pushforward! => begin
-            @be zero(dy) value_and_pushforward!(_, ba, f, x, dx, extras)
-        end,
-        :pushforward! => begin
-            @be zero(dy) pushforward!(_, ba, f, x, dx, extras)
-        end,
-    )
+    bench1 = @be zero(dy) value_and_pushforward!(_, ba, f, x, dx, extras)
+    bench2 = @be zero(dy) pushforward!(_, ba, f, x, dx, extras)
+    if test_allocations && dy isa Number
+        soft_test_zero(minimum(bench1).allocs)
+        soft_test_zero(minimum(bench2).allocs)
+    end
+    return Dict(:value_and_pushforward! => bench1, :pushforward! => bench2)
 end
 
-function run_benchmark_pushforward_mutating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_pushforward_mutating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     isa(mode(ba), ReverseMode) && return Dict()
     (; f, x, y, dx, dy) = deepcopy(scenario)
     f! = f
     extras = prepare_pushforward(ba, f!, x, y)
-    return Dict(
-        :value_and_pushforward! => begin
-            @be (zero(y), zero(dy)) value_and_pushforward!(_[1], _[2], ba, f!, x, dx, extras)
-        end,
+    bench1 = @be (zero(y), zero(dy)) value_and_pushforward!(
+        _[1], _[2], ba, f!, x, dx, extras
     )
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+    end
+    return Dict(:value_and_pushforward! => bench1)
 end
 
 ## Pullback
 
-function run_benchmark_pullback_allocating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_pullback_allocating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     isa(mode(ba), ForwardMode) && return Dict()
     (; f, x, dx, dy) = deepcopy(scenario)
     extras = prepare_pullback(ba, f, x)
-    return Dict(
-        :value_and_pullback! => begin
-            @be zero(dx) value_and_pullback!(_, ba, f, x, dy, extras)
-        end,
-        :pullback! => begin
-            @be zero(dx) pullback!(_, ba, f, x, dy, extras)
-        end,
-    )
+    bench1 = @be zero(dx) value_and_pullback!(_, ba, f, x, dy, extras)
+    bench2 = @be zero(dx) pullback!(_, ba, f, x, dy, extras)
+    if test_allocations && dy isa Number
+        soft_test_zero(minimum(bench1).allocs)
+        soft_test_zero(minimum(bench2).allocs)
+    end
+    return Dict(:value_and_pullback! => bench1, :pullback! => bench2)
 end
 
-function run_benchmark_pullback_mutating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_pullback_mutating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     isa(mode(ba), ForwardMode) && return Dict()
     (; f, x, y, dx, dy) = deepcopy(scenario)
     f! = f
     extras = prepare_pullback(ba, f!, x, y)
-    return Dict(
-        :value_and_pullback! => begin
-            @be (zero(y), zero(dx)) value_and_pullback!(_[1], _[2], ba, f!, x, dy, extras)
-        end,
-    )
+    bench1 = @be (zero(y), zero(dx)) value_and_pullback!(_[1], _[2], ba, f!, x, dy, extras)
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+    end
+    return Dict(:value_and_pullback! => bench1)
 end
 
 ## Derivative
 
-function run_benchmark_derivative_allocating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_derivative_allocating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     (; f, x) = deepcopy(scenario)
     extras = prepare_derivative(ba, f, x)
-    return Dict(:value_and_derivative => begin
-        @be value_and_derivative(ba, f, x, extras)
-    end)
+    bench1 = @be value_and_derivative(ba, f, x, extras)
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+    end
+    return Dict(:value_and_derivative => bench1)
 end
 
 ## Multiderivative
 
-function run_benchmark_multiderivative_allocating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_multiderivative_allocating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     (; f, x, dy) = deepcopy(scenario)
     extras = prepare_multiderivative(ba, f, x)
-    return Dict(
-        :value_and_multiderivative! => begin
-            @be zero(dy) value_and_multiderivative!(_, ba, f, x, extras)
-        end,
-    )
+    bench1 = @be zero(dy) value_and_multiderivative!(_, ba, f, x, extras)
+    # never test allocations
+    return Dict(:value_and_multiderivative! => bench1)
 end
 
-function run_benchmark_multiderivative_mutating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_multiderivative_mutating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     (; f, x, y, dy) = deepcopy(scenario)
     f! = f
     extras = prepare_multiderivative(ba, f!, x, y)
-    return Dict(
-        :value_and_multiderivative! => begin
-            @be (zero(y), zero(dy)) value_and_multiderivative!(_[1], _[2], ba, f!, x, extras)
-        end,
+    bench1 = @be (zero(y), zero(dy)) value_and_multiderivative!(
+        _[1], _[2], ba, f!, x, extras
     )
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+    end
+    return Dict(:value_and_multiderivative! => bench1)
 end
 
 ## Gradient
 
-function run_benchmark_gradient_allocating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_gradient_allocating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     (; f, x, dx) = deepcopy(scenario)
     extras = prepare_gradient(ba, f, x)
-    return Dict(
-        :value_and_gradient! => begin
-            @be zero(dx) value_and_gradient!(_, ba, f, x, extras)
-        end,
-        :gradient! => begin
-            @be zero(dx) gradient!(_, ba, f, x, extras)
-        end,
-    )
+    bench1 = @be zero(dx) value_and_gradient!(_, ba, f, x, extras)
+    bench2 = @be zero(dx) gradient!(_, ba, f, x, extras)
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+        soft_test_zero(minimum(bench2).allocs)
+    end
+    return Dict(:value_and_gradient! => bench1, :gradient! => bench2)
 end
 
 ## Jacobian
 
-function run_benchmark_jacobian_allocating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_jacobian_allocating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     (; f, x, y) = deepcopy(scenario)
     jac_template = zeros(eltype(y), length(y), length(x))
     extras = prepare_jacobian(ba, f, x)
-    return Dict(
-        :value_and_jacobian! => begin
-            @be zero(jac_template) value_and_jacobian!(_, ba, f, x, extras)
-        end,
-    )
+    bench1 = @be zero(jac_template) value_and_jacobian!(_, ba, f, x, extras)
+    # never test allocations
+    return Dict(:value_and_jacobian! => bench1)
 end
 
-function run_benchmark_jacobian_mutating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_jacobian_mutating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     (; f, x, y) = deepcopy(scenario)
     f! = f
     jac_template = zeros(eltype(y), length(y), length(x))
     extras = prepare_jacobian(ba, f!, x, y)
-    return Dict(
-        :value_and_jacobian! => begin
-            @be (zero(y), zero(jac_template)) value_and_jacobian!(
-                _[1], _[2], ba, f!, x, extras
-            )
-        end,
+    bench1 = @be (zero(y), zero(jac_template)) value_and_jacobian!(
+        _[1], _[2], ba, f!, x, extras
     )
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+    end
+    return Dict(:value_and_jacobian! => bench1)
 end
 
 ## Second derivative
 
-function run_benchmark_second_derivative_allocating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_second_derivative_allocating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     (; f, x) = deepcopy(scenario)
     extras = prepare_second_derivative(ba, f, x)
-    return Dict(
-        :value_derivative_and_second_derivative => begin
-            @be value_derivative_and_second_derivative(ba, f, x, extras)
-        end,
-    )
+    bench1 = @be value_derivative_and_second_derivative(ba, f, x, extras)
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+    end
+    return Dict(:value_derivative_and_second_derivative => bench1)
 end
 
 ## Hessian-vector product
 
 function run_benchmark_hessian_vector_product_allocating(
-    ba::AbstractADType, scenario::Scenario
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
 )
     (; f, x, dx) = deepcopy(scenario)
     extras = prepare_hessian_vector_product(ba, f, x)
-    return Dict(
-        :hessian_vector_product! => begin
-            @be zero(dx) hessian_vector_product!(_, ba, f, x, dx, extras)
-        end,
-    )
+    bench1 = @be zero(dx) hessian_vector_product!(_, ba, f, x, dx, extras)
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+    end
+    return Dict(:hessian_vector_product! => bench1)
 end
 
 ## Hessian
 
-function run_benchmark_hessian_allocating(ba::AbstractADType, scenario::Scenario)
+function run_benchmark_hessian_allocating(
+    ba::AbstractADType, scenario::Scenario; test_allocations::Bool
+)
     (; f, x, y, dx) = deepcopy(scenario)
     extras = prepare_hessian(ba, f, x)
     hess_template = zeros(eltype(y), length(x), length(x))
-    return Dict(
-        :value_gradient_and_hessian! => begin
-            @be (zero(dx), zero(hess_template)) value_gradient_and_hessian!(
-                _[1], _[2], ba, f, x, extras
-            )
-        end,
-        :hessian! => begin
-            @be (zero(hess_template)) hessian!(_, ba, f, x, extras)
-        end,
+    bench1 = @be (zero(dx), zero(hess_template)) value_gradient_and_hessian!(
+        _[1], _[2], ba, f, x, extras
     )
+    bench2 = @be (zero(hess_template)) hessian!(_, ba, f, x, extras)
+    if test_allocations
+        soft_test_zero(minimum(bench1).allocs)
+        soft_test_zero(minimum(bench2).allocs)
+    end
+    return Dict(:value_gradient_and_hessian! => bench1, :hessian! => bench2)
 end
 
 end

--- a/src/DifferentiationTest/test_operators.jl
+++ b/src/DifferentiationTest/test_operators.jl
@@ -118,13 +118,16 @@ function test_operators(
             test_type_stability(backends, operators, scenarios)
         end
         if benchmark || allocations
-            result = run_benchmark(backends, operators, scenarios)
-            if allocations
-                test_allocations(result)
-            end
+            result = run_benchmark(
+                backends, operators, scenarios; test_allocations=allocations
+            )
         end
     end
-    return result
+    if benchmark
+        return result
+    else
+        return nothing
+    end
 end
 
 """

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -4,16 +4,16 @@
 Compute the primal value `y = f(x)` and the derivative `der = f'(x)` of a scalar-to-scalar function.
 """
 function value_and_derivative(
-    backend::AbstractADType, f, x::Number, extras=prepare_derivative(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::Number, extras=prepare_derivative(backend, f, x)
+) where {F}
     return value_and_derivative_aux(backend, f, x, extras, mode(backend))
 end
 
-function value_and_derivative_aux(backend, f, x, extras, ::ForwardMode)
+function value_and_derivative_aux(backend, f::F, x, extras, ::ForwardMode) where {F}
     return value_and_pushforward(backend, f, x, one(x), extras)
 end
 
-function value_and_derivative_aux(backend, f, x, extras, ::ReverseMode)
+function value_and_derivative_aux(backend, f::F, x, extras, ::ReverseMode) where {F}
     return value_and_pullback(backend, f, x, one(x), extras)
 end
 
@@ -23,15 +23,15 @@ end
 Compute the derivative `der = f'(x)` of a scalar-to-scalar function.
 """
 function derivative(
-    backend::AbstractADType, f, x::Number, extras=prepare_derivative(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::Number, extras=prepare_derivative(backend, f, x)
+) where {F}
     return derivative_aux(backend, f, x, extras, mode(backend))
 end
 
-function derivative_aux(backend, f, x, extras, ::ForwardMode)
+function derivative_aux(backend, f::F, x, extras, ::ForwardMode) where {F}
     return pushforward(backend, f, x, one(x), extras)
 end
 
-function derivative_aux(backend, f, x, extras, ::ReverseMode)
+function derivative_aux(backend, f::F, x, extras, ::ReverseMode) where {F}
     return pullback(backend, f, x, one(x), extras)
 end

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -6,14 +6,16 @@ Compute the primal value `y = f(x)` and the gradient `grad = ∇f(x)` of an arra
 function value_and_gradient!(
     grad::AbstractArray,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     extras=prepare_gradient(backend, f, x),
-)
+) where {F}
     return value_and_gradient_aux!(grad, backend, f, x, extras, mode(backend))
 end
 
-function value_and_gradient_aux!(grad, backend::AbstractADType, f, x, extras, ::ForwardMode)
+function value_and_gradient_aux!(
+    grad, backend::AbstractADType, f::F, x, extras, ::ForwardMode
+) where {F}
     y = f(x)
     for j in eachindex(IndexCartesian(), grad)
         dx_j = basisarray(backend, grad, j)
@@ -22,7 +24,7 @@ function value_and_gradient_aux!(grad, backend::AbstractADType, f, x, extras, ::
     return y, grad
 end
 
-function value_and_gradient_aux!(grad, backend, f, x, extras, ::ReverseMode)
+function value_and_gradient_aux!(grad, backend, f::F, x, extras, ::ReverseMode) where {F}
     return value_and_pullback!(grad, backend, f, x, one(eltype(x)), extras)
 end
 
@@ -32,17 +34,17 @@ end
 Compute the primal value `y = f(x)` and the gradient `grad = ∇f(x)` of an array-to-scalar function.
 """
 function value_and_gradient(
-    backend::AbstractADType, f, x::AbstractArray, extras=prepare_gradient(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::AbstractArray, extras=prepare_gradient(backend, f, x)
+) where {F}
     return value_and_gradient_aux(backend, f, x, extras, mode(backend))
 end
 
-function value_and_gradient_aux(backend, f, x, extras, ::AbstractMode)
+function value_and_gradient_aux(backend, f::F, x, extras, ::AbstractMode) where {F}
     grad = similar(x)
     return value_and_gradient!(grad, backend, f, x, extras)
 end
 
-function value_and_gradient_aux(backend, f, x, extras, ::ReverseMode)
+function value_and_gradient_aux(backend, f::F, x, extras, ::ReverseMode) where {F}
     return value_and_pullback(backend, f, x, one(eltype(x)), extras)
 end
 
@@ -54,18 +56,18 @@ Compute the gradient `grad = ∇f(x)` of an array-to-scalar function, overwritin
 function gradient!(
     grad::AbstractArray,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     extras=prepare_gradient(backend, f, x),
-)
+) where {F}
     return gradient_aux!(grad, backend, f, x, extras, mode(backend))
 end
 
-function gradient_aux!(grad, backend, f, x, extras, ::AbstractMode)
+function gradient_aux!(grad, backend, f::F, x, extras, ::AbstractMode) where {F}
     return last(value_and_gradient!(grad, backend, f, x, extras))
 end
 
-function gradient_aux!(grad, backend, f, x, extras, ::ReverseMode)
+function gradient_aux!(grad, backend, f::F, x, extras, ::ReverseMode) where {F}
     return pullback!(grad, backend, f, x, one(eltype(x)), extras)
 end
 
@@ -75,15 +77,15 @@ end
 Compute the gradient `grad = ∇f(x)` of an array-to-scalar function.
 """
 function gradient(
-    backend::AbstractADType, f, x::AbstractArray, extras=prepare_gradient(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::AbstractArray, extras=prepare_gradient(backend, f, x)
+) where {F}
     return gradient_aux(backend, f, x, extras, mode(backend))
 end
 
-function gradient_aux(backend, f, x, extras, ::AbstractMode)
+function gradient_aux(backend, f::F, x, extras, ::AbstractMode) where {F}
     return last(value_and_gradient(backend, f, x, extras))
 end
 
-function gradient_aux(backend, f, x, extras, ::ReverseMode)
+function gradient_aux(backend, f::F, x, extras, ::ReverseMode) where {F}
     return pullback(backend, f, x, one(eltype(x)), extras)
 end

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -25,10 +25,10 @@ function value_gradient_and_hessian!(
     grad::AbstractArray,
     hess::AbstractMatrix,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     extras=prepare_hessian(backend, f, x),
-)
+) where {F}
     return value_gradient_and_hessian!(
         grad, hess, SecondOrder(backend, backend), f, x, extras
     )
@@ -38,18 +38,18 @@ function value_gradient_and_hessian!(
     grad::AbstractArray,
     hess::AbstractMatrix,
     backend::SecondOrder,
-    f,
+    f::F,
     x::AbstractArray,
     extras=prepare_hessian(backend, f, x),
-)
+) where {F}
     return value_gradient_and_hessian_aux!(
         grad, hess, backend, f, x, extras, mode(inner(backend)), mode(outer(backend))
     )
 end
 
 function value_gradient_and_hessian_aux!(
-    grad, hess, backend, f, x, extras, ::AbstractMode, ::ForwardMode
-)
+    grad, hess, backend, f::F, x, extras, ::AbstractMode, ::ForwardMode
+) where {F}
     y = f(x)
     check_hess(hess, x)
     for (k, j) in enumerate(eachindex(IndexCartesian(), x))
@@ -61,8 +61,8 @@ function value_gradient_and_hessian_aux!(
 end
 
 function value_gradient_and_hessian_aux!(
-    grad, hess, backend, f, x, extras, ::AbstractMode, ::ReverseMode
-)
+    grad, hess, backend, f::F, x, extras, ::AbstractMode, ::ReverseMode
+) where {F}
     y, _ = value_and_gradient!(grad, inner(backend), f, x, extras)
     check_hess(hess, x)
     for (k, j) in enumerate(eachindex(IndexCartesian(), x))
@@ -81,8 +81,8 @@ Compute the primal value `y = f(x)`, the gradient `grad = ∇f(x)` and the Hessi
 $HESS_NOTES
 """
 function value_gradient_and_hessian(
-    backend::AbstractADType, f, x::AbstractArray, extras=prepare_hessian(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::AbstractArray, extras=prepare_hessian(backend, f, x)
+) where {F}
     grad = similar(x)
     hess = similar(x, length(x), length(x))
     return value_gradient_and_hessian!(grad, hess, backend, f, x, extras)
@@ -98,10 +98,10 @@ $HESS_NOTES
 function hessian!(
     hess::AbstractMatrix,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     extras=prepare_hessian(backend, f, x),
-)
+) where {F}
     grad = similar(x)
     return last(value_gradient_and_hessian!(grad, hess, backend, f, x, extras))
 end
@@ -114,7 +114,7 @@ Compute the Hessian `hess = ∇²f(x)` of an array-to-scalar function.
 $HESS_NOTES
 """
 function hessian(
-    backend::AbstractADType, f, x::AbstractArray, extras=prepare_hessian(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::AbstractArray, extras=prepare_hessian(backend, f, x)
+) where {F}
     return last(value_gradient_and_hessian(backend, f, x, extras))
 end

--- a/src/hessian_vector_product.jl
+++ b/src/hessian_vector_product.jl
@@ -18,11 +18,11 @@ Compute the gradient `grad = ∇f(x)` and the Hessian-vector product `hvp = ∇�
 """
 function gradient_and_hessian_vector_product(
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     v::AbstractArray,
     extras=prepare_hessian_vector_product(backend, f, x),
-)
+) where {F}
     return gradient_and_hessian_vector_product(
         SecondOrder(backend, backend), f, x, v, extras
     )
@@ -30,19 +30,19 @@ end
 
 function gradient_and_hessian_vector_product(
     backend::SecondOrder,
-    f,
+    f::F,
     x::AbstractArray,
     v::AbstractArray,
     extras=prepare_hessian_vector_product(backend, f, x),
-)
+) where {F}
     return gradient_and_hessian_vector_product_aux(
         backend, f, x, v, extras, mode(inner(backend)), mode(outer(backend))
     )
 end
 
 function gradient_and_hessian_vector_product_aux(
-    backend, f, x, v, extras, ::AbstractMode, ::ForwardMode
-)
+    backend, f::F, x, v, extras, ::AbstractMode, ::ForwardMode
+) where {F}
     grad_aux(z) = gradient(inner(backend), f, z, extras)
     return value_and_pushforward(outer(backend), grad_aux, x, v, extras)
 end
@@ -65,11 +65,11 @@ function gradient_and_hessian_vector_product!(
     grad::AbstractArray,
     hvp::AbstractArray,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     v::AbstractArray,
     extras=prepare_hessian_vector_product(backend, f, x),
-)
+) where {F}
     return gradient_and_hessian_vector_product!(
         grad, hvp, SecondOrder(backend, backend), f, x, v, extras
     )
@@ -79,19 +79,19 @@ function gradient_and_hessian_vector_product!(
     grad::AbstractArray,
     hvp::AbstractArray,
     backend::SecondOrder,
-    f,
+    f::F,
     x::AbstractArray,
     v::AbstractArray,
     extras=prepare_hessian_vector_product(backend, f, x),
-)
+) where {F}
     return gradient_and_hessian_vector_product_aux!(
         grad, hvp, backend, f, x, v, extras, mode(inner(backend)), mode(outer(backend))
     )
 end
 
 function gradient_and_hessian_vector_product_aux!(
-    grad, hvp, backend, f, x, v, extras, ::AbstractMode, ::ForwardMode
-)
+    grad, hvp, backend, f::F, x, v, extras, ::AbstractMode, ::ForwardMode
+) where {F}
     function grad_aux!(storage, z)
         gradient!(storage, inner(backend), f, z, extras)
         return nothing
@@ -114,37 +114,43 @@ Compute the Hessian-vector product `hvp = ∇²f(x) * v` of an array-to-scalar f
 """
 function hessian_vector_product(
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     v::AbstractArray,
     extras=prepare_hessian_vector_product(backend, f, x),
-)
+) where {F}
     return hessian_vector_product(SecondOrder(backend, backend), f, x, v, extras)
 end
 
 function hessian_vector_product(
     backend::SecondOrder,
-    f,
+    f::F,
     x::AbstractArray,
     v::AbstractArray,
     extras=prepare_hessian_vector_product(backend, f, x),
-)
+) where {F}
     return hessian_vector_product_aux(
         backend, f, x, v, extras, mode(inner(backend)), mode(outer(backend))
     )
 end
 
-function hessian_vector_product_aux(backend, f, x, v, extras, ::ReverseMode, ::ReverseMode)
+function hessian_vector_product_aux(
+    backend, f::F, x, v, extras, ::ReverseMode, ::ReverseMode
+) where {F}
     dotgrad_aux(z) = dot(gradient(inner(backend), f, z, extras), v)
     return gradient(outer(backend), dotgrad_aux, x, extras)
 end
 
-function hessian_vector_product_aux(backend, f, x, v, extras, ::ForwardMode, ::ReverseMode)
+function hessian_vector_product_aux(
+    backend, f::F, x, v, extras, ::ForwardMode, ::ReverseMode
+) where {F}
     jvp_aux(z) = pushforward(inner(backend), f, z, v, extras)
     return gradient(outer(backend), jvp_aux, x, extras)
 end
 
-function hessian_vector_product_aux(backend, f, x, v, extras, ::AbstractMode, ::ForwardMode)
+function hessian_vector_product_aux(
+    backend, f::F, x, v, extras, ::AbstractMode, ::ForwardMode
+) where {F}
     _, hvp = gradient_and_hessian_vector_product(backend, f, x, v, extras)
     return hvp
 end
@@ -157,44 +163,44 @@ Compute the Hessian-vector product `hvp = ∇²f(x) * v` of an array-to-scalar f
 function hessian_vector_product!(
     hvp::AbstractArray,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     v::AbstractArray,
     extras=prepare_hessian_vector_product(backend, f, x),
-)
+) where {F}
     return hessian_vector_product!(hvp, SecondOrder(backend, backend), f, x, v, extras)
 end
 
 function hessian_vector_product!(
     hvp::AbstractArray,
     backend::SecondOrder,
-    f,
+    f::F,
     x::AbstractArray,
     v::AbstractArray,
     extras=prepare_hessian_vector_product(backend, f, x),
-)
+) where {F}
     return hessian_vector_product_aux!(
         hvp, backend, f, x, v, extras, mode(inner(backend)), mode(outer(backend))
     )
 end
 
 function hessian_vector_product_aux!(
-    hvp, backend, f, x, v, extras, ::ReverseMode, ::ReverseMode
-)
+    hvp, backend, f::F, x, v, extras, ::ReverseMode, ::ReverseMode
+) where {F}
     dotgrad_aux(z) = dot(gradient(inner(backend), f, z, extras), v)  # allocates
     return gradient!(hvp, outer(backend), dotgrad_aux, x, extras)
 end
 
 function hessian_vector_product_aux!(
-    hvp, backend, f, x, v, extras, ::ForwardMode, ::ReverseMode
-)
+    hvp, backend, f::F, x, v, extras, ::ForwardMode, ::ReverseMode
+) where {F}
     jvp_aux(z) = pushforward(inner(backend), f, z, v, extras)
     return gradient!(hvp, outer(backend), jvp_aux, x, extras)
 end
 
 function hessian_vector_product_aux!(
-    hvp, backend, f, x, v, extras, ::AbstractMode, ::ForwardMode
-)
+    hvp, backend, f::F, x, v, extras, ::AbstractMode, ::ForwardMode
+) where {F}
     grad = similar(x)  # allocates
     _, hvp = gradient_and_hessian_vector_product!(grad, hvp, backend, f, x, v, extras)
     return hvp

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -24,10 +24,10 @@ $JAC_NOTES
 function value_and_jacobian!(
     jac::AbstractMatrix,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     extras=prepare_jacobian(backend, f, x),
-)
+) where {F}
     return value_and_jacobian_aux!(jac, backend, f, x, extras, mode(backend))
 end
 
@@ -35,14 +35,14 @@ function value_and_jacobian!(
     y::AbstractArray,
     jac::AbstractMatrix,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     extras=prepare_jacobian(backend, f, x, y),
-)
+) where {F}
     return value_and_jacobian_aux!(y, jac, backend, f, x, extras, mode(backend))
 end
 
-function value_and_jacobian_aux!(jac, backend, f, x, extras, ::ForwardMode)
+function value_and_jacobian_aux!(jac, backend, f::F, x, extras, ::ForwardMode) where {F}
     y = f(x)
     check_jac(jac, x, y)
     for (k, j) in enumerate(eachindex(IndexCartesian(), x))
@@ -53,7 +53,7 @@ function value_and_jacobian_aux!(jac, backend, f, x, extras, ::ForwardMode)
     return y, jac
 end
 
-function value_and_jacobian_aux!(y, jac, backend, f!, x, extras, ::ForwardMode)
+function value_and_jacobian_aux!(y, jac, backend, f!::F, x, extras, ::ForwardMode) where {F}
     check_jac(jac, x, y)
     for (k, j) in enumerate(eachindex(IndexCartesian(), x))
         dx_j = basisarray(backend, x, j)
@@ -63,7 +63,7 @@ function value_and_jacobian_aux!(y, jac, backend, f!, x, extras, ::ForwardMode)
     return y, jac
 end
 
-function value_and_jacobian_aux!(jac, backend, f, x, extras, ::ReverseMode)
+function value_and_jacobian_aux!(jac, backend, f::F, x, extras, ::ReverseMode) where {F}
     y = f(x)
     check_jac(jac, x, y)
     for (k, i) in enumerate(eachindex(IndexCartesian(), y))
@@ -74,7 +74,7 @@ function value_and_jacobian_aux!(jac, backend, f, x, extras, ::ReverseMode)
     return y, jac
 end
 
-function value_and_jacobian_aux!(y, jac, backend, f!, x, extras, ::ReverseMode)
+function value_and_jacobian_aux!(y, jac, backend, f!::F, x, extras, ::ReverseMode) where {F}
     check_jac(jac, x, y)
     for (k, i) in enumerate(eachindex(IndexCartesian(), y))
         dy_i = basisarray(backend, y, i)
@@ -92,8 +92,8 @@ Compute the primal value `y = f(x)` and the Jacobian matrix `jac = ∂f(x)` of a
 $JAC_NOTES
 """
 function value_and_jacobian(
-    backend::AbstractADType, f, x::AbstractArray, extras=prepare_jacobian(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::AbstractArray, extras=prepare_jacobian(backend, f, x)
+) where {F}
     y = f(x)
     T = promote_type(eltype(x), eltype(y))
     jac = similar(y, T, length(y), length(x))
@@ -110,10 +110,10 @@ $JAC_NOTES
 function jacobian!(
     jac::AbstractMatrix,
     backend::AbstractADType,
-    f,
+    f::F,
     x::AbstractArray,
     extras=prepare_jacobian(backend, f, x),
-)
+) where {F}
     return last(value_and_jacobian!(jac, backend, f, x, extras))
 end
 
@@ -125,7 +125,7 @@ Compute the Jacobian matrix `jac = ∂f(x)` of an array-to-array function.
 $JAC_NOTES
 """
 function jacobian(
-    backend::AbstractADType, f, x::AbstractArray, extras=prepare_jacobian(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::AbstractArray, extras=prepare_jacobian(backend, f, x)
+) where {F}
     return last(value_and_jacobian(backend, f, x, extras))
 end

--- a/src/multiderivative.jl
+++ b/src/multiderivative.jl
@@ -7,10 +7,10 @@ Compute the primal value `y = f(x)` and the (array-valued) derivative `multider 
 function value_and_multiderivative!(
     multider::AbstractArray,
     backend::AbstractADType,
-    f,
+    f::F,
     x::Number,
     extras=prepare_multiderivative(backend, f, x),
-)
+) where {F}
     return value_and_multiderivative_aux!(multider, backend, f, x, extras, mode(backend))
 end
 
@@ -18,22 +18,28 @@ function value_and_multiderivative!(
     y::AbstractArray,
     multider::AbstractArray,
     backend::AbstractADType,
-    f,
+    f::F,
     x::Number,
     extras=prepare_multiderivative(backend, f, x, y),
-)
+) where {F}
     return value_and_multiderivative_aux!(y, multider, backend, f, x, extras, mode(backend))
 end
 
-function value_and_multiderivative_aux!(multider, backend, f, x, extras, ::ForwardMode)
+function value_and_multiderivative_aux!(
+    multider, backend, f::F, x, extras, ::ForwardMode
+) where {F}
     return value_and_pushforward!(multider, backend, f, x, one(x), extras)
 end
 
-function value_and_multiderivative_aux!(y, multider, backend, f!, x, extras, ::ForwardMode)
+function value_and_multiderivative_aux!(
+    y, multider, backend, f!::F, x, extras, ::ForwardMode
+) where {F}
     return value_and_pushforward!(y, multider, backend, f!, x, one(x), extras)
 end
 
-function value_and_multiderivative_aux!(multider, backend, f, x, extras, ::ReverseMode)
+function value_and_multiderivative_aux!(
+    multider, backend, f::F, x, extras, ::ReverseMode
+) where {F}
     y = f(x)
     for i in eachindex(IndexCartesian(), multider)
         dy_i = basisarray(backend, multider, i)
@@ -42,7 +48,9 @@ function value_and_multiderivative_aux!(multider, backend, f, x, extras, ::Rever
     return y, multider
 end
 
-function value_and_multiderivative_aux!(y, multider, backend, f!, x, extras, ::ReverseMode)
+function value_and_multiderivative_aux!(
+    y, multider, backend, f!::F, x, extras, ::ReverseMode
+) where {F}
     for i in eachindex(IndexCartesian(), multider)
         dy_i = basisarray(backend, multider, i)
         y, multider[i] = value_and_pullback!(y, multider[i], backend, f!, x, dy_i, extras)
@@ -56,16 +64,16 @@ end
 Compute the primal value `y = f(x)` and the (array-valued) derivative `multider = f'(x)` of a scalar-to-array function.
 """
 function value_and_multiderivative(
-    backend::AbstractADType, f, x::Number, extras=prepare_multiderivative(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::Number, extras=prepare_multiderivative(backend, f, x)
+) where {F}
     return value_and_multiderivative_aux(backend, f, x, extras, mode(backend))
 end
 
-function value_and_multiderivative_aux(backend, f, x, extras, ::ForwardMode)
+function value_and_multiderivative_aux(backend, f::F, x, extras, ::ForwardMode) where {F}
     return value_and_pushforward(backend, f, x, one(x), extras)
 end
 
-function value_and_multiderivative_aux(backend, f, x, extras, ::AbstractMode)
+function value_and_multiderivative_aux(backend, f::F, x, extras, ::AbstractMode) where {F}
     multider = similar(f(x))
     return value_and_multiderivative!(multider, backend, f, x, extras)
 end
@@ -78,18 +86,18 @@ Compute the (array-valued) derivative `multider = f'(x)` of a scalar-to-array fu
 function multiderivative!(
     multider::AbstractArray,
     backend::AbstractADType,
-    f,
+    f::F,
     x::Number,
     extras=prepare_multiderivative(backend, f, x),
-)
+) where {F}
     return multiderivative_aux!(multider, backend, f, x, extras, mode(backend))
 end
 
-function multiderivative_aux!(multider, backend, f, x, extras, ::ForwardMode)
+function multiderivative_aux!(multider, backend, f::F, x, extras, ::ForwardMode) where {F}
     return pushforward!(multider, backend, f, x, one(x), extras)
 end
 
-function multiderivative_aux!(multider, backend, f, x, extras, ::AbstractMode)
+function multiderivative_aux!(multider, backend, f::F, x, extras, ::AbstractMode) where {F}
     return last(value_and_multiderivative!(multider, backend, f, x, extras))
 end
 
@@ -99,15 +107,15 @@ end
 Compute the (array-valued) derivative `multider = f'(x)` of a scalar-to-array function.
 """
 function multiderivative(
-    backend::AbstractADType, f, x::Number, extras=prepare_multiderivative(backend, f, x)
-)
+    backend::AbstractADType, f::F, x::Number, extras=prepare_multiderivative(backend, f, x)
+) where {F}
     return multiderivative_aux(backend, f, x, extras, mode(backend))
 end
 
-function multiderivative_aux(backend, f, x, extras, ::ForwardMode)
+function multiderivative_aux(backend, f::F, x, extras, ::ForwardMode) where {F}
     return pushforward(backend, f, x, one(x), extras)
 end
 
-function multiderivative_aux(backend, f, x, extras, ::AbstractMode)
+function multiderivative_aux(backend, f::F, x, extras, ::AbstractMode) where {F}
     return last(value_and_multiderivative(backend, f, x, extras))
 end

--- a/src/pullback.jl
+++ b/src/pullback.jl
@@ -7,11 +7,11 @@ Compute the primal value `y = f(x)` and the vector-Jacobian product `dx = ∂f(x
 !!! info "Interface requirement"
     This is the only required implementation for a reverse mode backend.
 """
-function value_and_pullback!(dx, backend::AbstractADType, f, x, dy)
+function value_and_pullback!(dx, backend::AbstractADType, f::F, x, dy) where {F}
     return value_and_pullback!(dx, backend, f, x, dy, prepare_pullback(backend, f, x))
 end
 
-function value_and_pullback!(y, dx, backend::AbstractADType, f, x, dy)
+function value_and_pullback!(y, dx, backend::AbstractADType, f::F, x, dy) where {F}
     return value_and_pullback!(y, dx, backend, f, x, dy, prepare_pullback(backend, f, x, y))
 end
 
@@ -21,8 +21,8 @@ end
 Compute the primal value `y = f(x)` and the vector-Jacobian product `dx = ∂f(x)' * dy`.
 """
 function value_and_pullback(
-    backend::AbstractADType, f, x, dy, extras=prepare_pullback(backend, f, x)
-)
+    backend::AbstractADType, f::F, x, dy, extras=prepare_pullback(backend, f, x)
+) where {F}
     dx = mysimilar(x)
     return value_and_pullback!(dx, backend, f, x, dy, extras)
 end
@@ -33,8 +33,8 @@ end
 Compute the vector-Jacobian product `dx = ∂f(x)' * dy`, overwriting `dx` if possible.
 """
 function pullback!(
-    dx, backend::AbstractADType, f, x, dy, extras=prepare_pullback(backend, f, x)
-)
+    dx, backend::AbstractADType, f::F, x, dy, extras=prepare_pullback(backend, f, x)
+) where {F}
     return last(value_and_pullback!(dx, backend, f, x, dy, extras))
 end
 
@@ -43,6 +43,8 @@ end
 
 Compute the vector-Jacobian product `dx = ∂f(x)' * dy`.
 """
-function pullback(backend::AbstractADType, f, x, dy, extras=prepare_pullback(backend, f, x))
+function pullback(
+    backend::AbstractADType, f::F, x, dy, extras=prepare_pullback(backend, f, x)
+) where {F}
     return last(value_and_pullback(backend, f, x, dy, extras))
 end

--- a/src/pushforward.jl
+++ b/src/pushforward.jl
@@ -7,11 +7,11 @@ Compute the primal value `y = f(x)` and the Jacobian-vector product `dy = ∂f(x
 !!! info "Interface requirement"
     This is the only required implementation for a forward mode backend.
 """
-function value_and_pushforward!(dy, backend::AbstractADType, f, x, dx)
+function value_and_pushforward!(dy, backend::AbstractADType, f::F, x, dx) where {F}
     return value_and_pushforward!(dy, backend, f, x, dx, prepare_pushforward(backend, f, x))
 end
 
-function value_and_pushforward!(y, dy, backend::AbstractADType, f, x, dx)
+function value_and_pushforward!(y, dy, backend::AbstractADType, f::F, x, dx) where {F}
     return value_and_pushforward!(
         y, dy, backend, f, x, dx, prepare_pushforward(backend, f, x, y)
     )
@@ -23,8 +23,8 @@ end
 Compute the primal value `y = f(x)` and the Jacobian-vector product `dy = ∂f(x) * dx`.
 """
 function value_and_pushforward(
-    backend::AbstractADType, f, x, dx, extras=prepare_pushforward(backend, f, x)
-)
+    backend::AbstractADType, f::F, x, dx, extras=prepare_pushforward(backend, f, x)
+) where {F}
     dy = mysimilar(f(x))
     return value_and_pushforward!(dy, backend, f, x, dx, extras)
 end
@@ -35,8 +35,8 @@ end
 Compute the Jacobian-vector product `dy = ∂f(x) * dx`, overwriting `dy` if possible.
 """
 function pushforward!(
-    dy, backend::AbstractADType, f, x, dx, extras=prepare_pushforward(backend, f, x)
-)
+    dy, backend::AbstractADType, f::F, x, dx, extras=prepare_pushforward(backend, f, x)
+) where {F}
     return last(value_and_pushforward!(dy, backend, f, x, dx, extras))
 end
 
@@ -46,7 +46,7 @@ end
 Compute the Jacobian-vector product `dy = ∂f(x) * dx`.
 """
 function pushforward(
-    backend::AbstractADType, f, x, dx, extras=prepare_pushforward(backend, f, x)
-)
+    backend::AbstractADType, f::F, x, dx, extras=prepare_pushforward(backend, f, x)
+) where {F}
     return last(value_and_pushforward(backend, f, x, dx, extras))
 end

--- a/src/second_derivative.jl
+++ b/src/second_derivative.jl
@@ -4,16 +4,19 @@
 Compute the primal value `y = f(x)`, the derivative `der = f'(x)` and the second derivative `derder = f''(x)` of a scalar-to-scalar function.
 """
 function value_derivative_and_second_derivative(
-    backend::AbstractADType, f, x::Number, extras=prepare_second_derivative(backend, f, x)
-)
+    backend::AbstractADType,
+    f::F,
+    x::Number,
+    extras=prepare_second_derivative(backend, f, x),
+) where {F}
     return value_derivative_and_second_derivative(
         SecondOrder(backend, backend), f, x, extras
     )
 end
 
 function value_derivative_and_second_derivative(
-    backend::SecondOrder, f, x::Number, extras=prepare_second_derivative(backend, f, x)
-)
+    backend::SecondOrder, f::F, x::Number, extras=prepare_second_derivative(backend, f, x)
+) where {F}
     y = f(x)
     der_aux(x) = derivative(inner(backend), f, x, extras)
     der, derder = value_and_derivative(outer(backend), der_aux, x, extras)
@@ -26,14 +29,17 @@ end
 Compute the second derivative `derder = f''(x)` of a scalar-to-scalar function.
 """
 function second_derivative(
-    backend::AbstractADType, f, x::Number, extras=prepare_second_derivative(backend, f, x)
-)
+    backend::AbstractADType,
+    f::F,
+    x::Number,
+    extras=prepare_second_derivative(backend, f, x),
+) where {F}
     return second_derivative(SecondOrder(backend, backend), f, x, extras)
 end
 
 function second_derivative(
-    backend::SecondOrder, f, x::Number, extras=prepare_second_derivative(backend, f, x)
-)
+    backend::SecondOrder, f::F, x::Number, extras=prepare_second_derivative(backend, f, x)
+) where {F}
     der_aux(x) = derivative(inner(backend), f, x, extras)
     derder = derivative(outer(backend), der_aux, x, extras)
     return derder

--- a/test/zero.jl
+++ b/test/zero.jl
@@ -30,6 +30,7 @@ result = test_operators(
     type_stability=false,
     benchmark=true,
     allocations=true,
+    second_order=false,
 );
 
 data = parse_benchmark(result)


### PR DESCRIPTION
- Turn `operator(backend, f, x)` into `operator(backend, f::F, x) where {F}` everywhere to avoid the performance pitfall <https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing>
- Simplify allocation testing to have a nicer testset structure instead of parsing the `BenchmarkDict`