### PR TITLE
Prepation for outer backend of SecondOrder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ We support most of the backends defined by [ADTypes.jl](https://github.com/SciML
 | [Tracker.jl](https://github.com/FluxML/Tracker.jl)                              | `AutoTracker()`                                            |
 | [Zygote.jl](https://github.com/FluxML/Zygote.jl)                                | `AutoZygote()`                                             |
 
-We also support additional (experimental) backends:
+We also provide some experimental backends ourselves:
 
-| backend                                                                          | object                      |
-| :------------------------------------------------------------------------------- | :-------------------------- |
-| [FastDifferentiation.jl](https://github.com/brianguenter/FastDifferentiation.jl) | `AutoFastDifferentiation()` |
-| [Tapir.jl](https://github.com/withbayes/Tapir.jl)                                | `AutoTapir()`               |
+| backend                                                                          | object                                                         |
+| :------------------------------------------------------------------------------- | :------------------------------------------------------------- |
+| [FastDifferentiation.jl](https://github.com/brianguenter/FastDifferentiation.jl) | `AutoFastDifferentiation()`, `AutoSparseFastDifferentiation()` |
+| [Tapir.jl](https://github.com/withbayes/Tapir.jl)                                | `AutoTapir()`                                                  |
 
 ## Example
 

--- a/docs/src/overview.md
+++ b/docs/src/overview.md
@@ -101,8 +101,7 @@ By default, all the preparation functions return `nothing`.
 We do not make any guarantees on their implementation for each backend, or on the performance gains that can be expected.
 
 !!! warning
-    We haven't yet figured out how to deal with extras for second-order operators, because closures make our life rather complicated.
-    For now, consider that preparation doesn't work there in general, although some individual backends may be okay already.
+    For `SecondOrder` backends, the inner differentiation cannot be prepared at the moment, only the outer one is.
 
 ## FAQ
 
@@ -118,7 +117,6 @@ The sparsity pattern is computed automatically with [Symbolics.jl](https://githu
 
 If you need to work with sparse Hessians, you can use a sparse backend as the _outer_ backend of a `SecondOrder`.
 This means the Hessian is obtained as the sparse Jacobian of the gradient.
-Since preparation does not yet work for second order, the sparsity pattern is currently recomputed every time, so you may not gain much time as things stand.
 
 !!! danger
     Sparsity support is still experimental, use at your own risk.

--- a/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -15,8 +15,9 @@ DI.supports_mutation(::AutoChainRules) = DI.MutationNotSupported()
 DI.mode(::AutoForwardChainRules) = ADTypes.AbstractForwardMode
 DI.mode(::AutoReverseChainRules) = ADTypes.AbstractReverseMode
 
-## Pushforward
+## Pushforward (unused)
 
+#=
 DI.prepare_pushforward(f, ::AutoForwardChainRules, x) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(
@@ -26,6 +27,7 @@ function DI.value_and_pushforward(
     y, new_dy = frule_via_ad(rc, (NoTangent(), dx), f, x)
     return y, new_dy
 end
+=#
 
 ## Pullback
 

--- a/ext/DifferentiationInterfaceEnzymeExt/reverse_allocating.jl
+++ b/ext/DifferentiationInterfaceEnzymeExt/reverse_allocating.jl
@@ -68,3 +68,15 @@ function DI.gradient!!(f, grad, ::AutoReverseEnzyme, x::AbstractArray, ::NoGradi
     gradient!(Reverse, grad_sametype, f, x)
     return grad_sametype
 end
+
+function DI.value_and_gradient(
+    f, backend::AutoReverseEnzyme, x::AbstractArray, ::NoGradientExtras
+)
+    return DI.value_and_pullback(f, backend, x, one(eltype(x)), NoPullbackExtras())
+end
+
+function DI.value_and_gradient!!(
+    f, grad, backend::AutoReverseEnzyme, x::AbstractArray, ::NoGradientExtras
+)
+    return DI.value_and_pullback!!(f, grad, backend, x, one(eltype(x)), NoPullbackExtras())
+end

--- a/ext/DifferentiationInterfaceFastDifferentiationExt/allocating.jl
+++ b/ext/DifferentiationInterfaceFastDifferentiationExt/allocating.jl
@@ -122,6 +122,25 @@ function DI.value_and_derivative!!(
     return DI.value_and_derivative(f, backend, x, extras)
 end
 
+function DI.derivative(
+    f,
+    backend::AnyAutoFastDifferentiation,
+    x,
+    extras::FastDifferentiationAllocatingDerivativeExtras,
+)
+    return DI.value_and_derivative(f, backend, x, extras)[2]
+end
+
+function DI.derivative!!(
+    f,
+    der,
+    backend::AnyAutoFastDifferentiation,
+    x,
+    extras::FastDifferentiationAllocatingDerivativeExtras,
+)
+    return DI.derivative(f, backend, x, extras)
+end
+
 ## Jacobian
 
 struct FastDifferentiationAllocatingJacobianExtras{E} <: JacobianExtras
@@ -226,7 +245,7 @@ struct FastDifferentiationHVPExtras{E} <: HVPExtras
     hvp_exe::E
 end
 
-function DI.prepare_hvp(f, ::AnyAutoFastDifferentiation, x)
+function DI.prepare_hvp(f, ::AnyAutoFastDifferentiation, x, v)
     x_var = if x isa Number
         only(make_variables(:x))
     else

--- a/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -3,7 +3,12 @@ module DifferentiationInterfaceForwardDiffExt
 using ADTypes: AbstractADType, AutoForwardDiff, AutoSparseForwardDiff
 import DifferentiationInterface as DI
 using DifferentiationInterface:
-    DerivativeExtras, GradientExtras, HessianExtras, JacobianExtras, NoPushforwardExtras
+    DerivativeExtras,
+    GradientExtras,
+    HessianExtras,
+    JacobianExtras,
+    NoDerivativeExtras,
+    NoPushforwardExtras
 using ForwardDiff.DiffResults: DiffResults, DiffResult, GradientResult
 using ForwardDiff:
     Chunk,

--- a/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
+++ b/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
@@ -11,7 +11,9 @@ using DifferentiationInterface:
     GradientExtras,
     HessianExtras,
     JacobianExtras,
+    NoDerivativeExtras,
     NoGradientExtras,
+    NoHessianExtras,
     NoJacobianExtras,
     PushforwardExtras
 using DocStringExtensions

--- a/ext/DifferentiationInterfacePolyesterForwardDiffExt/allocating.jl
+++ b/ext/DifferentiationInterfacePolyesterForwardDiffExt/allocating.jl
@@ -59,38 +59,44 @@ end
 
 ## Gradient
 
-DI.prepare_gradient(f, ::AnyAutoPolyForwardDiff, x) = NoGradientExtras()
+function DI.prepare_gradient(f, backend::AnyAutoPolyForwardDiff, x)
+    return DI.prepare_gradient(f, single_threaded(backend), x)
+end
 
 function DI.value_and_gradient!!(
-    f,
-    grad::AbstractVector,
-    ::AnyAutoPolyForwardDiff{C},
-    x::AbstractVector,
-    ::NoGradientExtras,
+    f, grad, ::AnyAutoPolyForwardDiff{C}, x::AbstractVector, ::GradientExtras
 ) where {C}
     threaded_gradient!(f, grad, x, Chunk{C}())
     return f(x), grad
 end
 
 function DI.gradient!!(
-    f,
-    grad::AbstractVector,
-    ::AnyAutoPolyForwardDiff{C},
-    x::AbstractVector,
-    ::NoGradientExtras,
+    f, grad, ::AnyAutoPolyForwardDiff{C}, x::AbstractVector, ::GradientExtras
 ) where {C}
     threaded_gradient!(f, grad, x, Chunk{C}())
     return grad
 end
 
+function DI.value_and_gradient!!(
+    f, grad, backend::AnyAutoPolyForwardDiff{C}, x::AbstractArray, extras::GradientExtras
+) where {C}
+    return DI.value_and_gradient!!(f, grad, single_threaded(backend), x, extras)
+end
+
+function DI.gradient!!(
+    f, grad, backend::AnyAutoPolyForwardDiff{C}, x::AbstractArray, extras::GradientExtras
+) where {C}
+    return DI.gradient!!(f, grad, single_threaded(backend), x, extras)
+end
+
 function DI.value_and_gradient(
-    f, backend::AnyAutoPolyForwardDiff, x::AbstractVector, extras::NoGradientExtras
+    f, backend::AnyAutoPolyForwardDiff, x::AbstractArray, extras::GradientExtras
 )
     return DI.value_and_gradient!!(f, similar(x), backend, x, extras)
 end
 
 function DI.gradient(
-    f, backend::AnyAutoPolyForwardDiff, x::AbstractVector, extras::NoGradientExtras
+    f, backend::AnyAutoPolyForwardDiff, x::AbstractArray, extras::GradientExtras
 )
     return DI.gradient!!(f, similar(x), backend, x, extras)
 end

--- a/ext/DifferentiationInterfaceSparseDiffToolsExt/DifferentiationInterfaceSparseDiffToolsExt.jl
+++ b/ext/DifferentiationInterfaceSparseDiffToolsExt/DifferentiationInterfaceSparseDiffToolsExt.jl
@@ -2,7 +2,8 @@ module DifferentiationInterfaceSparseDiffToolsExt
 
 using ADTypes
 import DifferentiationInterface as DI
-using DifferentiationInterface: JacobianExtras, NoHessianExtras, SecondOrder, inner, outer
+using DifferentiationInterface:
+    HessianExtras, JacobianExtras, NoHessianExtras, SecondOrder, inner, outer
 using SparseDiffTools:
     AutoSparseEnzyme,
     JacPrototypeSparsityDetection,

--- a/lib/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/lib/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -208,7 +208,7 @@ function run_benchmark!(
     data::Vector{BenchmarkDataRow}, ba::AbstractADType, scen::HVPScenario{false}
 )
     (; f, x, y, dx) = deepcopy(scen)
-    extras = prepare_hvp(f, ba, x)
+    extras = prepare_hvp(f, ba, x, dx)
     bench1 = @be mysimilar(x) hvp!!(f, _, ba, x, dx, extras)
     record!(data, ba, hvp, scen, bench1)
     return nothing

--- a/lib/DifferentiationInterfaceTest/src/tests/call_count.jl
+++ b/lib/DifferentiationInterfaceTest/src/tests/call_count.jl
@@ -141,7 +141,7 @@ end
 
 function test_call_count(ba::AbstractADType, scen::HVPScenario{false})
     (; f, x, y, dx) = deepcopy(scen)
-    extras = prepare_hvp(CallCounter(f), ba, x)
+    extras = prepare_hvp(CallCounter(f), ba, x, dx)
     cc = CallCounter(f)
     p_in = mysimilar(x)
     hvp!!(cc, p_in, ba, x, dx, extras)

--- a/lib/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/lib/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -387,7 +387,7 @@ function test_correctness(
     ref_backend,
 )
     (; f, x, dx) = new_scen = deepcopy(scen)
-    extras = prepare_hvp(f, ba, x)
+    extras = prepare_hvp(f, ba, x, dx)
     hvp_true = if ref_backend isa AbstractADType
         hvp(f, ref_backend, x, dx)
     else

--- a/lib/DifferentiationInterfaceTest/src/tests/sparsity.jl
+++ b/lib/DifferentiationInterfaceTest/src/tests/sparsity.jl
@@ -22,10 +22,10 @@ function test_sparsity(ba::AbstractADType, scen::JacobianScenario{false}; ref_ba
         @test jac4 isa SparseMatrixCSC
     end
     @testset "Sparsity pattern" begin
-        @test nnz(jac1) < length(jac_true)
-        @test nnz(jac2) < length(jac_true)
-        @test nnz(jac3) < length(jac_true)
-        @test nnz(jac4) < length(jac_true)
+        @test nnz(jac1) == nnz(jac_true)
+        @test nnz(jac2) == nnz(jac_true)
+        @test nnz(jac3) == nnz(jac_true)
+        @test nnz(jac4) == nnz(jac_true)
     end
     return nothing
 end
@@ -48,7 +48,7 @@ function test_sparsity(ba::AbstractADType, scen::JacobianScenario{true}; ref_bac
         @test jac1 isa SparseMatrixCSC
     end
     @testset "Sparsity pattern" begin
-        @test nnz(jac1) < length(jac_true)
+        @test nnz(jac1) == nnz(jac_true)
     end
     return nothing
 end
@@ -72,8 +72,8 @@ function test_sparsity(ba::AbstractADType, scen::HessianScenario{false}; ref_bac
         @test hess2 isa SparseMatrixCSC
     end
     @testset "Sparsity pattern" begin
-        @test nnz(hess1) < length(hess_true)
-        @test nnz(hess2) < length(hess_true)
+        @test nnz(hess1) == nnz(hess_true)
+        @test nnz(hess2) == nnz(hess_true)
     end
     return nothing
 end

--- a/lib/DifferentiationInterfaceTest/src/tests/type_stability.jl
+++ b/lib/DifferentiationInterfaceTest/src/tests/type_stability.jl
@@ -126,7 +126,7 @@ end
 
 function test_jet(ba::AbstractADType, scen::HVPScenario{false};)
     (; f, x, dx) = deepcopy(scen)
-    extras = prepare_hvp(f, ba, x)
+    extras = prepare_hvp(f, ba, x, dx)
     p_in = mysimilar(x)
 
     @test_opt hvp!!(f, p_in, ba, x, dx, extras)

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -1,14 +1,14 @@
 """
     check_available(backend)
 
-Check whether `backend` is available by trying a scalar-to-scalar derivative.
+Check whether `backend` is available by trying a gradient.
 
 !!! warning
     Might take a while due to compilation time.
 """
 function check_available(backend::AbstractADType)
     try
-        value_and_gradient(abs2, backend, 2.0)
+        value_and_gradient(sum, backend, [1.0])
         return true
     catch exception
         @warn "Backend $backend not available" exception

--- a/src/gradient.jl
+++ b/src/gradient.jl
@@ -14,22 +14,12 @@ struct PullbackGradientExtras{E<:PullbackExtras} <: GradientExtras
 end
 
 """
-    prepare_gradient([other_extras], f, backend, x) -> extras
+    prepare_gradient(f, backend, x) -> extras
 
 Create an `extras` object subtyping [`GradientExtras`](@ref) that can be given to gradient operators.
 """
-function prepare_gradient(::Extras, f_or_f!, backend::AbstractADType, args...)
-    return prepare_gradient(f_or_f!, backend, args...)
-end
-
 function prepare_gradient(f, backend::AbstractADType, x)
     return PullbackGradientExtras(prepare_pullback(f, backend, x))
-end
-
-function prepare_pullback(
-    extras::PullbackGradientExtras, f_or_f!, backend::AbstractADType, args...
-)
-    return extras.pullback_extras
 end
 
 ## Allocating
@@ -40,8 +30,7 @@ end
 function value_and_gradient(
     f, backend::AbstractADType, x, extras::GradientExtras=prepare_gradient(f, backend, x)
 )
-    new_extras = prepare_pullback(extras, f, backend, x)
-    return value_and_pullback(f, backend, x, one(eltype(x)), new_extras)
+    return value_and_pullback(f, backend, x, one(eltype(x)), extras.pullback_extras)
 end
 
 """
@@ -54,8 +43,7 @@ function value_and_gradient!!(
     x,
     extras::GradientExtras=prepare_gradient(f, backend, x),
 )
-    new_extras = prepare_pullback(extras, f, backend, x)
-    return value_and_pullback!!(f, grad, backend, x, one(eltype(x)), new_extras)
+    return value_and_pullback!!(f, grad, backend, x, one(eltype(x)), extras.pullback_extras)
 end
 
 """
@@ -64,7 +52,7 @@ end
 function gradient(
     f, backend::AbstractADType, x, extras::GradientExtras=prepare_gradient(f, backend, x)
 )
-    return value_and_gradient(f, backend, x, extras)[2]
+    return pullback(f, backend, x, one(eltype(x)), extras.pullback_extras)
 end
 
 """
@@ -77,5 +65,5 @@ function gradient!!(
     x,
     extras::GradientExtras=prepare_gradient(f, backend, x),
 )
-    return value_and_gradient!!(f, grad, backend, x, extras)[2]
+    return pullback!!(f, grad, backend, x, one(eltype(x)), extras.pullback_extras)
 end

--- a/src/hvp.jl
+++ b/src/hvp.jl
@@ -19,98 +19,167 @@ abstract type HVPExtras <: Extras end
 
 struct NoHVPExtras <: HVPExtras end
 
-"""
-    prepare_hvp([other_extras], f, backend, x) -> extras
-
-Create an `extras` object subtyping [`HVPExtras`](@ref) that can be given to Hessian-vector product operators.
-"""
-function prepare_hvp(::Extras, f_or_f!, backend::AbstractADType, args...)
-    return prepare_hvp(f_or_f!, backend, args...)
+struct ForwardOverForwardHVPExtras{C,E} <: HVPExtras
+    inner_gradient_closure::C
+    outer_pushforward_extras::E
 end
 
-prepare_hvp(f, ::AbstractADType, x) = NoHVPExtras()
+struct ForwardOverReverseHVPExtras{C,E} <: HVPExtras
+    inner_gradient_closure::C
+    outer_pushforward_extras::E
+end
+
+struct ReverseOverForwardHVPExtras{C,E} <: HVPExtras
+    inner_pushforward_closure_generator::C
+    outer_gradient_extras::E
+end
+
+struct ReverseOverReverseHVPExtras{C,E} <: HVPExtras
+    inner_gradient_closure::C
+    outer_pullback_extras::E
+end
+
+"""
+    prepare_hvp(f, backend, x, v) -> extras
+
+Create an `extras` object subtyping [`HVPExtras`](@ref) that can be given to Hessian-vector product operators.
+
+!!! warning
+    Unlike the others, this preparation operator takes an additional argument `v`.
+"""
+prepare_hvp(f, ::AbstractADType, x, v) = NoHVPExtras()
+
+function prepare_hvp(f, backend::SecondOrder, x, v)
+    return prepare_hvp_aux(f, backend, x, v, hvp_mode(backend))
+end
+
+function prepare_hvp_aux(f, backend::SecondOrder, x, v, ::ForwardOverForward)
+    # pushforward of many pushforwards in theory, but pushforward of gradient in practice
+    inner_gradient_closure(z) = gradient(f, inner(backend), z)
+    outer_pushforward_extras = prepare_pushforward(
+        inner_gradient_closure, outer(backend), x
+    )
+    return ForwardOverForwardHVPExtras(inner_gradient_closure, outer_pushforward_extras)
+end
+
+function prepare_hvp_aux(f, backend::SecondOrder, x, v, ::ForwardOverReverse)
+    # pushforward of gradient
+    inner_gradient_closure(z) = gradient(f, inner(backend), z)
+    outer_pushforward_extras = prepare_pushforward(
+        inner_gradient_closure, outer(backend), x
+    )
+    return ForwardOverReverseHVPExtras(inner_gradient_closure, outer_pushforward_extras)
+end
+
+function prepare_hvp_aux(f, backend::SecondOrder, x, v, ::ReverseOverForward)
+    # gradient of pushforward
+    # uses v in the closure
+    inner_pushforward_closure_generator(v) = z -> pushforward(f, inner(backend), z, v)
+    outer_gradient_extras = prepare_gradient(
+        inner_pushforward_closure_generator(v), outer(backend), x
+    )
+    return ReverseOverForwardHVPExtras(
+        inner_pushforward_closure_generator, outer_gradient_extras
+    )
+end
+
+function prepare_hvp_aux(f, backend::SecondOrder, x, v, ::ReverseOverReverse)
+    # pullback of the gradient
+    inner_gradient_closure(z) = gradient(f, inner(backend), z)
+    outer_pullback_extras = prepare_pullback(inner_gradient_closure, outer(backend), x)
+    return ReverseOverReverseHVPExtras(inner_gradient_closure, outer_pullback_extras)
+end
 
 ## Allocating
 
 """
     hvp(f, backend, x, v, [extras]) -> p
 """
-function hvp(f, backend::AbstractADType, x, v, extras::HVPExtras=prepare_hvp(f, backend, x))
+function hvp(
+    f, backend::AbstractADType, x, v, extras::HVPExtras=prepare_hvp(f, backend, x, v)
+)
     new_backend = SecondOrder(backend)
-    new_extras = prepare_hvp(f, new_backend, x)
+    new_extras = prepare_hvp(f, new_backend, x, v)
     return hvp(f, new_backend, x, v, new_extras)
 end
 
-function hvp(f, backend::SecondOrder, x, v, extras::HVPExtras=prepare_hvp(f, backend, x))
-    return hvp_aux(f, backend, x, v, extras, hvp_mode(backend))
+function hvp(f, backend::SecondOrder, x, v, extras::HVPExtras=prepare_hvp(f, backend, x, v))
+    return hvp_aux(f, backend, x, v, extras)
 end
 
-function hvp_aux(f, backend, x, v, extras, ::ForwardOverReverse)
-    # JVP of the gradient
-    gradient_closure(z) = gradient(f, inner(backend), z)
-    p = pushforward(gradient_closure, outer(backend), x, v)
-    return p
+function hvp_aux(f, backend, x, v, extras::ForwardOverForwardHVPExtras)
+    return pushforward(
+        extras.inner_gradient_closure, outer(backend), x, v, extras.outer_pushforward_extras
+    )
 end
 
-function hvp_aux(f, backend, x, v, extras, ::ReverseOverForward)
-    # gradient of the JVP
-    pushforward_closure(z) = pushforward(f, inner(backend), z, v)
-    p = gradient(pushforward_closure, outer(backend), x)
-    return p
+function hvp_aux(f, backend, x, v, extras::ForwardOverReverseHVPExtras)
+    return pushforward(
+        extras.inner_gradient_closure, outer(backend), x, v, extras.outer_pushforward_extras
+    )
 end
 
-function hvp_aux(f, backend, x, v, extras, ::ReverseOverReverse)
-    # VJP of the gradient
-    gradient_closure(z) = gradient(f, inner(backend), z)
-    p = pullback(gradient_closure, outer(backend), x, v)
-    return p
+function hvp_aux(f, backend, x, v, extras::ReverseOverForwardHVPExtras)
+    inner_pushforward_closure = extras.inner_pushforward_closure_generator(v)
+    return gradient(
+        inner_pushforward_closure, outer(backend), x, extras.outer_gradient_extras
+    )
 end
 
-function hvp_aux(f, backend, x, v, extras, ::ForwardOverForward)
-    # JVPs of JVPs in theory
-    # also pushforward of gradient in practice
-    gradient_closure(z) = gradient(f, inner(backend), z)
-    p = pushforward(gradient_closure, outer(backend), x, v)
-    return p
+function hvp_aux(f, backend, x, v, extras::ReverseOverReverseHVPExtras)
+    return pullback(
+        extras.inner_gradient_closure, outer(backend), x, v, extras.outer_pullback_extras
+    )
 end
 
 """
     hvp!!(f, p, backend, x, v, [extras]) -> p
 """
 function hvp!!(
-    f, p, backend::AbstractADType, x, v, extras::HVPExtras=prepare_hvp(f, backend, x)
+    f, p, backend::AbstractADType, x, v, extras::HVPExtras=prepare_hvp(f, backend, x, v)
 )
     new_backend = SecondOrder(backend)
-    new_extras = prepare_hvp(f, new_backend, x)
+    new_extras = prepare_hvp(f, new_backend, x, v)
     return hvp!!(f, p, new_backend, x, v, new_extras)
 end
 
 function hvp!!(
-    f, p, backend::SecondOrder, x, v, extras::HVPExtras=prepare_hvp(f, backend, x)
+    f, p, backend::SecondOrder, x, v, extras::HVPExtras=prepare_hvp(f, backend, x, v)
 )
-    return hvp_aux!!(f, p, backend, x, v, extras, hvp_mode(backend))
+    return hvp_aux!!(f, p, backend, x, v, extras)
 end
 
-function hvp_aux!!(f, p, backend, x, v, extras, ::ForwardOverReverse)
-    gradient_closure(z) = gradient(f, inner(backend), z)
-    p = pushforward!!(gradient_closure, p, outer(backend), x, v)
-    return p
+function hvp_aux!!(f, p, backend, x, v, extras::ForwardOverForwardHVPExtras)
+    return pushforward!!(
+        extras.inner_gradient_closure,
+        p,
+        outer(backend),
+        x,
+        v,
+        extras.outer_pushforward_extras,
+    )
 end
 
-function hvp_aux!!(f, p, backend, x, v, extras, ::ReverseOverForward)
-    pushforward_closure(z) = pushforward(f, inner(backend), z, v)
-    p = gradient!!(pushforward_closure, p, outer(backend), x)
-    return p
+function hvp_aux!!(f, p, backend, x, v, extras::ForwardOverReverseHVPExtras)
+    return pushforward!!(
+        extras.inner_gradient_closure,
+        p,
+        outer(backend),
+        x,
+        v,
+        extras.outer_pushforward_extras,
+    )
 end
 
-function hvp_aux!!(f, p, backend, x, v, extras, ::ReverseOverReverse)
-    gradient_closure(z) = gradient(f, inner(backend), z)
-    p = pullback!!(gradient_closure, p, outer(backend), x, v)
-    return p
+function hvp_aux!!(f, p, backend, x, v, extras::ReverseOverForwardHVPExtras)
+    inner_pushforward_closure = extras.inner_pushforward_closure_generator(v)
+    return gradient!!(
+        inner_pushforward_closure, p, outer(backend), x, extras.outer_gradient_extras
+    )
 end
 
-function hvp_aux!!(f, p, backend, x, v, extras, ::ForwardOverForward)
-    gradient_closure(z) = gradient(f, inner(backend), z)
-    p = pushforward!!(gradient_closure, p, outer(backend), x, v)
-    return p
+function hvp_aux!!(f, p, backend, x, v, extras::ReverseOverReverseHVPExtras)
+    return pullback!!(
+        extras.inner_gradient_closure, p, outer(backend), x, v, extras.outer_pullback_extras
+    )
 end

--- a/src/pullback.jl
+++ b/src/pullback.jl
@@ -10,15 +10,11 @@ abstract type PullbackExtras <: Extras end
 struct NoPullbackExtras <: PullbackExtras end
 
 """
-    prepare_pullback([other_extras], f, backend, x) -> extras
-    prepare_pullback([other_extras], f!, backend, y, x) -> extras
+    prepare_pullback(f, backend, x) -> extras
+    prepare_pullback(f!, backend, y, x) -> extras
 
 Create an `extras` object subtyping [`PullbackExtras`](@ref) that can be given to pullback operators.
 """
-function prepare_pullback(::Extras, f_or_f!, backend::AbstractADType, args...)
-    return prepare_pullback(f_or_f!, backend, args...)
-end
-
 prepare_pullback(f, ::AbstractADType, x) = NoPullbackExtras()
 prepare_pullback(f!, ::AbstractADType, y, x) = NoPullbackExtras()
 
@@ -37,7 +33,7 @@ function value_and_pullback(
     dy,
     extras::PullbackExtras=prepare_pullback(f, backend, x),
 )
-    new_extras = prepare_pushforward(extras, f, backend, x)
+    new_extras = prepare_pushforward(f, backend, x)
     y = f(x)
     dx = if x isa Number && y isa Number
         dy * pushforward(f, backend, x, one(x), new_extras)
@@ -113,7 +109,7 @@ function value_and_pullback!!(
     dy,
     extras::PullbackExtras=prepare_pullback(f!, backend, y, x),
 )
-    new_extras = prepare_pushforward(extras, f!, backend, y, x)
+    new_extras = prepare_pushforward(f!, backend, y, x)
     dx = if x isa Number && y isa AbstractArray
         dot(dy, value_and_pushforward!!(f!, y, similar(y), backend, x, one(x), new_extras)[2])
     elseif x isa AbstractArray && y isa AbstractArray

--- a/src/pushforward.jl
+++ b/src/pushforward.jl
@@ -10,15 +10,11 @@ abstract type PushforwardExtras <: Extras end
 struct NoPushforwardExtras <: PushforwardExtras end
 
 """
-    prepare_pushforward([other_extras], f, backend, x) -> extras
-    prepare_pushforward([other_extras], f!, backend, y, x) -> extras
+    prepare_pushforward(f, backend, x) -> extras
+    prepare_pushforward(f!, backend, y, x) -> extras
 
 Create an `extras` object subtyping [`PushforwardExtras`](@ref) that can be given to pushforward operators.
 """
-function prepare_pushforward(::Extras, f_or_f!, backend::AbstractADType, args...)
-    return prepare_pushforward(f_or_f!, backend, args...)
-end
-
 prepare_pushforward(f, ::AbstractADType, x) = NoPushforwardExtras()
 prepare_pushforward(f!, ::AbstractADType, y, x) = NoPushforwardExtras()
 
@@ -37,7 +33,7 @@ function value_and_pushforward(
     dx,
     extras::PushforwardExtras=prepare_pushforward(f, backend, x),
 )
-    new_extras = prepare_pullback(extras, f, backend, x)
+    new_extras = prepare_pullback(f, backend, x)
     y = f(x)
     dy = if x isa Number && y isa Number
         dx * pullback(f, backend, x, one(y), new_extras)
@@ -113,7 +109,7 @@ function value_and_pushforward!!(
     dx,
     extras::PushforwardExtras=prepare_pushforward(f!, backend, y, x),
 )
-    new_extras = prepare_pullback(extras, f!, backend, y, x)
+    new_extras = prepare_pullback(f!, backend, y, x)
     dy = if x isa Number && y isa AbstractArray
         map(CartesianIndices(y)) do i
             dx * value_and_pullback!!(


### PR DESCRIPTION
**Core**

- Remove the automatic conversion of extras between operator types
- Now, an extension needs to define the preparation and all four variants of an operator if it wants to support it
- In our fallbacks, explicitly grab the fields of the higher-level extras to serve as lower-level extras
- Add second derivative outer extras 
- Add the four cases of HVP outer extras corresponding to the four HVP modes
- The signature for `prepare_hvp` takes an additional argument `v`

**Extensions**

- Add some missing operator variants to avoid errors
- Make PolyesterForwardDiff rely on ForwardDiff preparation so that speeds are equal
- Add Hessian sparsity preparation for SparseDiffTools