### PR TITLE
Reinsert prep for some backends + remove specialization on f

### DIFF
--- a/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -16,17 +16,13 @@ DI.mode(::AutoReverseChainRules) = ADTypes.AbstractReverseMode
 
 ## Primitives
 
-function DI.value_and_pushforward(
-    f::F, backend::AutoForwardChainRules, x, dx, extras::Nothing
-) where {F}
+function DI.value_and_pushforward(f, backend::AutoForwardChainRules, x, dx, extras::Nothing)
     rc = ruleconfig(backend)
     y, new_dy = frule_via_ad(rc, (NoTangent(), dx), f, x)
     return y, new_dy
 end
 
-function DI.value_and_pullback(
-    f::F, backend::AutoReverseChainRules, x, dy, extras::Nothing
-) where {F}
+function DI.value_and_pullback(f, backend::AutoReverseChainRules, x, dy, extras::Nothing)
     rc = ruleconfig(backend)
     y, pullback = rrule_via_ad(rc, f, x)
     _, new_dx = pullback(dy)

--- a/ext/DifferentiationInterfaceCorrectnessTestExt/DifferentiationInterfaceCorrectnessTestExt.jl
+++ b/ext/DifferentiationInterfaceCorrectnessTestExt/DifferentiationInterfaceCorrectnessTestExt.jl
@@ -57,11 +57,6 @@ function test_correctness(ba::AbstractADType, ::typeof(pushforward), scen::Scena
 
     @testset "Primal value" begin
         @test myisapprox(y_out, y)
-        @testset "Mutation" begin
-            if ismutable(y)
-                @test myisapprox(y_in, y)
-            end
-        end
     end
     @testset "Tangent value" begin
         @test myisapprox(dy_out, dy_true; rtol=1e-3)
@@ -107,11 +102,6 @@ function test_correctness(ba::AbstractADType, ::typeof(pullback), scen::Scenario
 
     @testset "Primal value" begin
         @test myisapprox(y_out, y)
-        @testset "Mutation" begin
-            if ismutable(y)
-                @test myisapprox(y_in, y)
-            end
-        end
     end
     @testset "Cotangent value" begin
         @test myisapprox(dx_out, dx_true; rtol=1e-3)
@@ -157,11 +147,6 @@ function test_correctness(ba::AbstractADType, ::typeof(derivative), scen::Scenar
 
     @testset "Primal value" begin
         @test myisapprox(y_out, y)
-        @testset "Mutation" begin
-            if ismutable(y)
-                @test myisapprox(y_in, y)
-            end
-        end
     end
     @testset "Derivative value" begin
         @test myisapprox(der_out, der_true; rtol=1e-3)
@@ -176,7 +161,11 @@ function test_correctness(ba::AbstractADType, ::typeof(gradient), scen::Scenario
     grad_true = if x isa Number
         ForwardDiff.derivative(f, x)
     else
-        only(Zygote.gradient(f, x))
+        try
+            ForwardDiff.gradient(f, x)
+        catch e
+            only(Zygote.gradient(f, x))
+        end
     end
 
     y_out1, grad_out1 = value_and_gradient(f, ba, x)
@@ -223,10 +212,6 @@ function test_correctness(ba::AbstractADType, ::typeof(jacobian), scen::Scenario
         @test myisapprox(jac_out2, jac_true; rtol=1e-3)
         @test myisapprox(jac_out3, jac_true; rtol=1e-3)
         @test myisapprox(jac_out4, jac_true; rtol=1e-3)
-        @testset "Mutation" begin
-            @test myisapprox(jac_in2, jac_true; rtol=1e-3)
-            @test myisapprox(jac_in4, jac_true; rtol=1e-3)
-        end
     end
     return test_scen_intact(new_scen, scen)
 end
@@ -242,15 +227,9 @@ function test_correctness(ba::AbstractADType, ::typeof(jacobian), scen::Scenario
 
     @testset "Primal value" begin
         @test myisapprox(y_out, y)
-        @testset "Mutation" begin
-            @test myisapprox(y_in, y)
-        end
     end
     @testset "Jacobian value" begin
         @test myisapprox(jac_out, jac_true; rtol=1e-3)
-        @testset "Mutation" begin
-            @test myisapprox(jac_in, jac_true; rtol=1e-3)
-        end
     end
     return test_scen_intact(new_scen, scen)
 end

--- a/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
+++ b/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
@@ -9,7 +9,7 @@ DI.supports_mutation(::AutoDiffractor) = DI.MutationNotSupported()
 DI.mode(::AutoDiffractor) = ADTypes.AbstractForwardMode
 DI.mode(::AutoChainRules{<:DiffractorRuleConfig}) = ADTypes.AbstractForwardMode
 
-function DI.value_and_pushforward(f::F, ::AutoDiffractor, x, dx, extras::Nothing) where {F}
+function DI.value_and_pushforward(f, ::AutoDiffractor, x, dx, extras::Nothing)
     vpff = AD.value_and_pushforward_function(DiffractorForwardBackend(), f, x)
     y, dy = vpff((dx,))
     return y, dy

--- a/ext/DifferentiationInterfaceEnzymeExt/forward_allocating.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt/forward_allocating.jl
@@ -1,8 +1,6 @@
 ## Pushforward
 
-function DI.value_and_pushforward(
-    f::F, backend::AutoForwardEnzyme, x, dx, extras::Nothing
-) where {F}
+function DI.value_and_pushforward(f, backend::AutoForwardEnzyme, x, dx, extras::Nothing)
     dx_sametype = convert(typeof(x), copy(dx))
     y, new_dy = autodiff(backend.mode, f, Duplicated, Duplicated(x, dx_sametype))
     return y, new_dy

--- a/ext/DifferentiationInterfaceEnzymeExt/forward_mutating.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt/forward_mutating.jl
@@ -1,8 +1,8 @@
 ## Pushforward
 
 function DI.value_and_pushforward!!(
-    f!::F, y, dy, backend::AutoForwardEnzyme, x, dx, extras::Nothing
-) where {F}
+    f!, y, dy, backend::AutoForwardEnzyme, x, dx, extras::Nothing
+)
     dx_sametype = convert(typeof(x), copy(dx))
     dy_sametype = convert(typeof(y), dy)
     autodiff(

--- a/ext/DifferentiationInterfaceEnzymeExt/reverse_allocating.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt/reverse_allocating.jl
@@ -1,16 +1,14 @@
 ## Pullback
 
 function DI.value_and_pullback!!(
-    f::F, _dx, ::AutoReverseEnzyme, x::Number, dy::Number, extras::Nothing
-) where {F}
+    f, _dx, ::AutoReverseEnzyme, x::Number, dy::Number, extras::Nothing
+)
     der, y = autodiff(ReverseWithPrimal, f, Active, Active(x))
     new_dx = dy * only(der)
     return y, new_dx
 end
 
-function DI.value_and_pullback!!(
-    f::F, dx, ::AutoReverseEnzyme, x, dy::Number, extras::Nothing
-) where {F}
+function DI.value_and_pullback!!(f, dx, ::AutoReverseEnzyme, x, dy::Number, extras::Nothing)
     dx_sametype = convert(typeof(x), dx)
     dx_sametype = myzero!!(dx_sametype)
     _, y = autodiff(ReverseWithPrimal, f, Active, Duplicated(x, dx_sametype))
@@ -18,29 +16,25 @@ function DI.value_and_pullback!!(
     return y, myupdate!!(dx, dx_sametype)
 end
 
-function DI.value_and_pullback(
-    f::F, backend::AutoReverseEnzyme, x, dy::Number, extras
-) where {F}
+function DI.value_and_pullback(f, backend::AutoReverseEnzyme, x, dy::Number, extras)
     dx = mysimilar(x)
     return DI.value_and_pullback!!(f, dx, backend, x, dy, extras)
 end
 
 ## Gradient
 
-function DI.gradient(f::F, backend::AutoReverseEnzyme, x, extras::Nothing) where {F}
+function DI.gradient(f, backend::AutoReverseEnzyme, x, extras::Nothing)
     return gradient(Reverse, f, x)
 end
 
-function DI.gradient!!(f::F, grad, backend::AutoReverseEnzyme, x, extras::Nothing) where {F}
+function DI.gradient!!(f, grad, backend::AutoReverseEnzyme, x, extras::Nothing)
     return gradient!(Reverse, grad, f, x)
 end
 
-function DI.gradient(f::F, backend::AutoReverseEnzyme, x::Number, extras::Nothing) where {F}
+function DI.gradient(f, backend::AutoReverseEnzyme, x::Number, extras::Nothing)
     return autodiff(Reverse, f, Active(x))
 end
 
-function DI.gradient!!(
-    f::F, grad, backend::AutoReverseEnzyme, x::Number, extras::Nothing
-) where {F}
+function DI.gradient!!(f, grad, backend::AutoReverseEnzyme, x::Number, extras::Nothing)
     return autodiff(Reverse, f, Active(x))
 end

--- a/ext/DifferentiationInterfaceEnzymeExt/reverse_mutating.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt/reverse_mutating.jl
@@ -1,16 +1,14 @@
 ## Pullback
 
 function DI.value_and_pullback!!(
-    f!::F, y, _dx, ::AutoReverseEnzyme, x::Number, dy, extras::Nothing
-) where {F}
+    f!, y, _dx, ::AutoReverseEnzyme, x::Number, dy, extras::Nothing
+)
     dy_sametype = convert(typeof(y), copy(dy))
     _, new_dx = only(autodiff(Reverse, f!, Const, Duplicated(y, dy_sametype), Active(x)))
     return y, new_dx
 end
 
-function DI.value_and_pullback!!(
-    f!::F, y, dx, ::AutoReverseEnzyme, x, dy, extras::Nothing
-) where {F}
+function DI.value_and_pullback!!(f!, y, dx, ::AutoReverseEnzyme, x, dy, extras::Nothing)
     dx_sametype = convert(typeof(x), dx)
     dx_sametype = myzero!!(dx_sametype)
     dy_sametype = convert(typeof(y), copy(dy))

--- a/ext/DifferentiationInterfaceFastDifferentiationExt/allocating.jl
+++ b/ext/DifferentiationInterfaceFastDifferentiationExt/allocating.jl
@@ -1,6 +1,6 @@
 ## Pushforward
 
-function DI.prepare_pushforward(f::F, ::AutoFastDifferentiation, x) where {F}
+function DI.prepare_pushforward(f, ::AutoFastDifferentiation, x)
     x_var = if x isa Number
         only(make_variables(:x))
     else
@@ -16,8 +16,8 @@ function DI.prepare_pushforward(f::F, ::AutoFastDifferentiation, x) where {F}
 end
 
 function DI.value_and_pushforward(
-    f::F, ::AutoFastDifferentiation, x, dx, jvp_exe::RuntimeGeneratedFunction
-) where {F}
+    f, ::AutoFastDifferentiation, x, dx, jvp_exe::RuntimeGeneratedFunction
+)
     y = f(x)
     v_vec = vcat(myvec(x), myvec(dx))
     jv_vec = jvp_exe(v_vec)
@@ -29,15 +29,13 @@ function DI.value_and_pushforward(
 end
 
 function DI.value_and_pushforward(
-    f::F, backend::AutoFastDifferentiation, x, dx, extras::Nothing
-) where {F}
+    f, backend::AutoFastDifferentiation, x, dx, extras::Nothing
+)
     jvp_exe = DI.prepare_pushforward(f, backend, x)
     return DI.value_and_pushforward(f, backend, x, dx, jvp_exe)
 end
 
-function DI.value_and_pushforward!!(
-    f::F, dy, backend::AutoFastDifferentiation, x, dx, extras
-) where {F}
+function DI.value_and_pushforward!!(f, dy, backend::AutoFastDifferentiation, x, dx, extras)
     y, new_dy = DI.value_and_pushforward(f, backend, x, dx, extras)
     return y, myupdate!!(dy, new_dy)
 end

--- a/ext/DifferentiationInterfaceFiniteDiffExt/allocating.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt/allocating.jl
@@ -2,7 +2,7 @@
 
 function DI.value_and_pushforward!!(
     f, _dy::Number, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
-) where {F,fdtype}
+) where {fdtype}
     y = f(x)
     step(t::Number)::Number = f(x .+ t .* dx)
     new_dy = finite_difference_derivative(step, zero(eltype(dx)), fdtype, eltype(y), y)
@@ -11,7 +11,7 @@ end
 
 function DI.value_and_pushforward!!(
     f, dy::AbstractArray, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
-) where {F,fdtype}
+) where {fdtype}
     y = f(x)
     step(t::Number)::AbstractArray = f(x .+ t .* dx)
     finite_difference_gradient!(
@@ -22,7 +22,7 @@ end
 
 function DI.value_and_pushforward(
     f, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
-) where {F,fdtype}
+) where {fdtype}
     y = f(x)
     step(t::Number) = f(x .+ t .* dx)
     new_dy = finite_difference_derivative(step, zero(eltype(dx)), fdtype, eltype(y), y)

--- a/ext/DifferentiationInterfaceFiniteDiffExt/allocating.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt/allocating.jl
@@ -1,7 +1,7 @@
 ## Pushforward
 
 function DI.value_and_pushforward!!(
-    f::F, _dy::Number, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
+    f, _dy::Number, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
 ) where {F,fdtype}
     y = f(x)
     step(t::Number)::Number = f(x .+ t .* dx)
@@ -10,7 +10,7 @@ function DI.value_and_pushforward!!(
 end
 
 function DI.value_and_pushforward!!(
-    f::F, dy::AbstractArray, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
+    f, dy::AbstractArray, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
 ) where {F,fdtype}
     y = f(x)
     step(t::Number)::AbstractArray = f(x .+ t .* dx)
@@ -21,7 +21,7 @@ function DI.value_and_pushforward!!(
 end
 
 function DI.value_and_pushforward(
-    f::F, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
+    f, ::AutoFiniteDiff{fdtype}, x, dx, extras::Nothing
 ) where {F,fdtype}
     y = f(x)
     step(t::Number) = f(x .+ t .* dx)

--- a/ext/DifferentiationInterfaceFiniteDiffExt/mutating.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt/mutating.jl
@@ -1,7 +1,7 @@
 ## Pushforward
 
 function DI.value_and_pushforward!!(
-    f!::F,
+    f!,
     y::AbstractArray,
     dy::AbstractArray,
     ::AutoFiniteDiff{fdtype},

--- a/ext/DifferentiationInterfaceFiniteDiffExt/mutating.jl
+++ b/ext/DifferentiationInterfaceFiniteDiffExt/mutating.jl
@@ -8,7 +8,7 @@ function DI.value_and_pushforward!!(
     x,
     dx,
     extras::Nothing,
-) where {F,fdtype}
+) where {fdtype}
     function step(t::Number)::AbstractArray
         new_y = similar(y)
         f!(new_y, x .+ t .* dx)

--- a/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
+++ b/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
@@ -13,8 +13,8 @@ function FiniteDifferences.to_vec(a::OneElement)  # TODO: remove type piracy (ht
 end
 
 function DI.value_and_pushforward(
-    f::F, backend::AutoFiniteDifferences{fdm}, x, dx, extras::Nothing
-) where {F,fdm}
+    f, backend::AutoFiniteDifferences{fdm}, x, dx, extras::Nothing
+) where {fdm}
     y = f(x)
     return y, jvp(backend.fdm, f, (x, dx))
 end

--- a/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -2,7 +2,7 @@ module DifferentiationInterfaceForwardDiffExt
 
 using ADTypes: AbstractADType, AutoForwardDiff
 import DifferentiationInterface as DI
-using DiffResults: DiffResults
+using DiffResults: DiffResults, DiffResult, GradientResult
 using ForwardDiff:
     Chunk,
     Dual,

--- a/ext/DifferentiationInterfaceForwardDiffExt/allocating.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/allocating.jl
@@ -1,8 +1,72 @@
-function DI.value_and_pushforward(f::F, ::AutoForwardDiff, x, dx, extras::Nothing) where {F}
+## Pushforward
+
+function DI.value_and_pushforward(f, ::AutoForwardDiff, x, dx, extras::Nothing)
     T = tag_type(f, x)
     xdual = make_dual(T, x, dx)
     ydual = f(xdual)
     y = my_value(T, ydual)
     new_dy = my_derivative(T, ydual)
     return y, new_dy
+end
+
+## Gradient
+
+function DI.prepare_gradient(f, backend::AutoForwardDiff, x::AbstractArray)
+    return GradientConfig(f, x, choose_chunk(backend, x))
+end
+
+function DI.value_and_gradient!!(
+    f, grad::AbstractArray, ::AutoForwardDiff, x::AbstractArray, config::GradientConfig
+)
+    result = DiffResult(zero(eltype(x)), grad)
+    result = gradient!(result, f, x, config)
+    return DiffResults.value(result), DiffResults.gradient(result)
+end
+
+function DI.value_and_gradient(
+    f, backend::AutoForwardDiff, x::AbstractArray, config::GradientConfig
+)
+    grad = similar(x)
+    return DI.value_and_gradient!!(f, grad, backend, x, config)
+end
+
+function DI.gradient!!(
+    f, grad::AbstractArray, ::AutoForwardDiff, x::AbstractArray, config::GradientConfig
+)
+    return gradient!(grad, f, x, config)
+end
+
+function DI.gradient(f, ::AutoForwardDiff, x::AbstractArray, config::GradientConfig)
+    return gradient(f, x, config)
+end
+
+## Jacobian
+
+function DI.prepare_jacobian(f, backend::AutoForwardDiff, x::AbstractArray)
+    return JacobianConfig(f, x, choose_chunk(backend, x))
+end
+
+function DI.value_and_jacobian!!(
+    f, jac::AbstractMatrix, ::AutoForwardDiff, x::AbstractArray, config::JacobianConfig
+)
+    y = f(x)
+    result = DiffResult(y, jac)
+    result = jacobian!(result, f, x, config)
+    return DiffResults.value(result), DiffResults.jacobian(result)
+end
+
+function DI.value_and_jacobian(
+    f, ::AutoForwardDiff, x::AbstractArray, config::JacobianConfig
+)
+    return f(x), jacobian(f, x, config)
+end
+
+function DI.jacobian!!(
+    f, jac::AbstractMatrix, ::AutoForwardDiff, x::AbstractArray, config::JacobianConfig
+)
+    return jacobian!(jac, f, x, config)
+end
+
+function DI.jacobian(f, ::AutoForwardDiff, x::AbstractArray, config::JacobianConfig)
+    return jacobian(f, x, config)
 end

--- a/ext/DifferentiationInterfaceForwardDiffExt/mutating.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/mutating.jl
@@ -1,6 +1,4 @@
-function DI.value_and_pushforward!!(
-    f!::F, y, dy, ::AutoForwardDiff, x, dx, extras::Nothing
-) where {F}
+function DI.value_and_pushforward!!(f!, y, dy, ::AutoForwardDiff, x, dx, extras::Nothing)
     T = tag_type(f!, x)
     xdual = make_dual(T, x, dx)
     ydual = make_dual(T, y, dy)
@@ -8,4 +6,44 @@ function DI.value_and_pushforward!!(
     y = my_value!!(T, y, ydual)
     dy = my_derivative!!(T, dy, ydual)
     return y, dy
+end
+
+## Derivative
+
+function DI.prepare_derivative(f!, ::AutoForwardDiff, y::AbstractArray, x::Number)
+    return DerivativeConfig(f!, y, x)
+end
+
+function DI.value_and_derivative!!(
+    f!,
+    y::AbstractArray,
+    der::AbstractArray,
+    ::AutoForwardDiff,
+    x::Number,
+    config::DerivativeConfig,
+)
+    result = DiffResult(y, der)
+    result = derivative!(result, f!, y, x, config)
+    return DiffResults.value(result), DiffResults.derivative(result)
+end
+
+## Jacobian
+
+function DI.prepare_jacobian(
+    f!, backend::AutoForwardDiff, y::AbstractArray, x::AbstractArray
+)
+    return JacobianConfig(f!, y, x, choose_chunk(backend, x))
+end
+
+function DI.value_and_jacobian!!(
+    f!,
+    y::AbstractArray,
+    jac::AbstractMatrix,
+    ::AutoForwardDiff,
+    x::AbstractArray,
+    config::JacobianConfig,
+)
+    result = DiffResult(y, jac)
+    result = jacobian!(result, f!, y, x, config)
+    return DiffResults.value(result), DiffResults.jacobian(result)
 end

--- a/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -23,3 +23,10 @@ end
 function my_derivative!!(::Type{T}, dy, ydual) where {T}
     return extract_derivative!(T, dy, ydual)
 end
+
+struct ForwardDiffExtras{
+    C<:Union{DerivativeConfig,GradientConfig,JacobianConfig},R<:DiffResult
+}
+    config::C
+    result::R
+end

--- a/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -23,10 +23,3 @@ end
 function my_derivative!!(::Type{T}, dy, ydual) where {T}
     return extract_derivative!(T, dy, ydual)
 end
-
-struct ForwardDiffExtras{
-    C<:Union{DerivativeConfig,GradientConfig,JacobianConfig},R<:DiffResult
-}
-    config::C
-    result::R
-end

--- a/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
+++ b/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
@@ -1,6 +1,7 @@
 module DifferentiationInterfacePolyesterForwardDiffExt
 
 using ADTypes: AutoPolyesterForwardDiff, AutoForwardDiff
+using DifferentiationInterface: mysimilar
 import DifferentiationInterface as DI
 using DiffResults: DiffResults
 using DocStringExtensions
@@ -8,20 +9,7 @@ using ForwardDiff: Chunk
 using LinearAlgebra: mul!
 using PolyesterForwardDiff: threaded_gradient!, threaded_jacobian!
 
-## Pushforward
-
-function DI.value_and_pushforward(
-    f::F, ::AutoPolyesterForwardDiff{C}, x, dx, extras::Nothing
-) where {F,C}
-    return DI.value_and_pushforward(f, AutoForwardDiff{C,Nothing}(nothing), x, dx, extras)
-end
-
-function DI.value_and_pushforward!!(
-    f!::F, y, dy, ::AutoPolyesterForwardDiff{C}, x, dx, extras::Nothing
-) where {F,C}
-    return DI.value_and_pushforward!!(
-        f!, y, dy, AutoForwardDiff{C,Nothing}(nothing), x, dx, extras
-    )
-end
+include("allocating.jl")
+include("mutating.jl")
 
 end # module

--- a/ext/DifferentiationInterfacePolyesterForwardDiffExt/allocating.jl
+++ b/ext/DifferentiationInterfacePolyesterForwardDiffExt/allocating.jl
@@ -1,0 +1,72 @@
+
+## Pushforward
+
+function DI.value_and_pushforward(
+    f, ::AutoPolyesterForwardDiff{C}, x, dx, extras::Nothing
+) where {C}
+    return DI.value_and_pushforward(f, AutoForwardDiff{C,Nothing}(nothing), x, dx, extras)
+end
+
+function DI.value_and_pushforward!!(
+    f, dy, ::AutoPolyesterForwardDiff{C}, x, dx, extras::Nothing
+) where {C}
+    return DI.value_and_pushforward!!(
+        f, dy, AutoForwardDiff{C,Nothing}(nothing), x, dx, extras
+    )
+end
+
+## Gradient
+
+function DI.value_and_gradient!!(
+    f, grad::AbstractArray, ::AutoPolyesterForwardDiff{C}, x::AbstractArray, extras::Nothing
+) where {C}
+    threaded_gradient!(f, grad, x, Chunk{C}())
+    return f(x), grad
+end
+
+function DI.gradient!!(
+    f, grad::AbstractArray, ::AutoPolyesterForwardDiff{C}, x::AbstractArray, extras::Nothing
+) where {C}
+    threaded_gradient!(f, grad, x, Chunk{C}())
+    return grad
+end
+
+function DI.value_and_gradient(
+    f, backend::AutoPolyesterForwardDiff, x::AbstractArray, extras::Nothing
+)
+    return DI.value_and_gradient!!(f, mysimilar(x), backend, x, extras)
+end
+
+function DI.gradient(
+    f, backend::AutoPolyesterForwardDiff, x::AbstractArray, extras::Nothing
+)
+    return DI.gradient!!(f, mysimilar(x), backend, x, extras)
+end
+
+## Jacobian
+
+function DI.value_and_jacobian!!(
+    f, jac::AbstractMatrix, ::AutoPolyesterForwardDiff{C}, x::AbstractArray, extras::Nothing
+) where {C}
+    return f(x), threaded_jacobian!(f, jac, x, Chunk{C}())
+end
+
+function DI.jacobian!!(
+    f, jac::AbstractMatrix, ::AutoPolyesterForwardDiff{C}, x::AbstractArray, extras::Nothing
+) where {C}
+    return threaded_jacobian!(f, jac, x, Chunk{C}())
+end
+
+function DI.value_and_jacobian(
+    f, backend::AutoPolyesterForwardDiff, x::AbstractArray, extras::Nothing
+)
+    y = f(x)
+    return DI.value_and_jacobian!!(f, similar(y, length(y), length(x)), backend, x, extras)
+end
+
+function DI.jacobian(
+    f, backend::AutoPolyesterForwardDiff, x::AbstractArray, extras::Nothing
+)
+    y = f(x)
+    return DI.jacobian!!(f, similar(y, length(y), length(x)), backend, x, extras)
+end

--- a/ext/DifferentiationInterfacePolyesterForwardDiffExt/mutating.jl
+++ b/ext/DifferentiationInterfacePolyesterForwardDiffExt/mutating.jl
@@ -1,0 +1,22 @@
+## Pushforward
+
+function DI.value_and_pushforward!!(
+    f!, y, dy, ::AutoPolyesterForwardDiff{C}, x, dx, extras::Nothing
+) where {C}
+    return DI.value_and_pushforward!!(
+        f!, y, dy, AutoForwardDiff{C,Nothing}(nothing), x, dx, extras
+    )
+end
+
+function DI.value_and_jacobian!!(
+    f!,
+    y::AbstractArray,
+    jac::AbstractMatrix,
+    ::AutoPolyesterForwardDiff{C},
+    x::AbstractArray,
+    extras::Nothing,
+) where {C}
+    f!(y, x)
+    threaded_jacobian!(f!, y, jac, x, Chunk{C}())
+    return y, jac
+end

--- a/ext/DifferentiationInterfaceReverseDiffExt/DifferentiationInterfaceReverseDiffExt.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt/DifferentiationInterfaceReverseDiffExt.jl
@@ -2,7 +2,7 @@ module DifferentiationInterfaceReverseDiffExt
 
 using ADTypes: AutoReverseDiff
 import DifferentiationInterface as DI
-using DiffResults: DiffResults
+using DiffResults: DiffResults, DiffResult, GradientResult
 using DocStringExtensions
 using LinearAlgebra: mul!
 using ReverseDiff:

--- a/ext/DifferentiationInterfaceReverseDiffExt/allocating.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt/allocating.jl
@@ -1,13 +1,8 @@
 ## Pullback
 
 function DI.value_and_pullback!!(
-    f::F,
-    dx::AbstractArray,
-    ::AutoReverseDiff,
-    x::AbstractArray,
-    dy::Number,
-    extras::Nothing,
-) where {F}
+    f, dx::AbstractArray, ::AutoReverseDiff, x::AbstractArray, dy::Number, extras::Nothing
+)
     y = f(x)
     gradient!(dx, f, x)
     dx .*= dy
@@ -15,8 +10,8 @@ function DI.value_and_pullback!!(
 end
 
 function DI.value_and_pullback(
-    f::F, ::AutoReverseDiff, x::AbstractArray, dy::Number, extras::Nothing
-) where {F}
+    f, ::AutoReverseDiff, x::AbstractArray, dy::Number, extras::Nothing
+)
     y = f(x)
     dx = gradient(f, x)
     dx .*= dy
@@ -24,13 +19,13 @@ function DI.value_and_pullback(
 end
 
 function DI.value_and_pullback!!(
-    f::F,
+    f,
     dx::AbstractArray,
     ::AutoReverseDiff,
     x::AbstractArray,
     dy::AbstractArray,
     extras::Nothing,
-) where {F}
+)
     y = f(x)
     jac = jacobian(f, x)  # allocates
     mul!(vec(dx), transpose(jac), vec(dy))
@@ -38,8 +33,8 @@ function DI.value_and_pullback!!(
 end
 
 function DI.value_and_pullback(
-    f::F, ::AutoReverseDiff, x::AbstractArray, dy::AbstractArray, extras::Nothing
-) where {F}
+    f, ::AutoReverseDiff, x::AbstractArray, dy::AbstractArray, extras::Nothing
+)
     y = f(x)
     jac = jacobian(f, x)  # allocates
     dx = reshape(transpose(jac) * vec(dy), size(x))
@@ -48,10 +43,101 @@ end
 
 ### Trick for unsupported scalar input
 
-function DI.value_and_pullback(
-    f::F, backend::AutoReverseDiff, x::Number, dy, extras::Nothing
-) where {F}
+function DI.value_and_pullback(f, backend::AutoReverseDiff, x::Number, dy, extras::Nothing)
     x_array = [x]
     y, dx_array = DI.value_and_pullback(f ∘ only, backend, x_array, dy)
     return y, only(dx_array)
+end
+
+## Gradient
+
+function DI.prepare_gradient(f, backend::AutoReverseDiff, x::AbstractArray)
+    tape = GradientTape(f, x)
+    if backend.compile
+        tape = compile(tape)
+    end
+    return tape
+end
+
+function DI.value_and_gradient!!(
+    _f,
+    grad::AbstractArray,
+    ::AutoReverseDiff,
+    x::AbstractArray,
+    tape::Union{GradientTape,CompiledGradient},
+)
+    result = DiffResult(zero(eltype(x)), grad)
+    result = gradient!(result, tape, x)
+    return DiffResults.value(result), DiffResults.derivative(result)
+end
+
+function DI.value_and_gradient(
+    f,
+    backend::AutoReverseDiff,
+    x::AbstractArray,
+    tape::Union{GradientTape,CompiledGradient},
+)
+    grad = similar(x)
+    return DI.value_and_gradient!!(f, grad, backend, x, tape)
+end
+
+function DI.gradient!!(
+    _f,
+    grad::AbstractArray,
+    ::AutoReverseDiff,
+    x::AbstractArray,
+    tape::Union{GradientTape,CompiledGradient},
+)
+    return gradient!(grad, tape, x)
+end
+
+function DI.gradient(
+    _f, ::AutoReverseDiff, x::AbstractArray, tape::Union{GradientTape,CompiledGradient}
+)
+    return gradient!(tape, x)
+end
+
+## Jacobian
+
+function DI.prepare_jacobian(f, backend::AutoReverseDiff, x::AbstractArray)
+    tape = JacobianTape(f, x)
+    if backend.compile
+        tape = compile(tape)
+    end
+    return tape
+end
+
+function DI.value_and_jacobian!!(
+    f,
+    jac::AbstractMatrix,
+    ::AutoReverseDiff,
+    x::AbstractArray,
+    tape::Union{JacobianTape,CompiledJacobian},
+)
+    y = f(x)
+    result = DiffResult(y, jac)
+    result = jacobian!(result, tape, x)
+    return DiffResults.value(result), DiffResults.derivative(result)
+end
+
+function DI.value_and_jacobian(
+    f, ::AutoReverseDiff, x::AbstractArray, tape::Union{JacobianTape,CompiledJacobian}
+)
+    return f(x), jacobian!(tape, x)
+end
+
+function DI.jacobian!!(
+    _f,
+    jac::AbstractMatrix,
+    ::AutoReverseDiff,
+    x::AbstractArray,
+    tape::Union{JacobianTape,CompiledJacobian},
+)
+    return jacobian!(jac, tape, x)
+end
+
+function DI.jacobian(
+    f, ::AutoReverseDiff, x::AbstractArray, tape::Union{JacobianTape,CompiledJacobian}
+)
+    return jacobian!(tape, x)
 end

--- a/ext/DifferentiationInterfaceReverseDiffExt/mutating.jl
+++ b/ext/DifferentiationInterfaceReverseDiffExt/mutating.jl
@@ -1,14 +1,14 @@
 ## Pullback
 
 function DI.value_and_pullback!!(
-    f!::F,
+    f!,
     y::AbstractArray,
     dx::AbstractArray,
     ::AutoReverseDiff,
     x::AbstractArray,
     dy::AbstractArray,
     extras::Nothing,
-) where {F}
+)
     jac = jacobian(f!, y, x)
     mul!(vec(dx), transpose(jac), vec(dy))
     return y, dx
@@ -17,17 +17,42 @@ end
 ### Trick for unsupported scalar input
 
 function DI.value_and_pullback!!(
-    f!::F,
+    f!,
     y::AbstractArray,
-    dx::Number,
+    _dx::Number,
     backend::AutoReverseDiff,
     x::Number,
     dy::AbstractArray,
     extras::Nothing,
-) where {F}
+)
     x_array = [x]
     dx_array = similar(x_array)
     f!_only(_y::AbstractArray, _x_array) = f!(_y, only(_x_array))
     y, dx_array = DI.value_and_pullback!!(f!_only, y, dx_array, backend, x_array, dy)
     return y, only(dx_array)
+end
+
+## Jacobian
+
+function DI.prepare_jacobian(
+    f!, backend::AutoReverseDiff, y::AbstractArray, x::AbstractArray
+)
+    tape = JacobianTape(f!, y, x)
+    if backend.compile
+        tape = compile(tape)
+    end
+    return tape
+end
+
+function DI.value_and_jacobian!!(
+    _f!,
+    y::AbstractArray,
+    jac::AbstractMatrix,
+    ::AutoReverseDiff,
+    x::AbstractArray,
+    tape::Union{JacobianTape,CompiledJacobian},
+)
+    result = DiffResults.DiffResult(y, jac)
+    result = jacobian!(result, tape, x)
+    return DiffResults.value(result), DiffResults.derivative(result)
 end

--- a/ext/DifferentiationInterfaceTapedExt/DifferentiationInterfaceTapedExt.jl
+++ b/ext/DifferentiationInterfaceTapedExt/DifferentiationInterfaceTapedExt.jl
@@ -7,7 +7,7 @@ using Taped: build_rrule, value_and_pullback!!
 
 DI.supports_mutation(::AutoTaped) = DI.MutationNotSupported()
 
-function DI.value_and_pullback(f::F, ::AutoTaped, x, dy, extras::Nothing) where {F}
+function DI.value_and_pullback(f, ::AutoTaped, x, dy, extras::Nothing)
     rrule = build_rrule(f, x)
     y = f(x)
     dy_righttype = convert(typeof(y), dy)

--- a/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -8,37 +8,33 @@ DI.supports_mutation(::AutoTracker) = DI.MutationNotSupported()
 
 ## Pullback
 
-function DI.value_and_pullback(f::F, ::AutoTracker, x, dy, extras::Nothing) where {F}
+function DI.value_and_pullback(f, ::AutoTracker, x, dy, extras::Nothing)
     y, back = forward(f, x)
     return y, data(only(back(dy)))
 end
 
 ## Gradient
 
-function DI.gradient(f::F, ::AutoTracker, x, extras::Nothing) where {F}
+function DI.gradient(f, ::AutoTracker, x, extras::Nothing)
     grad = gradient(f, x)
     return data(only(grad))
 end
 
-function DI.value_and_gradient(f::F, ::AutoTracker, x, extras::Nothing) where {F}
+function DI.value_and_gradient(f, ::AutoTracker, x, extras::Nothing)
     (; val, grad) = withgradient(f, x)
     return val, data(only(grad))
 end
 
-function DI.value_and_gradient(
-    f::F, backend::AutoTracker, x::Number, extras::Nothing
-) where {F}
+function DI.value_and_gradient(f, backend::AutoTracker, x::Number, extras::Nothing)
     # fix for https://github.com/FluxML/Tracker.jl/issues/165
     return f(x), DI.gradient(f, backend, x, extras)
 end
 
-function DI.value_and_gradient!!(
-    f::F, grad, backend::AutoTracker, x, extras::Nothing
-) where {F}
+function DI.value_and_gradient!!(f, grad, backend::AutoTracker, x, extras::Nothing)
     return DI.value_and_gradient(f, backend, x, extras)
 end
 
-function DI.gradient!!(f::F, grad, backend::AutoTracker, x, extras::Nothing) where {F}
+function DI.gradient!!(f, grad, backend::AutoTracker, x, extras::Nothing)
     return DI.gradient(f, backend, x, extras)
 end
 

--- a/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -9,7 +9,7 @@ DI.supports_mutation(::AutoZygote) = DI.MutationNotSupported()
 
 ## Pullback
 
-function DI.value_and_pullback(f::F, ::AutoZygote, x, dy, extras::Nothing) where {F}
+function DI.value_and_pullback(f, ::AutoZygote, x, dy, extras::Nothing)
     y, back = pullback(f, x)
     dx = only(back(dy))
     return y, dx
@@ -17,13 +17,23 @@ end
 
 ## Gradient
 
-function DI.value_and_gradient(f::F, ::AutoZygote, x, extras::Nothing) where {F}
+function DI.value_and_gradient(f, ::AutoZygote, x, extras::Nothing)
     (; val, grad) = withgradient(f, x)
     return val, only(grad)
 end
 
-function DI.gradient(f::F, ::AutoZygote, x, extras::Nothing) where {F}
+function DI.gradient(f, ::AutoZygote, x, extras::Nothing)
     return only(gradient(f, x))
+end
+
+## Jacobian
+
+function DI.value_and_jacobian(f, ::AutoZygote, x::AbstractArray, extras::Nothing)
+    return f(x), only(jacobian(f, x))
+end
+
+function DI.jacobian(f, ::AutoZygote, x::AbstractArray, extras::Nothing)
+    return only(jacobian(f, x))
 end
 
 end

--- a/src/DifferentiationTest/test_call_count.jl
+++ b/src/DifferentiationTest/test_call_count.jl
@@ -5,12 +5,12 @@ end
 
 CallCounter(f::F) where {F} = CallCounter{F}(f, Ref(0))
 
-function (cc::CallCounter{F})(x) where {F}
+function (cc::CallCounter)(x)
     cc.count[] += 1
     return cc.f(x)
 end
 
-function (cc::CallCounter{F})(y, x) where {F}
+function (cc::CallCounter)(y, x)
     cc.count[] += 1
     return cc.f(y, x)
 end

--- a/src/DifferentiationTest/test_differentiation.jl
+++ b/src/DifferentiationTest/test_differentiation.jl
@@ -150,27 +150,27 @@ function test_differentiation(
                     compatible(backend, op, scen)
                 end
                     if correctness
-                        @testset verbose = true "Correctness" begin
+                        @testset "Correctness" begin
                             correctness_ext.test_correctness(backend, op, scen)
                         end
                     end
                     if error_free
-                        @testset verbose = true "Error-free" begin
+                        @testset "Error-free" begin
                             test_error_free(backend, op, scen)
                         end
                     end
                     if call_count
-                        @testset verbose = true "Call count" begin
+                        @testset "Call count" begin
                             test_call_count(backend, op, scen)
                         end
                     end
                     if type_stability
-                        @testset verbose = true "Type stability" begin
+                        @testset "Type stability" begin
                             jet_ext.test_jet(backend, op, scen)
                         end
                     end
                     if benchmark || allocations
-                        @testset verbose = true "Allocations" begin
+                        @testset "Allocations" begin
                             chairmarks_ext.run_benchmark!(
                                 benchmark_data, backend, op, scen; allocations=allocations
                             )

--- a/src/DifferentiationTest/zero.jl
+++ b/src/DifferentiationTest/zero.jl
@@ -20,41 +20,37 @@ DI.supports_mutation(::AutoZeroReverse) = DI.MutationSupported()
 
 ## Primitives
 
-function DI.value_and_pushforward!!(f::F, dy, ::AutoZeroForward, x, dx, ::Nothing) where {F}
+function DI.value_and_pushforward!!(f, dy, ::AutoZeroForward, x, dx, ::Nothing)
     y = f(x)
     dy = myzero!!(dy)
     return y, dy
 end
 
-function DI.value_and_pushforward!!(
-    f!::F, y, dy, ::AutoZeroForward, x, dx, ::Nothing
-) where {F}
+function DI.value_and_pushforward!!(f!, y, dy, ::AutoZeroForward, x, dx, ::Nothing)
     f!(y, x)
     dy = myzero!!(dy)
     return y, dy
 end
 
-function DI.value_and_pushforward(f::F, ::AutoZeroForward, x, dx, ::Nothing) where {F}
+function DI.value_and_pushforward(f, ::AutoZeroForward, x, dx, ::Nothing)
     y = f(x)
     dy = myzero(y)
     return y, dy
 end
 
-function DI.value_and_pullback!!(f::F, dx, ::AutoZeroReverse, x, dy, ::Nothing) where {F}
+function DI.value_and_pullback!!(f, dx, ::AutoZeroReverse, x, dy, ::Nothing)
     y = f(x)
     dx = myzero!!(dx)
     return y, dx
 end
 
-function DI.value_and_pullback!!(
-    f!::F, y, dx, ::AutoZeroReverse, x, dy, ::Nothing
-) where {F}
+function DI.value_and_pullback!!(f!, y, dx, ::AutoZeroReverse, x, dy, ::Nothing)
     f!(y, x)
     dx = myzero!!(dx)
     return y, dx
 end
 
-function DI.value_and_pullback(f::F, ::AutoZeroReverse, x, dy, ::Nothing) where {F}
+function DI.value_and_pullback(f, ::AutoZeroReverse, x, dy, ::Nothing)
     y = f(x)
     dx = myzero(x)
     return y, dx

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -4,20 +4,16 @@
     value_and_derivative(f, backend, x, [extras]) -> (y, der)
 """
 function value_and_derivative(
-    f::F, backend::AbstractADType, x::Number, extras=prepare_derivative(f, backend, x)
-) where {F}
+    f, backend::AbstractADType, x::Number, extras=prepare_derivative(f, backend, x)
+)
     return value_and_derivative_aux(f, backend, x, extras, supports_pushforward(backend))
 end
 
-function value_and_derivative_aux(
-    f::F, backend, x, extras, ::PushforwardSupported
-) where {F}
+function value_and_derivative_aux(f, backend, x, extras, ::PushforwardSupported)
     return value_and_pushforward(f, backend, x, one(x), extras)
 end
 
-function value_and_derivative_aux(
-    f::F, backend, x, extras, ::PushforwardNotSupported
-) where {F}
+function value_and_derivative_aux(f, backend, x, extras, ::PushforwardNotSupported)
     y = f(x)
     if y isa Number
         return value_and_pullback(f, backend, x, one(y))
@@ -34,28 +30,26 @@ end
     value_and_derivative!!(f, der, backend, x, [extras]) -> (y, der)
 """
 function value_and_derivative!!(
-    f::F, der, backend::AbstractADType, x::Number, extras=prepare_derivative(f, backend, x)
-) where {F}
+    f, der, backend::AbstractADType, x::Number, extras=prepare_derivative(f, backend, x)
+)
     return value_and_derivative_aux!!(
         f, der, backend, x, extras, supports_pushforward(backend)
     )
 end
 
-function value_and_derivative_aux!!(
-    f::F, der, backend, x, extras, ::PushforwardSupported
-) where {F}
+function value_and_derivative_aux!!(f, der, backend, x, extras, ::PushforwardSupported)
     return value_and_pushforward!!(f, der, backend, x, one(x), extras)
 end
 
 function value_and_derivative_aux!!(
-    f::F, _der::Number, backend, x, extras, ::PushforwardNotSupported
-) where {F}
+    f, _der::Number, backend, x, extras, ::PushforwardNotSupported
+)
     return value_and_pullback(f, backend, x, one(x), extras)
 end
 
 function value_and_derivative_aux!!(
-    f::F, der::AbstractArray, backend, x, extras, ::PushforwardNotSupported
-) where {F}
+    f, der::AbstractArray, backend, x, extras, ::PushforwardNotSupported
+)
     y = f(x)
     map!(der, CartesianIndices(y)) do i
         dy_i = basisarray(backend, y, i)
