### PR TITLE
Progress on nested scenarios for Flux

### DIFF
--- a/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -3,6 +3,7 @@ module DifferentiationInterfaceForwardDiffExt
 using ADTypes: AbstractADType, AutoForwardDiff
 import DifferentiationInterface as DI
 using DiffResults: DiffResults, DiffResult, GradientResult
+using Functors: fmap, fleaves
 using ForwardDiff:
     Chunk,
     Dual,

--- a/ext/DifferentiationInterfaceForwardDiffExt/allocating.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/allocating.jl
@@ -4,8 +4,8 @@ function DI.value_and_pushforward(f, ::AutoForwardDiff, x, dx, extras::Nothing)
     T = tag_type(f, x)
     xdual = make_dual(T, x, dx)
     ydual = f(xdual)
-    y = my_value(T, ydual)
-    new_dy = my_derivative(T, ydual)
+    y = myvalue(T, ydual)
+    new_dy = myderivative(T, ydual)
     return y, new_dy
 end
 

--- a/ext/DifferentiationInterfaceForwardDiffExt/mutating.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/mutating.jl
@@ -3,8 +3,8 @@ function DI.value_and_pushforward!!(f!, y, dy, ::AutoForwardDiff, x, dx, extras:
     xdual = make_dual(T, x, dx)
     ydual = make_dual(T, y, dy)
     f!(ydual, xdual)
-    y = my_value!!(T, y, ydual)
-    dy = my_derivative!!(T, dy, ydual)
+    y = myvalue!!(T, y, ydual)
+    dy = myderivative!!(T, dy, ydual)
     return y, dy
 end
 

--- a/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -4,22 +4,32 @@ choose_chunk(::AutoForwardDiff{C}, x) where {C} = Chunk{C}()
 
 tag_type(::F, x::Number) where {F} = Tag{F,typeof(x)}
 tag_type(::F, x::AbstractArray) where {F} = Tag{F,eltype(x)}
+tag_type(::F, x) where {F} = Tag{F,typeof(x)}
 
 make_dual(::Type{T}, x::Number, dx::Number) where {T} = Dual{T}(x, dx)
-make_dual(::Type{T}, x, dx) where {T} = Dual{T}.(x, dx)
+make_dual(::Type{T}, x::AbstractArray, dx) where {T} = Dual{T}.(x, dx)
+make_dual(::Type{T}, x, dx) where {T} = fmap(Dual{T}, x, dx)
 
-my_value(::Type{T}, ydual::Number) where {T} = value(T, ydual)
-my_value(::Type{T}, ydual) where {T} = value.(T, ydual)
+myvalue(::Type{T}, ydual::Number) where {T} = value(T, ydual)
+myvalue(::Type{T}, ydual::AbstractArray) where {T} = value.(T, ydual)
+myvalue(::Type{T}, ydual) where {T} = fmap(Base.Fix1(myvalue, T), ydual)
 
-my_value!!(::Type{T}, y::Number, ydual::Number) where {T} = value(T, ydual)
-my_value!!(::Type{T}, y, ydual) where {T} = y .= value.(T, ydual)
+myvalue!!(::Type{T}, y::Number, ydual::Number) where {T} = value(T, ydual)
+myvalue!!(::Type{T}, y::AbstractArray, ydual) where {T} = y .= value.(T, ydual)
+myvalue!!(::Type{T}, y, ydual) where {T} = fmap(Base.Fix1(myvalue, T), y, ydual)
 
-my_derivative(::Type{T}, ydual) where {T} = extract_derivative(T, ydual)
+myderivative(::Type{T}, ydual::Number) where {T} = extract_derivative(T, ydual)
+myderivative(::Type{T}, ydual::AbstractArray) where {T} = extract_derivative(T, ydual)
+myderivative(::Type{T}, ydual) where {T} = fmap(Base.Fix1(myvalue, T), ydual)
 
-function my_derivative!!(::Type{T}, dy::Number, ydual::Number) where {T}
+function myderivative!!(::Type{T}, dy::Number, ydual::Number) where {T}
     return extract_derivative(T, ydual)
 end
 
-function my_derivative!!(::Type{T}, dy, ydual) where {T}
+function myderivative!!(::Type{T}, dy::AbstractArray, ydual::AbstractArray) where {T}
     return extract_derivative!(T, dy, ydual)
+end
+
+function myderivative!!(::Type{T}, dy, ydual) where {T}
+    return fmap(Base.Fix1(myderivative!!, T), dy, ydual)
 end

--- a/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -20,7 +20,7 @@ myvalue!!(::Type{T}, y, ydual) where {T} = fmap(Base.Fix1(myvalue, T), y, ydual)
 
 myderivative(::Type{T}, ydual::Number) where {T} = extract_derivative(T, ydual)
 myderivative(::Type{T}, ydual::AbstractArray) where {T} = extract_derivative(T, ydual)
-myderivative(::Type{T}, ydual) where {T} = fmap(Base.Fix1(myvalue, T), ydual)
+myderivative(::Type{T}, ydual) where {T} = fmap(Base.Fix1(myderivative, T), ydual)
 
 function myderivative!!(::Type{T}, dy::Number, ydual::Number) where {T}
     return extract_derivative(T, ydual)

--- a/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -15,19 +15,24 @@ end
 
 ## Gradient
 
-function DI.gradient(f, ::AutoTracker, x, extras::Nothing)
-    grad = gradient(f, x)
-    return data(only(grad))
-end
-
 function DI.value_and_gradient(f, ::AutoTracker, x, extras::Nothing)
     (; val, grad) = withgradient(f, x)
     return val, data(only(grad))
 end
 
-function DI.value_and_gradient(f, backend::AutoTracker, x::Number, extras::Nothing)
+function DI.gradient(f, ::AutoTracker, x, extras::Nothing)
+    (; grad) = withgradient(f, x)
+    return data(only(grad))
+end
+
+function DI.value_and_gradient(f, ::AutoTracker, x::Number, extras::Nothing)
     # fix for https://github.com/FluxML/Tracker.jl/issues/165
-    return f(x), DI.gradient(f, backend, x, extras)
+    return f(x), data(only(gradient(f, x)))
+end
+
+function DI.gradient(f, ::AutoTracker, x::Number, extras::Nothing)
+    # fix for https://github.com/FluxML/Tracker.jl/issues/165
+    return data(only(gradient(f, x)))
 end
 
 function DI.value_and_gradient!!(f, grad, backend::AutoTracker, x, extras::Nothing)

--- a/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -26,6 +26,14 @@ function DI.gradient(f, ::AutoZygote, x, extras::Nothing)
     return only(gradient(f, x))
 end
 
+function DI.value_and_gradient!!(f, grad, backend::AutoZygote, x, extras::Nothing)
+    return DI.value_and_gradient(f, backend, x, extras)
+end
+
+function DI.gradient!!(f, grad, backend::AutoZygote, x, extras::Nothing)
+    return DI.gradient(f, backend, x, extras)
+end
+
 ## Jacobian
 
 function DI.value_and_jacobian(f, ::AutoZygote, x::AbstractArray, extras::Nothing)

--- a/src/DifferentiationInterface.jl
+++ b/src/DifferentiationInterface.jl
@@ -18,9 +18,9 @@ using ADTypes:
     AbstractSymbolicDifferentiationMode
 using DocStringExtensions
 using FillArrays: OneElement
-using Functors: fmap
+using Functors: fleaves, fmap
 using LinearAlgebra: dot
-using Test: Test
+using Test: Test, @test
 
 """
     AutoFastDifferentiation

--- a/src/DifferentiationTest/DifferentiationTest.jl
+++ b/src/DifferentiationTest/DifferentiationTest.jl
@@ -28,7 +28,8 @@ using ..DifferentiationInterface:
     supports_pushforward,
     supports_pullback
 using DocStringExtensions
-using Functors: fmap
+using Functors: @functor, fleaves, fmap
+using LinearAlgebra: dot
 using Test: @testset, @test
 
 include("scenario.jl")

--- a/src/DifferentiationTest/scenarios_nested.jl
+++ b/src/DifferentiationTest/scenarios_nested.jl
@@ -1,7 +1,50 @@
-nested_norm(x::Number) = abs2(x)
-nested_norm(x) = sum(nested_norm, x)
+@kwdef struct Layer{W,B,A}
+    w::W
+    b::B
+    σ::A = nothing
+end
 
-function nested_scenarios()
-    scenarios = [Scenario(nested_norm; x=([1.0, 2.0], [3.0, 4.0, 5.0]))]
-    return scenarios
+@functor Layer
+
+(l::Layer{<:Number,<:Number,<:Nothing})(x::Number) = l.w * x + l.b
+(l::Layer{<:Number,<:Number})(x::Number) = l.σ(l.w * x + l.b)
+
+(l::Layer{<:AbstractMatrix,<:AbstractVector,<:Nothing})(x::AbstractVector) = l.w * x + l.b
+(l::Layer{<:AbstractMatrix,<:AbstractVector})(x::AbstractVector) = l.σ.(l.w * x + l.b)
+
+call_layer(l::Layer{<:Number,<:Number}) = l(3.0)
+call_layer(l::Layer{<:AbstractMatrix,<:AbstractVector}) = l(3 * ones(size(l.w, 2)))
+
+sum_call_layer(l) = sum(call_layer(l))
+
+nested_norm(x::Number) = abs2(x)
+nested_norm(x::AbstractArray) = sum(abs2, x)
+nested_norm(x) = sum(nested_norm, fleaves(x))
+
+function make_complicated(x::Number)
+    return (a=[2x, 3x], b=([exp(x);;],))
+end
+
+function make_complicated_with_immutables(x::Number)
+    return (a=[2x, 3x], b=([exp(x);;],), c=sin(x))
+end
+
+function nested_scenarios(; immutables=true)
+    scenarios_without_immutables = [
+        Scenario(make_complicated, 2.0),
+        Scenario(nested_norm; x=make_complicated(2.0)),
+        Scenario(sum_call_layer; x=Layer(; w=rand(2, 3), b=rand(2))),
+        Scenario(sum_call_layer; x=Layer(; w=rand(2, 3), b=rand(2), σ=tanh)),
+    ]
+    scenarios_with_immutables = [
+        Scenario(make_complicated_with_immutables, 2.0),
+        Scenario(nested_norm; x=make_complicated_with_immutables(2.0)),
+        Scenario(call_layer; x=Layer(; w=2.0, b=4.0)),
+        Scenario(call_layer; x=Layer(; w=2.0, b=4.0, σ=tanh)),
+    ]
+    if immutables
+        return vcat(scenarios_with_immutables, scenarios_without_immutables)
+    else
+        return scenarios_without_immutables
+    end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,7 +43,7 @@ myvec(x) = mapreduce(myvec, vcat, fleaves(x))
 
 myzero(x::Number) = zero(x)
 myzero(x::AbstractArray) = zero(x)
-myzero(x::Nothing) = zero(x)
+myzero(x::Nothing) = nothing
 myzero(x) = fmap(myzero, x)
 
 myzero!!(x::Number) = zero(x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,9 +1,22 @@
 myisapprox(x::Number, y::Number; kwargs...) = isapprox(x, y; kwargs...)
 myisapprox(x::AbstractArray, y::AbstractArray; kwargs...) = isapprox(x, y; kwargs...)
-myisapprox(x, y; kwargs...) = all(myisapprox(xi, yi; kwargs...) for (xi, yi) in zip(x, y))
+myisapprox(x::Function, y::Function; kwargs...) = x === y
+myisapprox(x::Nothing, y::Nothing; kwargs...) = true
+myisapprox(x::Nothing, y; kwargs...) = false
+myisapprox(x, y::Nothing; kwargs...) = false
+
+function myisapprox(x, y; kwargs...)
+    for (xi, yi) in zip(fleaves(x), fleaves(y))
+        if !myisapprox(xi, yi; kwargs...)
+            return false
+        end
+    end
+    return true
+end
 
 mymul!!(x::Number, a) = x * a
 mymul!!(x::AbstractArray, a) = x .*= a
+mymul!!(x::Nothing, a) = nothing
 mymul!!(x, a) = fmap(Base.Fix2(mymul!!, a), x)
 
 myupdate!!(_old::Number, new::Number) = new
@@ -13,21 +26,29 @@ myupdate!!(old, new) = fmap(myupdate!!, old, new)
 
 mysimilar(x::Number) = zero(x)
 mysimilar(x::AbstractArray) = similar(x)
+mysimilar(x::Nothing) = nothing
+mysimilar(x::Function) = x
 mysimilar(x) = fmap(mysimilar, x)
 
 mysimilar_random(x::Number) = randn(typeof(x))
 mysimilar_random(x::AbstractArray) = map(mysimilar_random, similar(x))
+mysimilar_random(x::Nothing) = nothing
+mysimilar_random(x::Function) = x
 mysimilar_random(x) = fmap(mysimilar_random, x)
 
 myvec(x::Number) = [x]
 myvec(x::AbstractArray) = vec(x)
+myvec(x::Nothing) = []
+myvec(x) = mapreduce(myvec, vcat, fleaves(x))
 
 myzero(x::Number) = zero(x)
 myzero(x::AbstractArray) = zero(x)
-myzero(x) = fmap(zero, x)
+myzero(x::Nothing) = zero(x)
+myzero(x) = fmap(myzero, x)
 
 myzero!!(x::Number) = zero(x)
 myzero!!(x::AbstractArray) = x .= zero(eltype(x))
+myzero!!(x::Nothing) = nothing
 myzero!!(x) = fmap(myzero!!, x)
 
 """

--- a/test/nested.jl
+++ b/test/nested.jl
@@ -1,5 +1,20 @@
 include("test_imports.jl")
 
+using ForwardDiff: ForwardDiff
+using Tracker: Tracker
 using Zygote: Zygote
 
-test_differentiation([AutoZygote()], [gradient], nested_scenarios(););
+test_differentiation(AutoZygote(), [gradient], nested_scenarios(); detailed=true);
+
+test_differentiation(
+    AutoTracker(), [gradient], nested_scenarios(; immutables=false); detailed=true
+);
+
+test_differentiation(
+    AutoForwardDiff(),
+    [derivative],
+    nested_scenarios();
+    detailed=true,
+    correctness=false,
+    error_free=true,
+);


### PR DESCRIPTION
**Core**

- Improve all the `my...` functions with Functors

**Tests**

- Add more complicated nested scenarios, test them on Zygote and Tracker

**Extensions**

- ForwardDiff: use Functors on dual-specific functions to be more generic
- Tracker: use `withgradient` by default (more modern), with a fallback for number inputs