### PR TITLE
Make value_and_pullback the primitive

### DIFF
--- a/DifferentiationInterface/docs/src/backends.md
+++ b/DifferentiationInterface/docs/src/backends.md
@@ -18,7 +18,7 @@ function all_backends()
         AutoFiniteDiff(),
         AutoFiniteDifferences(FiniteDifferences.central_fdm(3, 1)),
         AutoForwardDiff(),
-        AutoPolyesterForwardDiff(; chunksize=2),
+        AutoPolyesterForwardDiff(; chunksize=1),
         AutoReverseDiff(),
         AutoTapir(),
         AutoTracker(),

--- a/DifferentiationInterface/docs/src/design.md
+++ b/DifferentiationInterface/docs/src/design.md
@@ -17,12 +17,5 @@ Advanced users are welcome to code more backends and submit pull requests!
 
 ## Fallback call structure
 
-For simplicity, we remove `value_` in the operator names below.
-
-!!! note "Edge labels"
-
-    Full edges in the following graphs require a single call to the destination.
-    Dotted edges require multiple calls to the destination, the number is indicated on the edge.
-
 !!! warning
     This is still in flux, come back later!

--- a/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -17,7 +17,7 @@ DI.mode(::AutoReverseChainRules) = ADTypes.AbstractReverseMode
 
 ## Pullback
 