@@ -68,8 +62,8 @@ end
     derivative(f, backend, x, [extras]) -> der
 """
 function derivative(
-    f::F, backend::AbstractADType, x::Number, extras=prepare_derivative(f, backend, x)
-) where {F}
+    f, backend::AbstractADType, x::Number, extras=prepare_derivative(f, backend, x)
+)
     return last(value_and_derivative(f, backend, x, extras))
 end
 
@@ -77,8 +71,8 @@ end
     derivative!!(f, der, backend, x, [extras]) -> der
 """
 function derivative!!(
-    f::F, der, backend::AbstractADType, x::Number, extras=prepare_derivative(f, backend, x)
-) where {F}
+    f, der, backend::AbstractADType, x::Number, extras=prepare_derivative(f, backend, x)
+)
     return last(value_and_derivative!!(f, der, backend, x, extras))
 end
 
@@ -88,33 +82,25 @@ end
     value_and_derivative!!(f!, y, der, backend, x, [extras]) -> (y, der)
 """
 function value_and_derivative!!(
-    f!::F,
+    f!,
     y,
     der,
     backend::AbstractADType,
     x::Number,
     extras=prepare_derivative(f!, backend, y, x),
-) where {F}
+)
     return value_and_derivative_aux!!(
         f!, y, der, backend, x, extras, supports_pushforward(backend)
     )
 end
 
-function value_and_derivative_aux!!(
-    f!::F, y, der, backend, x, extras, ::PushforwardSupported
-) where {F}
+function value_and_derivative_aux!!(f!, y, der, backend, x, extras, ::PushforwardSupported)
     return value_and_pushforward!!(f!, y, der, backend, x, one(x), extras)
 end
 
 function value_and_derivative_aux!!(
-    f!::F,
-    y::AbstractArray,
-    der::AbstractArray,
-    backend,
-    x,
-    extras,
-    ::PushforwardNotSupported,
-) where {F}
+    f!, y::AbstractArray, der::AbstractArray, backend, x, extras, ::PushforwardNotSupported
+)
     f!(y, x)
     map!(der, CartesianIndices(y)) do i
         dy_i = basisarray(backend, y, i)

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -4,24 +4,22 @@
     value_and_gradient(f, backend, x, [extras]) -> (y, grad)
 """
 function value_and_gradient(
-    f::F, backend::AbstractADType, x, extras=prepare_gradient(f, backend, x)
-) where {F}
+    f, backend::AbstractADType, x, extras=prepare_gradient(f, backend, x)
+)
     return value_and_gradient_aux(f, backend, x, extras, supports_pullback(backend))
 end
 
