### PR TITLE
Switch order of arguments in preparation

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -1,6 +1,6 @@
 ## Pushforward
 
-DI.prepare_pushforward(f!, ::AutoForwardEnzyme, y, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AutoForwardEnzyme, x) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(
     f!, y, backend::AutoForwardEnzyme, x, dx, ::NoPushforwardExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -1,6 +1,6 @@
 ## Pullback
 
-DI.prepare_pullback(f!, ::AutoReverseEnzyme, y, x) = NoPullbackExtras()
+DI.prepare_pullback(f!, y, ::AutoReverseEnzyme, x) = NoPullbackExtras()
 
 function DI.value_and_pullback(
     f!, y, ::AutoReverseEnzyme, x::Number, dy, ::NoPullbackExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/twoarg.jl
@@ -5,7 +5,7 @@ struct FastDifferentiationTwoArgPushforwardExtras{E1,E2} <: PushforwardExtras
     jvp_exe!::E2
 end
 
-function DI.prepare_pushforward(f!, ::AnyAutoFastDifferentiation, y, x)
+function DI.prepare_pushforward(f!, y, ::AnyAutoFastDifferentiation, x)
     x_var = if x isa Number
         only(make_variables(:x))
     else
@@ -85,7 +85,7 @@ struct FastDifferentiationTwoArgDerivativeExtras{E1,E2} <: DerivativeExtras
     der_exe!::E2
 end
 
-function DI.prepare_derivative(f!, ::AnyAutoFastDifferentiation, y, x)
+function DI.prepare_derivative(f!, y, ::AnyAutoFastDifferentiation, x)
     x_var = only(make_variables(:x))
     y_var = make_variables(:y, size(y)...)
     f!(y_var, x_var)
@@ -153,7 +153,7 @@ struct FastDifferentiationTwoArgJacobianExtras{E1,E2} <: JacobianExtras
     jac_exe!::E2
 end
 
-function DI.prepare_jacobian(f!, backend::AnyAutoFastDifferentiation, y, x)
+function DI.prepare_jacobian(f!, y, backend::AnyAutoFastDifferentiation, x)
     x_var = make_variables(:x, size(x)...)
     y_var = make_variables(:y, size(y)...)
     f!(y_var, x_var)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/twoarg.jl
@@ -1,6 +1,6 @@
 ## Pushforward
 
-DI.prepare_pushforward(f!, ::AnyAutoFiniteDiff, y, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AnyAutoFiniteDiff, x) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(
     f!, y, backend::AnyAutoFiniteDiff, x, dx, ::NoPushforwardExtras
@@ -23,7 +23,7 @@ struct FiniteDiffTwoArgDerivativeExtras{C}
     cache::C
 end
 
-function DI.prepare_derivative(f!, ::AnyAutoFiniteDiff, y, x)
+function DI.prepare_derivative(f!, y, ::AnyAutoFiniteDiff, x)
     cache = nothing
     return FiniteDiffTwoArgDerivativeExtras(cache)
 end
@@ -65,7 +65,7 @@ struct FiniteDiffTwoArgJacobianExtras{C}
     cache::C
 end
 
-function DI.prepare_jacobian(f!, backend::AnyAutoFiniteDiff, y, x)
+function DI.prepare_jacobian(f!, y, backend::AnyAutoFiniteDiff, x)
     x1 = similar(x)
     fx = similar(y)
     fx1 = similar(y)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -1,4 +1,4 @@
-DI.prepare_pushforward(f!, ::AnyAutoForwardDiff, y, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AnyAutoForwardDiff, x) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(f!, y, ::AnyAutoForwardDiff, x, dx, ::NoPushforwardExtras)
     T = tag_type(f!, x)
@@ -16,7 +16,7 @@ struct ForwardDiffTwoArgDerivativeExtras{C} <: DerivativeExtras
     config::C
 end
 
-function DI.prepare_derivative(f!, ::AnyAutoForwardDiff, y::AbstractArray, x::Number)
+function DI.prepare_derivative(f!, y::AbstractArray, ::AnyAutoForwardDiff, x::Number)
     return ForwardDiffTwoArgDerivativeExtras(DerivativeConfig(f!, y, x))
 end
 
@@ -75,7 +75,7 @@ struct ForwardDiffTwoArgJacobianExtras{C} <: JacobianExtras
 end
 
 function DI.prepare_jacobian(
-    f!, backend::AnyAutoForwardDiff, y::AbstractArray, x::AbstractArray
+    f!, y::AbstractArray, backend::AnyAutoForwardDiff, x::AbstractArray
 )
     return ForwardDiffTwoArgJacobianExtras(
         JacobianConfig(f!, y, x, choose_chunk(backend, x))

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/twoarg.jl
@@ -1,7 +1,7 @@
 ## Pushforward
 
-function DI.prepare_pushforward(f!, backend::AnyAutoPolyForwardDiff, y, x)
-    return DI.prepare_pushforward(f!, single_threaded(backend), y, x)
+function DI.prepare_pushforward(f!, y, backend::AnyAutoPolyForwardDiff, x)
+    return DI.prepare_pushforward(f!, y, single_threaded(backend), x)
 end
 
 function DI.value_and_pushforward(
@@ -30,8 +30,8 @@ end
 
 ## Derivative
 
-function DI.prepare_derivative(f!, backend::AnyAutoPolyForwardDiff, y, x)
-    return DI.prepare_derivative(f!, single_threaded(backend), y, x)
+function DI.prepare_derivative(f!, y, backend::AnyAutoPolyForwardDiff, x)
+    return DI.prepare_derivative(f!, y, single_threaded(backend), x)
 end
 
 function DI.value_and_derivative(
@@ -58,7 +58,7 @@ end
 
 ## Jacobian
 
-DI.prepare_jacobian(f!, ::AnyAutoPolyForwardDiff, y, x) = NoJacobianExtras()
+DI.prepare_jacobian(f!, y, ::AnyAutoPolyForwardDiff, x) = NoJacobianExtras()
 
 function DI.value_and_jacobian(
     f!, y, ::AnyAutoPolyForwardDiff{C}, x, ::NoJacobianExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
@@ -1,6 +1,6 @@
 ## Pullback
 
-DI.prepare_pullback(f!, ::AnyAutoReverseDiff, y, x) = NoPullbackExtras()
+DI.prepare_pullback(f!, y, ::AnyAutoReverseDiff, x) = NoPullbackExtras()
 
 ### Array in
 
@@ -60,7 +60,7 @@ function DI.value_and_pullback(
     x_array = [x]
     dx_array = similar(x_array)
     f!_array(_y::AbstractArray, _x_array) = f!(_y, only(_x_array))
-    new_extras = DI.prepare_pullback(f!_array, backend, y, x_array)
+    new_extras = DI.prepare_pullback(f!_array, y, backend, x_array)
     y, dx_array = DI.value_and_pullback(f!_array, y, backend, x_array, dy, new_extras)
     return y, only(dx_array)
 end
@@ -72,7 +72,7 @@ struct ReverseDiffTwoArgJacobianExtras{T} <: JacobianExtras
 end
 
 function DI.prepare_jacobian(
-    f!, backend::AnyAutoReverseDiff, y::AbstractArray, x::AbstractArray
+    f!, y::AbstractArray, backend::AnyAutoReverseDiff, x::AbstractArray
 )
     tape = JacobianTape(f!, y, x)
     if backend.compile

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/twoarg.jl
@@ -7,7 +7,7 @@ for AutoSparse in SPARSE_BACKENDS
         ## Jacobian
 
         function DI.prepare_jacobian(
-            f!, backend::$AutoSparse, y::AbstractArray, x::AbstractArray
+            f!, y::AbstractArray, backend::$AutoSparse, x::AbstractArray
         )
             cache = sparse_jacobian_cache(
                 backend, SymbolicsSparsityDetection(), f!, similar(y), x

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/twoarg.jl
@@ -2,7 +2,7 @@ struct TapirTwoArgPullbackExtras{R} <: PullbackExtras
     rrule::R
 end
 
-function DI.prepare_pullback(f!, ::AutoTapir, y, x)
+function DI.prepare_pullback(f!, y, ::AutoTapir, x)
     return TapirTwoArgPullbackExtras(build_rrule(f!, y, x))
 end
 

--- a/DifferentiationInterface/src/derivative.jl
+++ b/DifferentiationInterface/src/derivative.jl
@@ -1,10 +1,12 @@
 ## Docstrings
 
 """
-    prepare_derivative(f,  backend,    x) -> extras
-    prepare_derivative(f!, backend, y, x) -> extras
+    prepare_derivative(f,     backend, x) -> extras
+    prepare_derivative(f!, y, backend, x) -> extras
 
 Create an `extras` object subtyping [`DerivativeExtras`](@ref) that can be given to derivative operators.
+
+Beware that in the two-argument case, `y` is mutated by `f!` during preparation.
 """
 function prepare_derivative end
 
@@ -51,8 +53,8 @@ function prepare_derivative(f, backend::AbstractADType, x)
     return PushforwardDerivativeExtras(prepare_pushforward(f, backend, x))
 end
 
-function prepare_derivative(f!, backend::AbstractADType, y, x)
-    return PushforwardDerivativeExtras(prepare_pushforward(f!, backend, y, x))
+function prepare_derivative(f!, y, backend::AbstractADType, x)
+    return PushforwardDerivativeExtras(prepare_pushforward(f!, y, backend, x))
 end
 
 ## One argument
@@ -102,7 +104,7 @@ function value_and_derivative(
     y,
     backend::AbstractADType,
     x,
-    extras::DerivativeExtras=prepare_derivative(f!, backend, y, x),
+    extras::DerivativeExtras=prepare_derivative(f!, y, backend, x),
 )
     return value_and_pushforward(f!, y, backend, x, one(x), extras.pushforward_extras)
 end
@@ -113,7 +115,7 @@ function value_and_derivative!(
     der,
     backend::AbstractADType,
     x,
-    extras::DerivativeExtras=prepare_derivative(f!, backend, y, x),
+    extras::DerivativeExtras=prepare_derivative(f!, y, backend, x),
 )
     return value_and_pushforward!(f!, y, der, backend, x, one(x), extras.pushforward_extras)
 end
@@ -123,7 +125,7 @@ function derivative(
     y,
     backend::AbstractADType,
     x,
-    extras::DerivativeExtras=prepare_derivative(f!, backend, y, x),
+    extras::DerivativeExtras=prepare_derivative(f!, y, backend, x),
 )
     return pushforward(f!, y, backend, x, one(x), extras.pushforward_extras)
 end
@@ -134,7 +136,7 @@ function derivative!(
     der,
     backend::AbstractADType,
     x,
-    extras::DerivativeExtras=prepare_derivative(f!, backend, y, x),
+    extras::DerivativeExtras=prepare_derivative(f!, y, backend, x),
 )
     return pushforward!(f!, y, der, backend, x, one(x), extras.pushforward_extras)
 end

--- a/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -152,13 +152,13 @@ function run_benchmark!(
     (; f, x, y, dx) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_pushforward(f!, ba, y, x)
-    bench0 = @be prepare_pushforward(f!, ba, y, x) evals = 1 samples = 1
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
+    bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x) evals = 1 samples = 1
     bench1 = @be mysimilar(y) value_and_pushforward(f!, _, ba, x, dx, extras)
     bench2 = @be mysimilar(y) pushforward(f!, _, ba, x, dx, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_pushforward(cc!, ba, y, x)
+    extras = prepare_pushforward(cc!, mysimilar(y), ba, x)
     calls0 = reset_count!(cc!)
     value_and_pushforward(cc!, mysimilar(y), ba, x, dx, extras)
     calls1 = reset_count!(cc!)
@@ -179,8 +179,8 @@ function run_benchmark!(
     (; f, x, y, dx) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_pushforward(f!, ba, y, x)
-    bench0 = @be prepare_pushforward(f!, ba, y, x) evals = 1 samples = 1
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
+    bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x) evals = 1 samples = 1
     bench1 = @be (mysimilar(y), mysimilar(y)) value_and_pushforward!(
         f!, _[1], _[2], ba, x, dx, extras
     )
@@ -189,7 +189,7 @@ function run_benchmark!(
     )
     # count
     cc! = CallCounter(f!)
-    extras = prepare_pushforward(cc!, ba, y, x)
+    extras = prepare_pushforward(cc!, mysimilar(y), ba, x)
     calls0 = reset_count!(cc!)
     value_and_pushforward!(cc!, mysimilar(y), mysimilar(y), ba, x, dx, extras)
     calls1 = reset_count!(cc!)
@@ -280,13 +280,13 @@ function run_benchmark!(
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_pullback(f!, ba, y, x)
-    bench0 = @be prepare_pullback(f!, ba, y, x) evals = 1 samples = 1
+    extras = prepare_pullback(f!, mysimilar(y), ba, x)
+    bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x) evals = 1 samples = 1
     bench1 = @be mysimilar(y) value_and_pullback(f!, _, ba, x, dy, extras)
     bench2 = @be mysimilar(y) pullback(f!, _, ba, x, dy, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_pullback(cc!, ba, y, x)
+    extras = prepare_pullback(cc!, mysimilar(y), ba, x)
     calls0 = reset_count!(cc!)
     value_and_pullback(cc!, mysimilar(y), ba, x, dy, extras)
     calls1 = reset_count!(cc!)
@@ -305,15 +305,15 @@ function run_benchmark!(
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_pullback(f!, ba, y, x)
-    bench0 = @be prepare_pullback(f!, ba, y, x) evals = 1 samples = 1
+    extras = prepare_pullback(f!, mysimilar(y), ba, x)
+    bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x) evals = 1 samples = 1
     bench1 = @be (mysimilar(y), mysimilar(x)) value_and_pullback!(
         f!, _[1], _[2], ba, x, dy, extras
     )
     bench2 = @be (mysimilar(y), mysimilar(x)) pullback!(f!, _[1], _[2], ba, x, dy, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_pullback(cc!, ba, y, x)
+    extras = prepare_pullback(cc!, mysimilar(y), ba, x)
     calls0 = reset_count!(cc!)
     value_and_pullback!(cc!, mysimilar(y), mysimilar(x), ba, x, dy, extras)
     calls1 = reset_count!(cc!)
@@ -388,13 +388,13 @@ function run_benchmark!(
     (; f, x, y) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_derivative(f!, ba, y, x)
-    bench0 = @be prepare_derivative(f!, ba, y, x) evals = 1 samples = 1
+    extras = prepare_derivative(f!, mysimilar(y), ba, x)
+    bench0 = @be mysimilar(y) prepare_derivative(f!, _, ba, x) evals = 1 samples = 1
     bench1 = @be mysimilar(y) value_and_derivative(f!, _, ba, x, extras)
     bench2 = @be mysimilar(y) derivative(f!, _, ba, x, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_derivative(cc!, ba, y, x)
+    extras = prepare_derivative(cc!, mysimilar(y), ba, x)
     calls0 = reset_count!(cc!)
     value_and_derivative(cc!, mysimilar(y), ba, x, extras)
     calls1 = reset_count!(cc!)
@@ -415,15 +415,15 @@ function run_benchmark!(
     (; f, x, y) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_derivative(f!, ba, y, x)
-    bench0 = @be prepare_derivative(f!, ba, y, x) evals = 1 samples = 1
+    extras = prepare_derivative(f!, mysimilar(y), ba, x)
+    bench0 = @be mysimilar(y) prepare_derivative(f!, _, ba, x) evals = 1 samples = 1
     bench1 = @be (mysimilar(y), mysimilar(y)) value_and_derivative!(
         f!, _[1], _[2], ba, x, extras
     )
     bench2 = @be (mysimilar(y), mysimilar(y)) derivative!(f!, _[1], _[2], ba, x, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_derivative(cc!, ba, y, x)
+    extras = prepare_derivative(cc!, mysimilar(y), ba, x)
     calls0 = reset_count!(cc!)
     value_and_derivative!(cc!, mysimilar(y), mysimilar(y), ba, x, extras)
     calls1 = reset_count!(cc!)
@@ -549,13 +549,13 @@ function run_benchmark!(
     (; f, x, y) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_jacobian(f!, ba, y, x)
-    bench0 = @be prepare_jacobian(f!, ba, y, x) evals = 1 samples = 1
+    extras = prepare_jacobian(f!, mysimilar(y), ba, x)
+    bench0 = @be mysimilar(y) prepare_jacobian(f!, _, ba, x) evals = 1 samples = 1
     bench1 = @be mysimilar(y) value_and_jacobian(f!, _, ba, x, extras)
     bench2 = @be mysimilar(y) jacobian(f!, _, ba, x, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_jacobian(cc!, ba, y, x)
+    extras = prepare_jacobian(cc!, mysimilar(y), ba, x)
     calls0 = reset_count!(cc!)
     value_and_jacobian(cc!, mysimilar(y), ba, x, extras)
     calls1 = reset_count!(cc!)
@@ -575,8 +575,8 @@ function run_benchmark!(
     f! = f
     jac_template = mysimilar(jacobian(f!, mysimilar(y), ba, x))
     # benchmark
-    extras = prepare_jacobian(f!, ba, y, x)
-    bench0 = @be prepare_jacobian(f!, ba, y, x) evals = 1 samples = 1
+    extras = prepare_jacobian(f!, mysimilar(y), ba, x)
+    bench0 = @be mysimilar(y) prepare_jacobian(f!, _, ba, x) evals = 1 samples = 1
     bench1 = @be (mysimilar(y), mysimilar(jac_template)) value_and_jacobian!(
         f!, _[1], _[2], ba, x, extras
     )
@@ -585,7 +585,7 @@ function run_benchmark!(
     )
     # count
     cc! = CallCounter(f!)
-    extras = prepare_jacobian(cc!, ba, y, x)
+    extras = prepare_jacobian(cc!, y, ba, x)
     calls0 = reset_count!(cc!)
     value_and_jacobian!(cc!, mysimilar(y), mysimilar(jac_template), ba, x, extras)
     calls1 = reset_count!(cc!)

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -94,7 +94,7 @@ function test_correctness(
 )
     (; f, x, y, dx) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_pushforward(f!, ba, y, x)
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
     dy_true = if ref_backend isa AbstractADType
         pushforward(f!, mysimilar(y), ref_backend, x, dx)
     else
@@ -131,7 +131,7 @@ function test_correctness(
 )
     (; f, x, y, dx) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_pushforward(f!, ba, y, x)
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
     dy_true = if ref_backend isa AbstractADType
         pushforward(f!, mysimilar(y), ref_backend, x, dx)
     else
@@ -256,7 +256,7 @@ function test_correctness(
 )
     (; f, x, y, dy) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_pullback(f!, ba, y, x)
+    extras = prepare_pullback(f!, mysimilar(y), ba, x)
     dx_true = if ref_backend isa AbstractADType
         pullback(f!, mysimilar(y), ref_backend, x, dy)
     else
@@ -302,7 +302,7 @@ function test_correctness(
 )
     (; f, x, y, dy) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_pullback(f!, ba, y, x)
+    extras = prepare_pullback(f!, mysimilar(y), ba, x)
     dx_true = if ref_backend isa AbstractADType
         pullback(f!, mysimilar(y), ref_backend, x, dy)
     else
@@ -423,7 +423,7 @@ function test_correctness(
 )
     (; f, x, y) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_derivative(f!, ba, y, x)
+    extras = prepare_derivative(f!, mysimilar(y), ba, x)
     der_true = if ref_backend isa AbstractADType
         derivative(f!, mysimilar(y), ref_backend, x)
     else
@@ -460,7 +460,7 @@ function test_correctness(
 )
     (; f, x, y) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_derivative(f!, ba, y, x)
+    extras = prepare_derivative(f!, mysimilar(y), ba, x)
     der_true = if ref_backend isa AbstractADType
         derivative(f!, mysimilar(y), ref_backend, x)
     else
@@ -643,7 +643,7 @@ function test_correctness(
 )
     (; f, x, y) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_jacobian(f!, ba, y, x)
+    extras = prepare_jacobian(f!, mysimilar(y), ba, x)
     jac_true = if ref_backend isa AbstractADType
         jacobian(f!, mysimilar(y), ref_backend, x)
     else
@@ -680,7 +680,7 @@ function test_correctness(
 )
     (; f, x, y) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_jacobian(f!, ba, y, x)
+    extras = prepare_jacobian(f!, mysimilar(y), ba, x)
     jac_true = if ref_backend isa AbstractADType
         jacobian(f!, mysimilar(y), ref_backend, x)
     else

--- a/DifferentiationInterfaceTest/src/tests/sparsity.jl
+++ b/DifferentiationInterfaceTest/src/tests/sparsity.jl
@@ -53,7 +53,7 @@ function test_sparsity(
 )
     (; f, x, y) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_jacobian(f!, ba, y, x)
+    extras = prepare_jacobian(f!, mysimilar(y), ba, x)
     jac_true = if ref_backend isa AbstractADType
         jacobian(f!, mysimilar(y), ref_backend, x)
     else
@@ -77,7 +77,7 @@ end
 function test_sparsity(ba::AbstractADType, scen::JacobianScenario{2,:inplace}; ref_backend)
     (; f, x, y) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_jacobian(f!, ba, y, x)
+    extras = prepare_jacobian(f!, mysimilar(y), ba, x)
     jac_true = if ref_backend isa AbstractADType
         jacobian(f!, mysimilar(y), ref_backend, x)
     else

--- a/DifferentiationInterfaceTest/src/tests/type_stability.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability.jl
@@ -26,7 +26,7 @@ end
 function test_jet(ba::AbstractADType, scen::PushforwardScenario{2,:outofplace}; ref_backend)
     (; f, x, y, dx) = deepcopy(scen)
     f! = f
-    extras = prepare_pushforward(f!, ba, y, x)
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
     y_in = mysimilar(y)
 
     if Bool(pushforward_performance(ba))
@@ -39,7 +39,7 @@ end
 function test_jet(ba::AbstractADType, scen::PushforwardScenario{2,:inplace}; ref_backend)
     (; f, x, y, dx) = deepcopy(scen)
     f! = f
-    extras = prepare_pushforward(f!, ba, y, x)
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
     y_in, dy_in = mysimilar(y), mysimilar(y)
 
     if Bool(pushforward_performance(ba))
@@ -83,7 +83,7 @@ end
 function test_jet(ba::AbstractADType, scen::PullbackScenario{2,:outofplace}; ref_backend)
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
-    extras = prepare_pullback(f!, ba, y, x)
+    extras = prepare_pullback(f!, mysimilar(y), ba, x)
     y_in = mysimilar(y)
 
     _, pullbackfunc = value_and_pullback_split(f!, y, ba, x, extras)
@@ -99,7 +99,7 @@ end
 function test_jet(ba::AbstractADType, scen::PullbackScenario{2,:inplace}; ref_backend)
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
-    extras = prepare_pullback(f!, ba, y, x)
+    extras = prepare_pullback(f!, mysimilar(y), ba, x)
     y_in, dx_in = mysimilar(y), mysimilar(x)
 
     _, pullbackfunc! = value_and_pullback!_split(f!, y, ba, x, extras)
@@ -136,7 +136,7 @@ end
 function test_jet(ba::AbstractADType, scen::DerivativeScenario{2,:outofplace}; ref_backend)
     (; f, x, y) = deepcopy(scen)
     f! = f
-    extras = prepare_derivative(f!, ba, y, x)
+    extras = prepare_derivative(f!, mysimilar(y), ba, x)
     y_in = mysimilar(y)
 
     @test_opt value_and_derivative(f!, y_in, ba, x, extras)
@@ -147,7 +147,7 @@ end
 function test_jet(ba::AbstractADType, scen::DerivativeScenario{2,:inplace}; ref_backend)
     (; f, x, y) = deepcopy(scen)
     f! = f
-    extras = prepare_derivative(f!, ba, y, x)
+    extras = prepare_derivative(f!, mysimilar(y), ba, x)
     y_in, der_in = mysimilar(y), mysimilar(y)
 
     @test_opt value_and_derivative!(f!, y_in, der_in, ba, x, extras)
@@ -200,7 +200,7 @@ end
 function test_jet(ba::AbstractADType, scen::JacobianScenario{2,:outofplace}; ref_backend)
     (; f, x, y) = deepcopy(scen)
     f! = f
-    extras = prepare_jacobian(f!, ba, y, x)
+    extras = prepare_jacobian(f!, mysimilar(y), ba, x)
     y_in = mysimilar(y)
 
     @test_opt value_and_jacobian(f!, y_in, ba, x, extras)
@@ -211,7 +211,7 @@ end
 function test_jet(ba::AbstractADType, scen::JacobianScenario{2,:inplace}; ref_backend)
     (; f, x, y) = deepcopy(scen)
     f! = f
-    extras = prepare_jacobian(f!, ba, y, x)
+    extras = prepare_jacobian(f!, mysimilar(y), ba, x)
     y_in, jac_in = mysimilar(y), Matrix{eltype(y)}(undef, length(y), length(x))
 
     @test_opt value_and_jacobian!(f!, y_in, jac_in, ba, x, extras)

--- a/DifferentiationInterfaceTest/src/utils/misc.jl
+++ b/DifferentiationInterfaceTest/src/utils/misc.jl
@@ -1,4 +1,4 @@
-mysimilar(x::Number) = zero(x)
+# mysimilar(x::Number) = zero(x)
 mysimilar(x::AbstractArray) = similar(x)
 
 mysimilar_random(x::Number) = randn(typeof(x))

--- a/DifferentiationInterfaceTest/src/utils/zero_backends.jl
+++ b/DifferentiationInterfaceTest/src/utils/zero_backends.jl
@@ -13,7 +13,7 @@ struct AutoZeroForward <: ADTypes.AbstractForwardMode end
 DI.supports_mutation(::AutoZeroForward) = DI.MutationSupported()
 
 DI.prepare_pushforward(f, ::AutoZeroForward, x) = NoPushforwardExtras()
-DI.prepare_pushforward(f!, ::AutoZeroForward, y, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AutoZeroForward, x) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(f, ::AutoZeroForward, x, dx, ::NoPushforwardExtras)
     y = f(x)
@@ -54,7 +54,7 @@ struct AutoZeroReverse <: ADTypes.AbstractReverseMode end
 DI.supports_mutation(::AutoZeroReverse) = DI.MutationSupported()
 
 DI.prepare_pullback(f, ::AutoZeroReverse, x) = NoPullbackExtras()
-DI.prepare_pullback(f!, ::AutoZeroReverse, y, x) = NoPullbackExtras()
+DI.prepare_pullback(f!, y, ::AutoZeroReverse, x) = NoPullbackExtras()
 
 function DI.value_and_pullback(f, ::AutoZeroReverse, x, dy, ::NoPullbackExtras)
     y = f(x)


### PR DESCRIPTION
**Core**

- Replace `prepare_operator(f!, backend, y, x)` by `prepare_operator(f!, y, backend, x)` and warn that `y` can be modified

**Tests**

- Duplicate `y` before preparation to avoid destroying the scenario

**Extensions**

- Make the switch everywhere