### PR TITLE
Add split reverse mode

### DIFF
--- a/DifferentiationInterface/docs/src/overview.md
+++ b/DifferentiationInterface/docs/src/overview.md
@@ -120,3 +120,15 @@ This means the Hessian is obtained as the sparse Jacobian of the gradient.
 
 !!! danger
     Sparsity support is still experimental, use at your own risk.
+
+### Split reverse mode
+
+Many reverse mode AD backends expose a "split" option, which runs only the forward sweep, and encapsulates the reverse sweep in a closure.
+We make this available for everyone with the following operators:
+
+| out-of-place                       | in-place (or not)                    |
+| ---------------------------------- | ------------------------------------ |
+| [`value_and_pullback_split`](@ref) | [`value_and_pullback!!_split`](@ref) |
+
+!!! danger
+    Split reverse mode is still experimental, use at your own risk.

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -16,6 +16,18 @@ function DI.value_and_pullback(f, ::AutoTracker, x, dy, ::NoPullbackExtras)
     return y, data(only(back(dy)))
 end
 
+function DI.value_and_pullback_split(f, ::AutoTracker, x, ::NoPullbackExtras)
+    y, back = forward(f, x)
+    pullbackfunc(dy) = data(only(back(dy)))
+    return y, pullbackfunc
+end
+
+function DI.value_and_pullback!!_split(f, ::AutoTracker, x, ::NoPullbackExtras)
+    y, back = forward(f, x)
+    pullbackfunc!!(_dx, dy) = data(only(back(dy)))
+    return y, pullbackfunc!!
+end
+
 ## Gradient
 
 DI.prepare_gradient(f, ::AutoTracker, x) = NoGradientExtras()

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -22,6 +22,18 @@ function DI.value_and_pullback(f, ::AnyAutoZygote, x, dy, ::NoPullbackExtras)
     return y, dx
 end
 
+function DI.value_and_pullback_split(f, ::AnyAutoZygote, x, ::NoPullbackExtras)
+    y, back = pullback(f, x)
+    pullbackfunc(dy) = only(back(dy))
+    return y, pullbackfunc
+end
+
+function DI.value_and_pullback!!_split(f, ::AnyAutoZygote, x, ::NoPullbackExtras)
+    y, back = pullback(f, x)
+    pullbackfunc!!(_dx, dy) = only(back(dy))
+    return y, pullbackfunc!!
+end
+
 ## Gradient
 
 DI.prepare_gradient(f, ::AnyAutoZygote, x) = NoGradientExtras()

--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -107,6 +107,7 @@ export SecondOrder
 
 export value_and_pushforward!!, value_and_pushforward
 export value_and_pullback!!, value_and_pullback
+export value_and_pullback!!_split, value_and_pullback_split
 
 export value_and_derivative!!, value_and_derivative
 export value_and_gradient!!, value_and_gradient
@@ -130,34 +131,18 @@ export prepare_second_derivative, prepare_hvp, prepare_hessian
 export check_available, check_mutation, check_hessian
 
 function __init__()