-function value_and_gradient_aux(f::F, backend, x, extras, ::PullbackSupported) where {F}
+function value_and_gradient_aux(f, backend, x, extras, ::PullbackSupported)
     return value_and_pullback(f, backend, x, true, extras)
 end
 
-function value_and_gradient_aux(
-    f::F, backend, x::Number, extras, ::PullbackNotSupported
-) where {F}
+function value_and_gradient_aux(f, backend, x::Number, extras, ::PullbackNotSupported)
     return value_and_pushforward(f, backend, x, one(x), extras)
 end
 
 function value_and_gradient_aux(
-    f::F, backend, x::AbstractArray, extras, ::PullbackNotSupported
-) where {F}
+    f, backend, x::AbstractArray, extras, ::PullbackNotSupported
+)
     y = f(x)
     grad = map(CartesianIndices(x)) do j
         dx_j = basisarray(backend, x, j)
@@ -34,26 +32,24 @@ end
     value_and_gradient!!(f, grad, backend, x, [extras]) -> (y, grad)
 """
 function value_and_gradient!!(
-    f::F, grad, backend::AbstractADType, x, extras=prepare_gradient(f, backend, x)
-) where {F}
+    f, grad, backend::AbstractADType, x, extras=prepare_gradient(f, backend, x)
+)
     return value_and_gradient_aux!!(f, grad, backend, x, extras, supports_pullback(backend))
 end
 
-function value_and_gradient_aux!!(
-    f::F, grad, backend, x, extras, ::PullbackSupported
-) where {F}
+function value_and_gradient_aux!!(f, grad, backend, x, extras, ::PullbackSupported)
     return value_and_pullback!!(f, grad, backend, x, true, extras)
 end
 
 function value_and_gradient_aux!!(
-    f::F, grad, backend, x::Number, extras, ::PullbackNotSupported
-) where {F}
+    f, grad, backend, x::Number, extras, ::PullbackNotSupported
+)
     return value_and_pushforward(f, backend, x, one(x), extras)
 end
 
 function value_and_gradient_aux!!(
-    f::F, grad, backend, x::AbstractArray, extras, ::PullbackNotSupported
-) where {F}
+    f, grad, backend, x::AbstractArray, extras, ::PullbackNotSupported
+)
     y = f(x)
     map!(grad, CartesianIndices(x)) do j
         dx_j = basisarray(backend, x, j)
@@ -65,9 +61,7 @@ end
 """
     gradient(f, backend, x, [extras]) -> grad
 """
-function gradient(
-    f::F, backend::AbstractADType, x, extras=prepare_gradient(f, backend, x)
-) where {F}
+function gradient(f, backend::AbstractADType, x, extras=prepare_gradient(f, backend, x))
     return last(value_and_gradient(f, backend, x, extras))
 end
 
@@ -75,7 +69,7 @@ end
     gradient!!(f, grad, backend, x, [extras]) -> grad
 """
 function gradient!!(
-    f::F, grad, backend::AbstractADType, x, extras=prepare_gradient(f, backend, x)
-) where {F}
+    f, grad, backend::AbstractADType, x, extras=prepare_gradient(f, backend, x)
+)
     return last(value_and_gradient!!(f, grad, backend, x, extras))
 end

