### PR TITLE
Remove reference to BangBang

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -43,7 +43,7 @@ DifferentiationInterfaceZygoteExt = "Zygote"
 [compat]
 ADTypes = "0.2.7"
 ChainRulesCore = "1.23.0"
-Diffractor = "0.2.6 - 0.2.7"
+Diffractor = "=0.2.6"
 DocStringExtensions = "0.9.3"
 Enzyme = "0.11.20"
 FastDifferentiation = "0.3.7"

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -43,7 +43,7 @@ DifferentiationInterfaceZygoteExt = "Zygote"
 [compat]
 ADTypes = "0.2.7"
 ChainRulesCore = "1.23.0"
-Diffractor = "0.2.6"
+Diffractor = "0.2.6 - 0.2.7"
 DocStringExtensions = "0.9.3"
 Enzyme = "0.11.20"
 FastDifferentiation = "0.3.7"

--- a/DifferentiationInterface/docs/src/overview.md
+++ b/DifferentiationInterface/docs/src/overview.md
@@ -34,7 +34,7 @@ Several variants of each operator are defined:
 | [`pullback`](@ref)    | [`pullback!!`](@ref)    | [`value_and_pullback`](@ref)    | [`value_and_pullback!!`](@ref)    |
 
 !!! warning
-    The "bang-bang" syntactic convention `!!` signals that some of the arguments _can_ be mutated, but they do not _have to be_.
+    We use the syntactic convention `!!` to signal that some of the arguments _can_ be mutated, but they do not _have to be_.
     Such arguments will always be part of the return, so that one can simply reuse the operator's output and forget its input.
     In other words, this is good:
     ```julia


### PR DESCRIPTION
Amend the warning in the docs to avoid suggesting that the convention is exactly the same as BangBang.jl's