### PR TITLE
Choose sparsity detector

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/DifferentiationInterfaceSparseDiffToolsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/DifferentiationInterfaceSparseDiffToolsExt.jl
@@ -5,6 +5,7 @@ import DifferentiationInterface as DI
 using DifferentiationInterface:
     HessianExtras, JacobianExtras, NoHessianExtras, SecondOrder, inner, outer
 using SparseDiffTools:
+    AbstractMaybeSparsityDetection,
     AutoSparseEnzyme,
     JacPrototypeSparsityDetection,
     SymbolicsSparsityDetection,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/allocating.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/allocating.jl
@@ -13,9 +13,14 @@ for AutoSparse in SPARSE_BACKENDS
         ## Jacobian
 
         function DI.prepare_jacobian(f, backend::$AutoSparse, x::AbstractArray)
-            cache = sparse_jacobian_cache(
-                backend, SymbolicsSparsityDetection(), f, x; fx=f(x)
-            )
+            sparsity_detector::AbstractMaybeSparsityDetection =
+                if hasfield(typeof(backend), :sparsity_detector) &&
+                    !isnothing(backend.sparsity_detector)
+                    backend.sparsity_detector
+                else
+                    SymbolicsSparsityDetection()
+                end
+            cache = sparse_jacobian_cache(backend, sparsity_detector, f, x; fx=f(x))
             return SparseDiffToolsAllocatingJacobianExtras(cache)
         end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/mutating.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/mutating.jl
@@ -9,9 +9,14 @@ for AutoSparse in SPARSE_BACKENDS
         function DI.prepare_jacobian(
             f!, backend::$AutoSparse, y::AbstractArray, x::AbstractArray
         )
-            cache = sparse_jacobian_cache(
-                backend, SymbolicsSparsityDetection(), f!, similar(y), x
-            )
+            sparsity_detector::AbstractMaybeSparsityDetection =
+                if hasfield(typeof(backend), :sparsity_detector) &&
+                    !isnothing(backend.sparsity_detector)
+                    backend.sparsity_detector
+                else
+                    SymbolicsSparsityDetection()
+                end
+            cache = sparse_jacobian_cache(backend, sparsity_detector, f!, similar(y), x)
             return SparseDiffToolsMutatingJacobianExtras(cache)
         end
 


### PR DESCRIPTION
**Extensions**

- Modify SparseDiffTools extension to check if the backend has a `sparsity_detector` field and pick it instead of `SymbolicsSparsityDetection()`