--- a/src/hessian.jl
+++ b/src/hessian.jl
@@ -3,17 +3,13 @@
 """
     hessian(f, backend, x, [extras]) -> hess
 """
-function hessian(
-    f::F, backend::AbstractADType, x, extras=prepare_hessian(f, backend, x)
-) where {F}
+function hessian(f, backend::AbstractADType, x, extras=prepare_hessian(f, backend, x))
     new_backend = SecondOrder(backend, backend)
     new_extras = prepare_hessian(f, new_backend, x)
     return hessian(f, new_backend, x, new_extras)
 end
 
-function hessian(
-    f::F, backend::SecondOrder, x, extras=prepare_hessian(f, backend, x)
-) where {F}
+function hessian(f, backend::SecondOrder, x, extras=prepare_hessian(f, backend, x))
     # suboptimal for reverse-over-forward
     gradient_closure(z) = gradient(f, inner(backend), z, inner(extras))
     hess = jacobian(gradient_closure, outer(backend), x, outer(extras))

--- a/src/hvp.jl
+++ b/src/hvp.jl
@@ -13,46 +13,44 @@ By order of preference:
 """
     hvp(f, backend, x, v, [extras]) -> p
 """
-function hvp(
-    f::F, backend::AbstractADType, x, v, extras=prepare_hvp(f, backend, x)
-) where {F}
+function hvp(f, backend::AbstractADType, x, v, extras=prepare_hvp(f, backend, x))
     new_backend = SecondOrder(backend, backend)
     new_extras = prepare_hvp(f, new_backend, x)
     return hvp(f, new_backend, x, v, new_extras)
 end
 
 function hvp(
-    f::F, backend::SecondOrder, x::Number, v::Number, extras=prepare_hvp(f, backend, x)
-) where {F}
+    f, backend::SecondOrder, x::Number, v::Number, extras=prepare_hvp(f, backend, x)
+)
     return v * second_derivative(f, backend, x, extras)
 end
 
