### PR TITLE
Add y prototype in Tapir

### DIFF
--- a/DifferentiationInterface/test/test_imports.jl
+++ b/DifferentiationInterface/test/test_imports.jl
@@ -8,7 +8,6 @@ Pkg.develop(
 
 using DifferentiationInterface
 using DifferentiationInterfaceTest
-using DifferentiationInterfaceTest: AutoZeroForward, AutoZeroReverse
 
 using Aqua: Aqua
 using Documenter: Documenter


### PR DESCRIPTION
**Extensions**

- Save one function call in Tapir by doing it in the preparation step