### PR TITLE
Base reverse mode for allocating functions on split

### DIFF
--- a/DifferentiationInterface/docs/src/design.md
+++ b/DifferentiationInterface/docs/src/design.md
@@ -24,29 +24,5 @@ For simplicity, we remove `value_` in the operator names below.
     Full edges in the following graphs require a single call to the destination.
     Dotted edges require multiple calls to the destination, the number is indicated on the edge.
 
-### First order
-
-```mermaid
-flowchart LR
-    direction LR
-    subgraph Out-of-place
-        pushforward
-        pullback
-        derivative --> pushforward
-        gradient --> pullback
-        jacobian .-> |n|pushforward
-        jacobian .-> |m|pullback
-    end
-
-    subgraph In-place
-        pushforward!! --> pushforward
-        pullback!! --> pullback
-        derivative!! --> pushforward!!
-        gradient!! --> pullback!!
-        jacobian!! .-> |n|pushforward!!
-        jacobian!! .-> |m|pullback!!
-    end
-
-    pushforward .-> |m|pullback
-    pullback .-> |n|pushforward
-```
+!!! warning
+    This is still in flux, come back later!

--- a/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -19,13 +19,6 @@ DI.mode(::AutoReverseChainRules) = ADTypes.AbstractReverseMode
 
 DI.prepare_pullback(f, ::AutoForwardChainRules, x) = NoPullbackExtras()
 
-function DI.value_and_pullback(f, backend::AutoReverseChainRules, x, dy, ::NoPullbackExtras)
-    rc = ruleconfig(backend)
-    y, pullback = rrule_via_ad(rc, f, x)
-    _, new_dx = pullback(dy)
-    return y, new_dx
-end
-
 function DI.value_and_pullback_split(
     f, backend::AutoReverseChainRules, x, ::NoPullbackExtras
 )
@@ -33,15 +26,6 @@ function DI.value_and_pullback_split(
     y, pullback = rrule_via_ad(rc, f, x)
     pullbackfunc(dy) = last(pullback(dy))
     return y, pullbackfunc
-end
-
-function DI.value_and_pullback!!_split(
-    f, backend::AutoReverseChainRules, x, ::NoPullbackExtras
-)
-    rc = ruleconfig(backend)
-    y, pullback = rrule_via_ad(rc, f, x)
-    pullbackfunc!!(_dx, dy) = last(pullback(dy))
-    return y, pullbackfunc!!
 end
 
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/DifferentiationInterfaceTapirExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/DifferentiationInterfaceTapirExt.jl
@@ -9,6 +9,7 @@ using Tapir:
     NoTangent,
     build_rrule,
     increment!!,
+    primal,
     set_to_zero!!,
     tangent,
     tangent_type,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -11,21 +11,10 @@ DI.supports_mutation(::AutoTracker) = DI.MutationNotSupported()
 
 DI.prepare_pullback(f, ::AutoTracker, x) = NoPullbackExtras()
 
-function DI.value_and_pullback(f, ::AutoTracker, x, dy, ::NoPullbackExtras)
-    y, back = forward(f, x)
-    return y, data(only(back(dy)))
-end
-
 function DI.value_and_pullback_split(f, ::AutoTracker, x, ::NoPullbackExtras)
     y, back = forward(f, x)
     pullbackfunc(dy) = data(only(back(dy)))
     return y, pullbackfunc
-end
-
-function DI.value_and_pullback!!_split(f, ::AutoTracker, x, ::NoPullbackExtras)
-    y, back = forward(f, x)
-    pullbackfunc!!(_dx, dy) = data(only(back(dy)))
-    return y, pullbackfunc!!
 end
 
 ## Gradient

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -16,22 +16,10 @@ DI.supports_mutation(::AnyAutoZygote) = DI.MutationNotSupported()
 
 DI.prepare_pullback(f, ::AnyAutoZygote, x) = NoPullbackExtras()
 
-function DI.value_and_pullback(f, ::AnyAutoZygote, x, dy, ::NoPullbackExtras)
-    y, back = pullback(f, x)
-    dx = only(back(dy))
-    return y, dx
-end
-
 function DI.value_and_pullback_split(f, ::AnyAutoZygote, x, ::NoPullbackExtras)
     y, back = pullback(f, x)
     pullbackfunc(dy) = only(back(dy))
     return y, pullbackfunc
-end
-
-function DI.value_and_pullback!!_split(f, ::AnyAutoZygote, x, ::NoPullbackExtras)
-    y, back = pullback(f, x)
-    pullbackfunc!!(_dx, dy) = only(back(dy))
-    return y, pullbackfunc!!
 end
 
 ## Gradient

--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -130,20 +130,4 @@ export prepare_second_derivative, prepare_hvp, prepare_hessian
 
 export check_available, check_mutation, check_hessian
 
-function __init__()
-    Base.Experimental.register_error_hint(StackOverflowError) do io, exc
-        print(
-            io,
-            """\n
-            HINT: One of DifferentiationInterface's functions might be missing a method, which would trigger an endless loop of `pullback` calling `pushforward` and vice-versa.
-            Some possible fixes:
-            - switch to another backend
-            - if you don't want to switch, load the package extension corresponding to your backend
-            - if your backend is already loaded, define the primitive operator for the right combination of argument types
-            """,
-        )
-        return nothing
-    end
-end
-
 end # module

--- a/DifferentiationInterface/src/pushforward.jl
+++ b/DifferentiationInterface/src/pushforward.jl
@@ -33,19 +33,22 @@ function value_and_pushforward(
     dx,
     extras::PushforwardExtras=prepare_pushforward(f, backend, x),
 )
-    new_extras = prepare_pullback(f, backend, x)
-    y = f(x)
+    if !Bool(pullback_performance(backend))
+        error("Pullback not available for backend $backend")
+    end
+    pullback_extras = prepare_pullback(f, backend, x)
+    y, pullbackfunc = value_and_pullback_split(f, backend, x, pullback_extras)
     dy = if x isa Number && y isa Number
-        dx * pullback(f, backend, x, one(y), new_extras)
+        dx * pullbackfunc(one(y))
     elseif x isa AbstractArray && y isa Number
-        dot(dx, pullback(f, backend, x, one(y), new_extras))
+        dot(dx, pullbackfunc(one(y)))
     elseif x isa Number && y isa AbstractArray
         map(CartesianIndices(y)) do i
-            dx * pullback(f, backend, x, basis(backend, y, i), new_extras)
+            dx * pullbackfunc(basis(backend, y, i))
         end
     elseif x isa AbstractArray && y isa AbstractArray
         map(CartesianIndices(y)) do i
-            dot(dx, pullback(f, backend, x, basis(backend, y, i), new_extras))
+            dot(dx, pullbackfunc(basis(backend, y, i)))
         end
     end
     return y, dy


### PR DESCRIPTION
**Core**

- Make split reverse mode with `value_and_pullback_split` the primitive for allocating functions

**Extensions**

- Implement this for real in Zygote, Tracker, ChainRules, ReverseDiff
- Actually rely on `value_and_pullback` for Enzyme and Tapir