-function hvp(f::F, backend::SecondOrder, x, v, extras=prepare_hvp(f, backend, x)) where {F}
+function hvp(f, backend::SecondOrder, x, v, extras=prepare_hvp(f, backend, x))
     return hvp_aux(f, backend, x, v, extras, hvp_mode(backend))
 end
 
-function hvp_aux(f::F, backend, x, v, extras, ::ForwardOverReverse) where {F}
+function hvp_aux(f, backend, x, v, extras, orwardOverReverse)
     # JVP of the gradient
     gradient_closure(z) = gradient(f, inner(backend), z, inner(extras))
     p = pushforward(gradient_closure, outer(backend), x, v, outer(extras))
     return p
 end
 
-function hvp_aux(f::F, backend, x, v, extras, ::ReverseOverForward) where {F}
+function hvp_aux(f, backend, x, v, extras, ::ReverseOverForward)
     # gradient of the JVP
     jvp_closure(z) = pushforward(f, inner(backend), z, v, inner(extras))
     p = gradient(jvp_closure, outer(backend), x, outer(extras))
     return p
 end
 
-function hvp_aux(f::F, backend, x, v, extras, ::ReverseOverReverse) where {F}
+function hvp_aux(f, backend, x, v, extras, ::ReverseOverReverse)
     # VJP of the gradient
     gradient_closure(z) = gradient(f, inner(backend), z, inner(extras))
     p = pullback(gradient_closure, outer(backend), x, v, outer(extras))
     return p
 end
 