-DI.prepare_pullback(f, ::AutoForwardChainRules, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoReverseChainRules, x) = NoPullbackExtras()
 
 function DI.value_and_pullback_split(
     f, backend::AutoReverseChainRules, x, ::NoPullbackExtras
@@ -26,6 +26,13 @@ function DI.value_and_pullback_split(
     y, pullback = rrule_via_ad(rc, f, x)
     pullbackfunc(dy) = last(pullback(dy))
     return y, pullbackfunc
+end
+
+function DI.value_and_pullback(
+    f, backend::AutoReverseChainRules, x, dy, extras::NoPullbackExtras
+)
+    y, pullbackfunc = DI.value_and_pullback_split(f, backend, x, extras)
+    return y, pullbackfunc(dy)
 end
 
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_allocating.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_allocating.jl
@@ -69,24 +69,6 @@ function DI.pullback!!(f, dx, backend::AutoReverseEnzyme, x, dy, extras::NoPullb
     return DI.value_and_pullback!!(f, dx, backend, x, dy, extras)[2]
 end
 
-### Closure
-
-function DI.value_and_pullback_split(
-    f, backend::AutoReverseEnzyme, x, extras::NoPullbackExtras
-)
-    y = f(x)
-    pullbackfunc(dy) = DI.pullback(f, backend, x, dy, extras)
-    return y, pullbackfunc
-end
-
-function DI.value_and_pullback!!_split(
-    f, backend::AutoReverseEnzyme, x, extras::NoPullbackExtras
-)
-    y = f(x)
-    pullbackfunc!!(dx, dy) = DI.pullback!!(f, dx, backend, x, dy, extras)
-    return y, pullbackfunc!!
-end
-
 ## Gradient
 
 DI.prepare_gradient(f, ::AutoReverseEnzyme, x) = NoGradientExtras()

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/allocating.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/allocating.jl
@@ -38,19 +38,3 @@ function DI.pullback!!(
 )
     return DI.value_and_pullback!!(f, dx, backend, x, dy, extras)[2]
 end
-
-function DI.value_and_pullback_split(
-    f, backend::AutoTapir, x, extras::TapirAllocatingPullbackExtras
-)
-    y = f(x)
-    pullbackfunc(dy) = DI.pullback(f, backend, x, dy, extras)
-    return y, pullbackfunc
-end
-
-function DI.value_and_pullback!!_split(
-    f, backend::AutoTapir, x, extras::TapirAllocatingPullbackExtras
-)
-    y = f(x)
-    pullbackfunc!!(dx, dy) = DI.pullback!!(f, dx, backend, x, dy, extras)
-    return y, pullbackfunc!!
-end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -17,6 +17,11 @@ function DI.value_and_pullback_split(f, ::AutoTracker, x, ::NoPullbackExtras)
     return y, pullbackfunc
 end
 
+function DI.value_and_pullback(f, backend::AutoTracker, x, dy, extras::NoPullbackExtras)
+    y, pullbackfunc = DI.value_and_pullback_split(f, backend, x, extras)
+    return y, pullbackfunc(dy)
+end
+
 ## Gradient
 
 DI.prepare_gradient(f, ::AutoTracker, x) = NoGradientExtras()

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -22,6 +22,11 @@ function DI.value_and_pullback_split(f, ::AnyAutoZygote, x, ::NoPullbackExtras)
     return y, pullbackfunc
 end
 
+function DI.value_and_pullback(f, backend::AnyAutoZygote, x, dy, extras::NoPullbackExtras)
+    y, pullbackfunc = DI.value_and_pullback_split(f, backend, x, extras)
+    return y, pullbackfunc(dy)
+end
+
 ## Gradient
 
 DI.prepare_gradient(f, ::AnyAutoZygote, x) = NoGradientExtras()

--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -107,7 +107,7 @@ export SecondOrder
 
 export value_and_pushforward!!, value_and_pushforward
 export value_and_pullback!!, value_and_pullback
-export value_and_pullback!!_split, value_and_pullback_split
+export value_and_pullback!!_split, value_and_pullback_split, value_and_pullback!!_split!!
 
 export value_and_derivative!!, value_and_derivative
 export value_and_gradient!!, value_and_gradient

--- a/DifferentiationInterface/src/jacobian.jl
+++ b/DifferentiationInterface/src/jacobian.jl
@@ -174,10 +174,8 @@ function value_and_jacobian_aux!!(
     for (k, j) in enumerate(CartesianIndices(x))
         dx_j = basis(backend, x, j)
         jac_col_j_old = reshape(view(jac, :, k), size(y))
-        jac_col_j_new = last(
-            value_and_pushforward!!(
-                f!, y, jac_col_j_old, backend, x, dx_j, extras.pushforward_extras
-            ),
+        jac_col_j_new = pushforward!!(
+            f!, y, jac_col_j_old, backend, x, dx_j, extras.pushforward_extras
         )
         # this allocates
         copyto!(jac_col_j_old, jac_col_j_new)
@@ -193,14 +191,13 @@ function value_and_jacobian_aux!!(
     x::AbstractArray,
     extras::PullbackJacobianExtras,
 )
+    y, pullbackfunc!! = value_and_pullback!!_split!!(
+        f!, y, backend, x, extras.pullback_extras
+    )
     for (k, i) in enumerate(CartesianIndices(y))
         dy_i = basis(backend, y, i)
         jac_row_i_old = reshape(view(jac, k, :), size(x))
-        jac_row_i_new = last(
-            value_and_pullback!!(
-                f!, y, jac_row_i_old, backend, x, dy_i, extras.pullback_extras
-            ),
-        )
+        jac_row_i_new = pullbackfunc!!(y, jac_row_i_old, dy_i)
         # this allocates
         copyto!(jac_row_i_old, jac_row_i_new)
     end

--- a/DifferentiationInterface/src/pushforward.jl
+++ b/DifferentiationInterface/src/pushforward.jl
@@ -9,14 +9,31 @@ abstract type PushforwardExtras <: Extras end
 
 struct NoPushforwardExtras <: PushforwardExtras end
 
+struct PullbackPushforwardExtras{E} <: PushforwardExtras
+    pullback_extras::E
+end
+
 """
     prepare_pushforward(f, backend, x) -> extras
     prepare_pushforward(f!, backend, y, x) -> extras
 
 Create an `extras` object subtyping [`PushforwardExtras`](@ref) that can be given to pushforward operators.
 """
-prepare_pushforward(f, ::AbstractADType, x) = NoPushforwardExtras()
-prepare_pushforward(f!, ::AbstractADType, y, x) = NoPushforwardExtras()
+function prepare_pushforward(f, backend::AbstractADType, x)
+    return prepare_pushforward_aux(f, backend, x, pushforward_performance(backend))
+end
+
+function prepare_pushforward(f!, backend::AbstractADType, y, x)
+    return prepare_pushforward_aux(f!, backend, y, x, pushforward_performance(backend))
+end
+
+function prepare_pushforward_aux(f, backend, x, ::PushforwardSlow)
+    return PullbackPushforwardExtras(prepare_pullback(f, backend, x))
+end
+
+function prepare_pushforward_aux(f!, backend, y, x, ::PushforwardSlow)
+    return PullbackPushforwardExtras(prepare_pullback(f!, backend, y, x))
+end
 
 ## Allocating
 
@@ -33,13 +50,11 @@ function value_and_pushforward(
     dx,
     extras::PushforwardExtras=prepare_pushforward(f, backend, x),
 )
-    return value_and_pushforward_aux(
-        f, backend, x, dx, extras, pushforward_performance(backend)
-    )
+    return value_and_pushforward_aux(f, backend, x, dx, extras)
 end
 
-function value_and_pushforward_aux(f, backend, x, dx, extras, ::PushforwardSlow)
-    pullback_extras = prepare_pullback(f, backend, x)
+function value_and_pushforward_aux(f, backend, x, dx, extras::PullbackPushforwardExtras)
+    (; pullback_extras) = extras
     y, pullbackfunc = value_and_pullback_split(f, backend, x, pullback_extras)
     dy = if x isa Number && y isa Number
         dx * pullbackfunc(one(y))
@@ -115,22 +130,42 @@ function value_and_pushforward!!(
     dx,
     extras::PushforwardExtras=prepare_pushforward(f!, backend, y, x),
 )
-    new_extras = prepare_pullback(f!, backend, y, x)
-    dy = if x isa Number && y isa AbstractArray
-        map(CartesianIndices(y)) do i
-            dx * value_and_pullback!!(
-                f!, y, zero(x), backend, x, basis(backend, y, i), new_extras
-            )[2]
+    return value_and_pushforward_aux!!(f!, y, dy, backend, x, dx, extras)
+end
+
+function value_and_pushforward_aux!!(
+    f!, y, dy, backend, x, dx, extras::PullbackPushforwardExtras
+)
+    (; pullback_extras) = extras
+    new_dy = if x isa Number && y isa AbstractArray
+        map!(dy, CartesianIndices(y)) do i
+            dx * pullback!!(f!, y, zero(x), backend, x, basis(backend, y, i), pullback_extras)
         end
     elseif x isa AbstractArray && y isa AbstractArray
-        map(CartesianIndices(y)) do i
+        map!(dy, CartesianIndices(y)) do i
             dot(
                 dx,
-                value_and_pullback!!(
-                    f!, y, similar(x), backend, x, basis(backend, y, i), new_extras
-                )[2],
+                pullback!!(
+                    f!, y, similar(x), backend, x, basis(backend, y, i), pullback_extras
+                ),
             )
         end
     end
-    return y, dy
+    f!(y, x)
+    return y, new_dy
+end
+
+"""
+    pushforward!!(f!, y, dy, backend, x, dx, [extras]) -> dy
+"""
+function pushforward!!(
+    f!,
+    y,
+    dy,
+    backend::AbstractADType,
+    x,
+    dx,
+    extras::PushforwardExtras=prepare_pushforward(f!, backend, y, x),
+)
+    return value_and_pushforward!!(f!, y, dy, backend, x, dx, extras)[2]
 end

--- a/DifferentiationInterface/test/first_order.jl
+++ b/DifferentiationInterface/test/first_order.jl
@@ -7,7 +7,7 @@ all_backends = [
     AutoFiniteDiff(),
     AutoFiniteDifferences(FiniteDifferences.central_fdm(3, 1)),
     AutoForwardDiff(),
-    AutoPolyesterForwardDiff(; chunksize=2),
+    AutoPolyesterForwardDiff(; chunksize=1),
     AutoReverseDiff(; compile=true),
     AutoTapir(),
     AutoTracker(),

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ADTypes = "0.2.7"
-Chairmarks = "1.2"
+Chairmarks = "1.2.1"
 ComponentArrays = "0.15"
 DocStringExtensions = "0.9"
 JET = "0.8"

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 ADTypes = "0.2.7"
-Chairmarks = "1.2.1"
+Chairmarks = "1.2"
 ComponentArrays = "0.15"
 DocStringExtensions = "0.9"
 JET = "0.8"

--- a/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -127,15 +127,21 @@ function run_benchmark!(
     bench1 = @be (mysimilar(y), mysimilar(y)) value_and_pushforward!!(
         f!, _[1], _[2], ba, x, dx, extras
     )
+    bench2 = @be (mysimilar(y), mysimilar(y)) pushforward!!(
+        f!, _[1], _[2], ba, x, dx, extras
+    )
     # count
     cc! = CallCounter(f!)
     extras = prepare_pushforward(cc!, ba, y, x)
     calls0 = reset_count!(cc!)
     value_and_pushforward!!(cc!, mysimilar(y), mysimilar(y), ba, x, dx, extras)
     calls1 = reset_count!(cc!)
+    pushforward!!(cc!, mysimilar(y), mysimilar(y), ba, x, dx, extras)
+    calls2 = reset_count!(cc!)
     # record
     record!(data, ba, scen, prepare_pushforward, bench0, calls0)
     record!(data, ba, scen, value_and_pushforward!!, bench1, calls1)
+    record!(data, ba, scen, pushforward!!, bench2, calls2)
     return nothing
 end
 
@@ -186,15 +192,19 @@ function run_benchmark!(
     bench1 = @be (mysimilar(y), mysimilar(x)) value_and_pullback!!(
         f!, _[1], _[2], ba, x, dy, extras
     )
+    bench2 = @be (mysimilar(y), mysimilar(x)) pullback!!(f!, _[1], _[2], ba, x, dy, extras)
     # count
     cc! = CallCounter(f!)
     extras = prepare_pullback(cc!, ba, y, x)
     calls0 = reset_count!(cc!)
     value_and_pullback!!(cc!, mysimilar(y), mysimilar(x), ba, x, dy, extras)
     calls1 = reset_count!(cc!)
+    pullback!!(cc!, mysimilar(y), mysimilar(x), ba, x, dy, extras)
+    calls2 = reset_count!(cc!)
     # record
     record!(data, ba, scen, prepare_pullback, bench0, calls0)
     record!(data, ba, scen, value_and_pullback!!, bench1, calls1)
+    record!(data, ba, scen, pullback!!, bench2, calls2)
     return nothing
 end
 

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -72,6 +72,9 @@ function test_correctness(
     y10 = mysimilar(y)
     y1, dy1 = value_and_pushforward!!(f!, y10, mysimilar(y), ba, x, dx, extras)
 
+    y20 = mysimilar(y)
+    dy2 = pushforward!!(f!, y20, mysimilar(y), ba, x, dx, extras)
+
     let (≈)(x, y) = isapprox(x, y; atol, rtol)
         @testset "Primal value" begin
             @test y10 ≈ y
@@ -79,6 +82,7 @@ function test_correctness(
         end
         @testset "Tangent value" begin
             @test dy1 ≈ dy_true
+            @test dy2 ≈ dy_true
         end
     end
     test_scen_intact(new_scen, scen)
@@ -156,13 +160,23 @@ function test_correctness(
     y10 = mysimilar(y)
     y1, dx1 = value_and_pullback!!(f!, y10, mysimilar(x), ba, x, dy, extras)
 
+    y20 = mysimilar(y)
+    dx2 = pullback!!(f!, y20, mysimilar(x), ba, x, dy, extras)
+
+    y3, pullbackfunc!! = value_and_pullback!!_split!!(f!, y, ba, x, extras)
+    pullbackfunc!!(mysimilar(y), mysimilar(x), dy)  # call once in case the second errors
+    dx3 = pullbackfunc!!(mysimilar(y), mysimilar(x), dy)
+
     let (≈)(x, y) = isapprox(x, y; atol, rtol)
         @testset "Primal value" begin
             @test y10 ≈ y
             @test y1 ≈ y
+            @test y3 ≈ y
         end
         @testset "Cotangent value" begin
             @test dx1 ≈ dx_true
+            @test dx2 ≈ dx_true
+            @test dx3 ≈ dx_true
         end
     end
     test_scen_intact(new_scen, scen)

--- a/DifferentiationInterfaceTest/src/tests/type_stability.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability.jl
@@ -21,6 +21,7 @@ function test_jet(ba::AbstractADType, scen::PushforwardScenario{true};)
 
     if Bool(pushforward_performance(ba))
         @test_opt value_and_pushforward!!(f!, y_in, dy_in, ba, x, dx, extras)
+        @test_opt pushforward!!(f!, y_in, dy_in, ba, x, dx, extras)
     end
     return nothing
 end
@@ -51,8 +52,12 @@ function test_jet(ba::AbstractADType, scen::PullbackScenario{true};)
     y_in = mysimilar(y)
     dx_in = mysimilar(x)
 
+    _, pullbackfunc!! = value_and_pullback!!_split!!(f!, y, ba, x, extras)
+
     if Bool(pullback_performance(ba))
         @test_opt value_and_pullback!!(f!, y_in, dx_in, ba, x, dy, extras)
+        @test_opt pullback!!(f!, y_in, dx_in, ba, x, dy, extras)
+        @test_opt pullbackfunc!!(y_in, dx_in, dy)
     end
     return nothing
 end

--- a/DifferentiationInterfaceTest/src/utils/zero_backends.jl
+++ b/DifferentiationInterfaceTest/src/utils/zero_backends.jl
@@ -54,21 +54,16 @@ DI.supports_mutation(::AutoZeroReverse) = DI.MutationSupported()
 DI.prepare_pullback(f, ::AutoZeroReverse, x) = NoPullbackExtras()
 DI.prepare_pullback(f!, ::AutoZeroReverse, y, x) = NoPullbackExtras()
 
-struct ZeroPullbackFunc{X}
-    x::X
+function DI.value_and_pullback(f, ::AutoZeroReverse, x, dy, ::NoPullbackExtras)
+    y = f(x)
+    dx = myzero(x)
+    return y, dx
 end
 
-(zpf::ZeroPullbackFunc)(_dy) = myzero(zpf.x)
-
-function DI.value_and_pullback_split(f, ::AutoZeroReverse, x, ::NoPullbackExtras)
+function DI.value_and_pullback!!(f, dx, ::AutoZeroReverse, x, dy, ::NoPullbackExtras)
     y = f(x)
-    return y, ZeroPullbackFunc(x)
-end
-
-function DI.value_and_pullback!!_split(f, dx, ::AutoZeroReverse, x, ::NoPullbackExtras)
-    y = f(x)
-    pullbackfunc!!(dx, dy) = myzero!!(dx)
-    return y, pullbackfunc!!
+    dx = myzero!!(dx)
+    return y, dx
 end
 
 function DI.value_and_pullback!!(f!, y, dx, ::AutoZeroReverse, x, dy, ::NoPullbackExtras)


### PR DESCRIPTION
**Core**

- Make split reverse mode (`value_and_pullback_split`) depend on combined reverse mode (`value_and_pullback`), not the other way around
- Add `pushforward!!` and `pullback!!` for mutating functions (not sure about including `y` in the signature)
- Define pushforward extras for pullback in forward mode and vice versa

**Docs**

- Only guarantee numbers and arrays

**Tests**

- Add necessary tests and benchmark for new methods

**Extensions**

- Fix the reverse mode backends