-    Base.Experimental.register_error_hint(StackOverflowError) do io, exc, argtypes, kwargs
-        f_name = string(exc.f)
-        if (
-            f_name == "mode" ||
-            contains(f_name, "pushforward") ||
-            contains(f_name, "pullback") ||
-            contains(f_name, "derivative") ||
-            contains(f_name, "gradient") ||
-            contains(f_name, "jacobian") ||
-            contains(f_name, "hvp") ||
-            contains(f_name, "hessian")
+    Base.Experimental.register_error_hint(StackOverflowError) do io, exc
+        print(
+            io,
+            """\n
+            HINT: One of DifferentiationInterface's functions might be missing a method, which would trigger an endless loop of `pullback` calling `pushforward` and vice-versa.
+            Some possible fixes:
+            - switch to another backend
+            - if you don't want to switch, load the package extension corresponding to your backend
+            - if your backend is already loaded, define the primitive operator for the right combination of argument types
+            """,
         )
-            for T in argtypes
-                if T <: AbstractADType
-                    print(
-                        io,
-                        """\n
-                        HINT: One of DifferentiationInterface's functions is missing a method, which causes an endless loop of `pullback` calling `pushforward` and vice-versa.
-                        Some possible fixes:
-                        - switch to another backend
-                        - if you don't want to switch, load the package extension corresponding to backend `$T`
-                        - if the package is already loaded, define the method `$f_name` for the right combination of argument types
-                        """,
-                    )
-                    return nothing
-                end
-            end
-        end
+        return nothing
     end
 end
 

--- a/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -37,7 +37,7 @@ end
 function record!(
     data::Vector{BenchmarkDataRow},
     backend::AbstractADType,
-    operator::Function,
+    operator,
     scenario::AbstractScenario,
     bench,
 )
@@ -98,10 +98,13 @@ function run_benchmark!(
 )
     (; f, x, y, dy) = deepcopy(scen)
     extras = prepare_pullback(f, ba, x)
+    _, pullbackfunc!! = value_and_pullback!!_split(f, ba, x, extras)
     bench1 = @be mysimilar(x) value_and_pullback!!(f, _, ba, x, dy, extras)
     bench2 = @be mysimilar(x) pullback!!(f, _, ba, x, dy, extras)
+    bench3 = @be mysimilar(x) pullbackfunc!!(_, dy)
     record!(data, ba, value_and_pullback!!, scen, bench1)
     record!(data, ba, pullback!!, scen, bench2)
+    record!(data, ba, pullbackfunc!!, scen, bench3)
     return nothing
 end
 
@@ -111,10 +114,13 @@ function run_benchmark!(
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
     extras = prepare_pullback(f!, ba, y, x)
+    _, pullbackfunc!! = value_and_pullback!!_split(f!, y, ba, x, extras)
     bench1 = @be (mysimilar(y), mysimilar(x)) value_and_pullback!!(
         f!, _[1], _[2], ba, x, dy, extras
     )
+    bench2 = @be (mysimilar(y), mysimilar(x)) pullbackfunc!!(_[1], _[2], dy)
     record!(data, ba, value_and_pullback!!, scen, bench1)
+    record!(data, ba, pullbackfunc!!, scen, bench2)
     return nothing
 end
 

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -109,16 +109,25 @@ function test_correctness(
     dx3 = pullback(f, ba, x, dy, extras)
     dx4 = pullback!!(f, mysimilar(x), ba, x, dy, extras)
 
+    y5, pullbackfunc = value_and_pullback_split(f, ba, x, extras)
+    dx5 = pullbackfunc(dy)
+    y6, pullbackfunc!! = value_and_pullback!!_split(f, ba, x, extras)
+    dx6 = pullbackfunc!!(mysimilar(x), dy)
+
     let (≈)(x, y) = isapprox(x, y; atol, rtol)
         @testset "Primal value" begin
             @test y1 ≈ y
             @test y2 ≈ y
+            @test y5 ≈ y
+            @test y6 ≈ y
         end
         @testset "Cotangent value" begin
             @test dx1 ≈ dx_true
             @test dx2 ≈ dx_true
             @test dx3 ≈ dx_true
             @test dx4 ≈ dx_true
+            @test dx5 ≈ dx_true
+            @test dx6 ≈ dx_true
         end
     end
     test_scen_intact(new_scen, scen)
@@ -145,13 +154,20 @@ function test_correctness(
     y10 = mysimilar(y)
     y1, dx1 = value_and_pullback!!(f!, y10, mysimilar(x), ba, x, dy, extras)
 
+    y20 = mysimilar(y)
+    y2, pullbackfunc!! = value_and_pullback!!_split(f!, y20, ba, x, extras)
+    dx2 = pullbackfunc!!(y20, mysimilar(x), dy)
+
     let (≈)(x, y) = isapprox(x, y; atol, rtol)
         @testset "Primal value" begin
             @test y10 ≈ y
+            @test y20 ≈ y
             @test y1 ≈ y
+            @test y2 ≈ y
         end
         @testset "Cotangent value" begin
             @test dx1 ≈ dx_true
+            @test dx2 ≈ dx_true
         end
     end
     test_scen_intact(new_scen, scen)

--- a/DifferentiationInterfaceTest/src/tests/type_stability.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability.jl
@@ -32,9 +32,14 @@ function test_jet(ba::AbstractADType, scen::PullbackScenario{false};)
     extras = prepare_pullback(f, ba, x)
     dx_in = mysimilar(x)
 
+    _, pullbackfunc!! = value_and_pullback!!_split(f, ba, x, extras)
+    _, pullbackfunc = value_and_pullback_split(f, ba, x, extras)
+
     if Bool(pullback_performance(ba))
         @test_opt value_and_pullback!!(f, dx_in, ba, x, dy, extras)
         @test_opt value_and_pullback(f, ba, x, dy, extras)
+        @test_opt pullbackfunc!!(dx_in, dy)
+        @test_opt pullbackfunc(dy)
     end
     return nothing
 end
@@ -46,8 +51,11 @@ function test_jet(ba::AbstractADType, scen::PullbackScenario{true};)
     y_in = mysimilar(y)
     dx_in = mysimilar(x)
 
+    _, pullbackfunc!! = value_and_pullback!!_split(f!, y, ba, x, extras)
+
     if Bool(pullback_performance(ba))
         @test_opt value_and_pullback!!(f!, y_in, dx_in, ba, x, dy, extras)
+        @test_opt pullbackfunc!!(y_in, dx_in, dy)
     end
     return nothing
 end

--- a/DifferentiationInterfaceTest/test/test_imports.jl
+++ b/DifferentiationInterfaceTest/test/test_imports.jl
@@ -7,10 +7,7 @@ using JET: JET
 using JuliaFormatter: JuliaFormatter
 using Test
 
-using Chairmarks: Chairmarks
 using DataFrames: DataFrames
 using SparseArrays: SparseArrays
-
-##
 
 using ForwardDiff: ForwardDiff


### PR DESCRIPTION
**Core**

- Add `value_and_pullback_split` variants that call `pullback` under the hood
- Use it to speed up Jacobian

**Documentation**

- Add one paragraph on split reverse mode

**Tests**

- Add correctness and type stability tests for `value_and_pullback_split`

**Extensions**

- Implement split reverse mode for Zygote and Tracker