-function hvp_aux(f::F, backend, x, v, extras, ::ForwardOverForward) where {F}
+function hvp_aux(f, backend, x, v, extras, ::ForwardOverForward)
     # JVPs of JVPs in theory
     # also pushforward of gradient in practice
     gradient_closure(z) = gradient(f, inner(backend), z, inner(extras))

--- a/src/jacobian.jl
+++ b/src/jacobian.jl
@@ -4,14 +4,14 @@
     value_and_jacobian(f, backend, x, [extras]) -> (y, jac)
 """
 function value_and_jacobian(
-    f::F, backend::AbstractADType, x, extras=prepare_jacobian(f, backend, x)
-) where {F}
+    f, backend::AbstractADType, x, extras=prepare_jacobian(f, backend, x)
+)
     return value_and_jacobian_aux(f, backend, x, extras, supports_pushforward(backend))
 end
 
 function value_and_jacobian_aux(
-    f::F, backend, x::AbstractArray, extras, ::PushforwardSupported
-) where {F}
+    f, backend, x::AbstractArray, extras, ::PushforwardSupported
+)
     y = f(x)
     jac = stack(CartesianIndices(x); dims=2) do j
         dx_j = basisarray(backend, x, j)
@@ -22,8 +22,8 @@ function value_and_jacobian_aux(
 end
 
 function value_and_jacobian_aux(
-    f::F, backend, x::AbstractArray, extras, ::PushforwardNotSupported
-) where {F}
+    f, backend, x::AbstractArray, extras, ::PushforwardNotSupported
+)
     y = f(x)
     jac = stack(CartesianIndices(y); dims=1) do i
         dy_i = basisarray(backend, y, i)
@@ -37,20 +37,20 @@ end
     value_and_jacobian!!(f, jac, backend, x, [extras]) -> (y, jac)
 """
 function value_and_jacobian!!(
-    f::F,
+    f,
     jac::AbstractMatrix,
     backend::AbstractADType,
     x,
     extras=prepare_jacobian(f, backend, x),
-) where {F}
+)
     return value_and_jacobian_aux!!(
         f, jac, backend, x, extras, supports_pushforward(backend)
     )
 end
 
 function value_and_jacobian_aux!!(
-    f::F, jac, backend, x::AbstractArray, extras, ::PushforwardSupported
-) where {F}
+    f, jac, backend, x::AbstractArray, extras, ::PushforwardSupported
+)
     y = f(x)
     for (k, j) in enumerate(CartesianIndices(x))
         dx_j = basisarray(backend, x, j)
