### PR TITLE
ReverseDiff generality and avoid cross-fallbacks

### DIFF
--- a/ext/DifferentiationInterfaceReverseDiffExt/allocating.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt/allocating.jl
@@ -45,3 +45,13 @@ function DI.value_and_pullback(
     dx = reshape(transpose(jac) * vec(dy), size(x))
     return y, dx
 end
+
+### Trick for unsupported scalar input
+
+function DI.value_and_pullback(
+    f::F, backend::AutoReverseDiff, x::Number, dy, extras::Nothing
+) where {F}
+    x_array = [x]
+    y, dx_array = DI.value_and_pullback(f ∘ only, backend, x_array, dy)
+    return y, only(dx_array)
+end

--- a/ext/DifferentiationInterfaceReverseDiffExt/mutating.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt/mutating.jl
@@ -13,3 +13,21 @@ function DI.value_and_pullback!!(
     mul!(vec(dx), transpose(jac), vec(dy))
     return y, dx
 end
+
+### Trick for unsupported scalar input
+
+function DI.value_and_pullback!!(
+    f!::F,
+    y::AbstractArray,
+    dx::Number,
+    backend::AutoReverseDiff,
+    x::Number,
+    dy::AbstractArray,
+    extras::Nothing,
+) where {F}
+    x_array = [x]
+    dx_array = similar(x_array)
+    f!_only(_y::AbstractArray, _x_array) = f!(_y, only(_x_array))
+    y, dx_array = DI.value_and_pullback!!(f!_only, y, dx_array, backend, x_array, dy)
+    return y, only(dx_array)
+end

--- a/ext/DifferentiationInterfaceTapedExt/DifferentiationInterfaceTapedExt.jl
+++ b/ext/DifferentiationInterfaceTapedExt/DifferentiationInterfaceTapedExt.jl
@@ -9,6 +9,7 @@ DI.supports_mutation(::AutoTaped) = DI.MutationNotSupported()
 
 function DI.value_and_pullback(f::F, ::AutoTaped, x, dy, extras::Nothing) where {F}
     rrule = build_rrule(f, x)
+    y = f(x)
     dy_righttype = convert(typeof(y), dy)
     _, (_, dx) = value_and_pullback!!(rrule, dy_righttype, f, x)
     return y, dx

--- a/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -26,14 +26,4 @@ function DI.gradient(f::F, ::AutoZygote, x, extras::Nothing) where {F}
     return only(gradient(f, x))
 end
 
-function DI.value_and_gradient!!(
-    f::F, grad, backend::AutoZygote, x, extras::Nothing
-) where {F}
-    return DI.value_and_gradient(f, backend, x, extras)
-end
-
-function DI.gradient!!(f::F, grad, backend::AutoZygote, x, extras::Nothing) where {F}
-    return DI.gradient(f, backend, x, extras)
-end
-
 end

--- a/src/DifferentiationTest/test_error_free.jl
+++ b/src/DifferentiationTest/test_error_free.jl
@@ -6,6 +6,8 @@ function test_error_free(ba::AbstractADType, ::typeof(pushforward), scen::Scenar
 
     @test (value_and_pushforward!!(f, dy_in, ba, x, dx, extras); true)
     @test (value_and_pushforward(f, ba, x, dx, extras); true)
+    @test (pushforward!!(f, dy_in, ba, x, dx, extras); true)
+    @test (pushforward(f, ba, x, dx, extras); true)
     return nothing
 end
 
@@ -28,6 +30,8 @@ function test_error_free(ba::AbstractADType, ::typeof(pullback), scen::Scenario{
 
     @test (value_and_pullback!!(f, dx_in, ba, x, dy, extras); true)
     @test (value_and_pullback(f, ba, x, dy, extras); true)
+    @test (pullback!!(f, dx_in, ba, x, dy, extras); true)
+    @test (pullback(f, ba, x, dy, extras); true)
     return nothing
 end
 
@@ -51,6 +55,8 @@ function test_error_free(ba::AbstractADType, ::typeof(derivative), scen::Scenari
 
     @test (value_and_derivative!!(f, der_in, ba, x, extras); true)
     @test (value_and_derivative(f, ba, x, extras); true)
+    @test (derivative!!(f, der_in, ba, x, extras); true)
+    @test (derivative(f, ba, x, extras); true)
     return nothing
 end
 
@@ -74,6 +80,8 @@ function test_error_free(ba::AbstractADType, ::typeof(gradient), scen::Scenario{
 
     @test (value_and_gradient!!(f, grad_in, ba, x, extras); true)
     @test (value_and_gradient(f, ba, x, extras); true)
+    @test (gradient!!(f, grad_in, ba, x, extras); true)
+    @test (gradient(f, ba, x, extras); true)
     return nothing
 end
 
@@ -86,6 +94,8 @@ function test_error_free(ba::AbstractADType, ::typeof(jacobian), scen::Scenario{
 
     @test (value_and_jacobian!!(f, jac_in, ba, x, extras); true)
     @test (value_and_jacobian(f, ba, x, extras); true)
+    @test (jacobian!!(f, jac_in, ba, x, extras); true)
+    @test (jacobian(f, ba, x, extras); true)
     return nothing
 end
 

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -20,7 +20,7 @@ function value_and_derivative_aux(
 ) where {F}
     y = f(x)
     if y isa Number
-        return value_and_gradient(f, backend, x)
+        return value_and_pullback(f, backend, x, one(y))
     else
         der = map(CartesianIndices(y)) do i
             dy_i = basisarray(backend, y, i)
@@ -50,7 +50,7 @@ end
 function value_and_derivative_aux!!(
     f::F, _der::Number, backend, x, extras, ::PushforwardNotSupported
 ) where {F}
-    return value_and_gradient(f, backend, x, extras)
+    return value_and_pullback(f, backend, x, one(x), extras)
 end
 
 function value_and_derivative_aux!!(

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -16,7 +16,7 @@ end
 function value_and_gradient_aux(
     f::F, backend, x::Number, extras, ::PullbackNotSupported
 ) where {F}
-    return value_and_derivative(f, backend, x, extras)
+    return value_and_pushforward(f, backend, x, one(x), extras)
 end
 
 function value_and_gradient_aux(
@@ -48,7 +48,7 @@ end
 function value_and_gradient_aux!!(
     f::F, grad, backend, x::Number, extras, ::PullbackNotSupported
 ) where {F}
-    return value_and_derivative(f, backend, x, extras)
+    return value_and_pushforward(f, backend, x, one(x), extras)
 end
 
 function value_and_gradient_aux!!(

--- a/test/chainrules_reverse.jl
+++ b/test/chainrules_reverse.jl
@@ -1,4 +1,5 @@
-using ADTypes: AutoChainRules
+include("test_imports.jl")
+
 using Zygote: ZygoteRuleConfig
 
 @test check_available(AutoChainRules(ZygoteRuleConfig()))

--- a/test/diffractor.jl
+++ b/test/diffractor.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using Diffractor: Diffractor
 
 @test check_available(AutoDiffractor())

--- a/test/enzyme_forward.jl
+++ b/test/enzyme_forward.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using Enzyme: Enzyme
 
 @test check_available(AutoEnzyme(Enzyme.Forward))

--- a/test/enzyme_reverse.jl
+++ b/test/enzyme_reverse.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using Enzyme: Enzyme
 
 @test check_available(AutoEnzyme(Enzyme.Reverse))

--- a/test/fastdifferentiation.jl
+++ b/test/fastdifferentiation.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using DifferentiationInterface: AutoFastDifferentiation
 using FastDifferentiation: FastDifferentiation
 

--- a/test/finitediff.jl
+++ b/test/finitediff.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using FiniteDiff: FiniteDiff
 
 @test check_available(AutoFiniteDiff())

--- a/test/finitedifferences.jl
+++ b/test/finitedifferences.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using FiniteDifferences: FiniteDifferences, central_fdm
 
 @test check_available(AutoFiniteDifferences(central_fdm(5, 1)))

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using ForwardDiff: ForwardDiff
 
 @test check_available(AutoForwardDiff())

--- a/test/nested.jl
+++ b/test/nested.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using Enzyme: Enzyme
 using Tracker: Tracker
 using Zygote: Zygote

--- a/test/nobackend.jl
+++ b/test/nobackend.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using ADTypes: ADTypes
 
 struct AutoNothingForward <: ADTypes.AbstractForwardMode end

--- a/test/polyesterforwarddiff.jl
+++ b/test/polyesterforwarddiff.jl
@@ -1,4 +1,5 @@
-using ADTypes: AutoPolyesterForwardDiff
+include("test_imports.jl")
+
 using PolyesterForwardDiff: PolyesterForwardDiff
 
 @test check_available(AutoPolyesterForwardDiff(; chunksize=2))

--- a/test/reversediff.jl
+++ b/test/reversediff.jl
@@ -1,8 +1,9 @@
-using ADTypes: AutoReverseDiff
+include("test_imports.jl")
+
 using ReverseDiff: ReverseDiff
 
-@test_broken check_available(AutoReverseDiff())
+@test check_available(AutoReverseDiff())
 @test check_mutation(AutoReverseDiff())
 @test check_hessian(AutoReverseDiff())
 
-test_differentiation(AutoReverseDiff(); input_type=AbstractArray);
+test_differentiation(AutoReverseDiff());

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,22 +1,4 @@
-## Imports
-
-using ADTypes
-using DifferentiationInterface
-using DifferentiationInterface.DifferentiationTest
-
-using Aqua: Aqua
-using JET: JET
-using JuliaFormatter: JuliaFormatter
-using Test
-
-# used for testing
-using Chairmarks: Chairmarks
-using DataFrames: DataFrames
-using ForwardDiff: ForwardDiff
-using ComponentArrays
-using JLArrays
-using StaticArrays
-using Zygote: Zygote
+include("test_imports.jl")
 
 ## Main tests
 

--- a/test/taped.jl
+++ b/test/taped.jl
@@ -1,14 +1,10 @@
 using Pkg
 Pkg.add(; url="https://github.com/withbayes/Taped.jl/")
 
-using DifferentiationInterface
-using DifferentiationInterface: AutoTaped
-using DifferentiationInterface.DifferentiationTest
-using Taped: Taped
+include("test_imports.jl")
 
-using ForwardDiff: ForwardDiff
-using JET: JET
-using Test
+using DifferentiationInterface: AutoTaped
+using Taped: Taped
 
 @test check_available(AutoTaped())
 @test !check_mutation(AutoTaped())

--- a/test/test_imports.jl
+++ b/test/test_imports.jl
@@ -1,0 +1,18 @@
+## Imports
+
+using ADTypes
+using DifferentiationInterface
+using DifferentiationInterface.DifferentiationTest
+
+using Aqua: Aqua
+using JET: JET
+using JuliaFormatter: JuliaFormatter
+using Test
+
+using Chairmarks: Chairmarks
+using DataFrames: DataFrames
+using ForwardDiff: ForwardDiff
+using ComponentArrays
+using JLArrays
+using StaticArrays
+using Zygote: Zygote

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using Tracker: Tracker
 
 @test check_available(AutoTracker())
@@ -5,8 +7,5 @@ using Tracker: Tracker
 # @test !check_hessian(AutoTracker())
 
 test_differentiation(
-    AutoTracker();
-    output_type=Union{Number,AbstractVector},
-    second_order=false,
-    mutating=false,
+    AutoTracker(); output_type=Union{Number,AbstractVector}, second_order=false
 );

--- a/test/zero.jl
+++ b/test/zero.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using DifferentiationInterface.DifferentiationTest: AutoZeroForward, AutoZeroReverse
 
 @test check_available(AutoZeroForward())

--- a/test/zygote.jl
+++ b/test/zygote.jl
@@ -1,3 +1,5 @@
+include("test_imports.jl")
+
 using Zygote: Zygote
 
 @test check_available(AutoZygote())


### PR DESCRIPTION
**Core**

- Gradient for 1d input and derivative for 1d output used to cross-call each other when the backend was in the wrong mode. Now it's all pushforwards and pullbacks

**Extensions**

- ReverseDiff supports number input
- Taped is fixed

**Tests**

- Separate imports so that each test file is autonomous