@@ -63,8 +63,8 @@ function value_and_jacobian_aux!!(
 end
 
 function value_and_jacobian_aux!!(
-    f::F, jac, backend, x::AbstractArray, extras, ::PushforwardNotSupported
-) where {F}
+    f, jac, backend, x::AbstractArray, extras, ::PushforwardNotSupported
+)
     y = f(x)
     for (k, i) in enumerate(CartesianIndices(y))
         dy_i = basisarray(backend, y, i)
@@ -79,9 +79,7 @@ end
 """
     jacobian(f, backend, x, [extras]) -> jac
 """
-function jacobian(
-    f::F, backend::AbstractADType, x, extras=prepare_jacobian(f, backend, x)
-) where {F}
+function jacobian(f, backend::AbstractADType, x, extras=prepare_jacobian(f, backend, x))
     return last(value_and_jacobian(f, backend, x, extras))
 end
 
@@ -89,12 +87,12 @@ end
     jacobian!!(f, jac, backend, x, [extras]) -> jac
 """
 function jacobian!!(
-    f::F,
+    f,
     jac::AbstractMatrix,
     backend::AbstractADType,
     x,
     extras=prepare_jacobian(f, backend, x),
-) where {F}
+)
     return last(value_and_jacobian!!(f, jac, backend, x, extras))
 end
 
@@ -104,21 +102,19 @@ end
     value_and_jacobian!!(f!, y, jac, backend, x, [extras]) -> (y, jac)
 """
 function value_and_jacobian!!(
-    f!::F,
+    f!,
     y::AbstractArray,
     jac::AbstractMatrix,
     backend::AbstractADType,
     x::AbstractArray,
     extras=prepare_jacobian(f!, backend, y, x),
-) where {F}
+)
     return value_and_jacobian_aux!!(
         f!, y, jac, backend, x, extras, supports_pushforward(backend)
     )
 end
 
-function value_and_jacobian_aux!!(
-    f!::F, y, jac, backend, x, extras, ::PushforwardSupported
-) where {F}
+function value_and_jacobian_aux!!(f!, y, jac, backend, x, extras, ::PushforwardSupported)
     f!(y, x)
     for (k, j) in enumerate(CartesianIndices(x))
         dx_j = basisarray(backend, x, j)
@@ -132,9 +128,7 @@ function value_and_jacobian_aux!!(
     return y, jac
 end
 
-function value_and_jacobian_aux!!(
-    f!::F, y, jac, backend, x, extras, ::PushforwardNotSupported
-) where {F}
+function value_and_jacobian_aux!!(f!, y, jac, backend, x, extras, ::PushforwardNotSupported)
     f!(y, x)
     for (k, i) in enumerate(CartesianIndices(y))
         dy_i = basisarray(backend, y, i)

--- a/src/pullback.jl
+++ b/src/pullback.jl
@@ -6,7 +6,7 @@
 !!! info
     Required primitive for reverse mode backends to support allocating functions.
 """
-function value_and_pullback(f::F, backend::AbstractADType, x, dy) where {F}
+function value_and_pullback(f, backend::AbstractADType, x, dy)
     extras = prepare_pullback(f, backend, x)
     return value_and_pullback(f, backend, x, dy, extras)
 end
@@ -15,17 +15,15 @@ end
     value_and_pullback!!(f, dx, backend, x, dy, [extras]) -> (y, dx)
 """
 function value_and_pullback!!(
-    f::F, dx, backend::AbstractADType, x, dy, extras=prepare_pullback(f, backend, x)
-) where {F}
+    f, dx, backend::AbstractADType, x, dy, extras=prepare_pullback(f, backend, x)
+)
     return value_and_pullback(f, backend, x, dy, extras)
 end
 
 """
     pullback(f, backend, x, dy, [extras]) -> dx
 """
-function pullback(
-    f::F, backend::AbstractADType, x, dy, extras=prepare_pullback(f, backend, x)
-) where {F}
+function pullback(f, backend::AbstractADType, x, dy, extras=prepare_pullback(f, backend, x))
     return last(value_and_pullback(f, backend, x, dy, extras))
 end
 
@@ -33,8 +31,8 @@ end
     pullback!!(f, dx, backend, x, dy, [extras]) -> dx
 """
 function pullback!!(
-    f::F, dx, backend::AbstractADType, x, dy, extras=prepare_pullback(f, backend, x)
-) where {F}
+    f, dx, backend::AbstractADType, x, dy, extras=prepare_pullback(f, backend, x)
+)
     return last(value_and_pullback!!(f, dx, backend, x, dy, extras))
 end
 
@@ -46,7 +44,7 @@ end
 !!! info
     Required primitive for reverse mode backends to support mutating functions.
 """
-function value_and_pullback!!(f!::F, y, dx, backend::AbstractADType, x, dy) where {F}
+function value_and_pullback!!(f!, y, dx, backend::AbstractADType, x, dy)
     extras = prepare_pullback(f!, backend, y, x)
     return value_and_pullback!!(f!, y, dx, backend, x, dy, extras)
 end

--- a/src/pushforward.jl
+++ b/src/pushforward.jl
@@ -6,7 +6,7 @@
 !!! info
     Required primitive for forward mode backends to support allocating functions.
 """
-function value_and_pushforward(f::F, backend::AbstractADType, x, dx) where {F}
+function value_and_pushforward(f, backend::AbstractADType, x, dx)
     extras = prepare_pushforward(f, backend, x)
     return value_and_pushforward(f, backend, x, dx, extras)
 end
@@ -15,8 +15,8 @@ end
     value_and_pushforward!!(f, dy, backend, x, dx, [extras]) -> (y, dy)
 """
 function value_and_pushforward!!(
-    f::F, dy, backend::AbstractADType, x, dx, extras=prepare_pushforward(f, backend, x)
-) where {F}
+    f, dy, backend::AbstractADType, x, dx, extras=prepare_pushforward(f, backend, x)
+)
     return value_and_pushforward(f, backend, x, dx, extras)
 end
 
@@ -24,8 +24,8 @@ end
     pushforward(f, backend, x, dx, [extras]) -> (y, dy)
 """
 function pushforward(
-    f::F, backend::AbstractADType, x, dx, extras=prepare_pushforward(f, backend, x)
-) where {F}
+    f, backend::AbstractADType, x, dx, extras=prepare_pushforward(f, backend, x)
+)
     return last(value_and_pushforward(f, backend, x, dx, extras))
 end
 
@@ -33,8 +33,8 @@ end
     pushforward!!(f, dy, backend, x, dx, [extras]) -> (y, dy)
 """
 function pushforward!!(
-    f::F, dy, backend::AbstractADType, x, dx, extras=prepare_pushforward(f, backend, x)
-) where {F}
+    f, dy, backend::AbstractADType, x, dx, extras=prepare_pushforward(f, backend, x)
+)
     return last(value_and_pushforward!!(f, dy, backend, x, dx, extras))
 end
 
@@ -46,7 +46,7 @@ end
 !!! info
     Required primitive for forward mode backends to support mutating functions.
 """
-function value_and_pushforward!!(f!::F, y, dy, backend::AbstractADType, x, dx) where {F}
+function value_and_pushforward!!(f!, y, dy, backend::AbstractADType, x, dx)
     extras = prepare_pushforward(f!, backend, y, x)
     return value_and_pushforward!!(f!, y, dy, backend, x, dx, extras)
 end

--- a/src/second_derivative.jl
+++ b/src/second_derivative.jl
@@ -4,19 +4,16 @@
     second_derivative(f, backend, x, [extras]) -> der2
 """
 function second_derivative(
-    f::F,
-    backend::AbstractADType,
-    x::Number,
-    extras=prepare_second_derivative(f, backend, x),
-) where {F}
+    f, backend::AbstractADType, x::Number, extras=prepare_second_derivative(f, backend, x)
+)
     new_backend = SecondOrder(backend, backend)
     new_extras = prepare_second_derivative(f, new_backend, x)
     return second_derivative(f, new_backend, x, new_extras)
 end
 
 function second_derivative(
-    f::F, backend::SecondOrder, x::Number, extras=prepare_second_derivative(f, backend, x)
-) where {F}
+    f, backend::SecondOrder, x::Number, extras=prepare_second_derivative(f, backend, x)
+)
     derivative_closure(z) = derivative(f, inner(backend), z, inner(extras))
     der2 = derivative(derivative_closure, outer(backend), x, outer(extras))
     return der2

--- a/test/forwarddiff.jl
+++ b/test/forwarddiff.jl
@@ -11,5 +11,6 @@ test_differentiation(AutoForwardDiff(; chunksize=2); type_stability=true);
 test_differentiation(
     AutoForwardDiff(; chunksize=2),
     all_operators(),
-    weird_array_scenarios(; static=true, component=true, gpu=false),
+    weird_array_scenarios(; static=true, component=true, gpu=false);
+    excluded=[jacobian],
 );

--- a/test/nested.jl
+++ b/test/nested.jl
@@ -1,7 +1,5 @@
 include("test_imports.jl")
 
-using Enzyme: Enzyme
-using Tracker: Tracker
 using Zygote: Zygote
 
 test_differentiation([AutoZygote()], [gradient], nested_scenarios(););

--- a/test/tracker.jl
+++ b/test/tracker.jl
@@ -4,7 +4,7 @@ using Tracker: Tracker
 
 @test check_available(AutoTracker())
 @test !check_mutation(AutoTracker())
-# @test !check_hessian(AutoTracker())
+@test !check_hessian(AutoTracker())
 
 test_differentiation(
     AutoTracker(); output_type=Union{Number,AbstractVector}, second_order=false


### PR DESCRIPTION
**Core**

- Remove all `f::F` and `where {F}` forcing specialization, since the allocation tests now pass without that for zero backends [shrug]

**Extensions**

- Add preparation for ForwardDiff, ReverseDiff and PolyesterForwardDiff
- Add jacobian for Zygote
- Remove `f` specialization there too