### PR TITLE
Only jacobian and hessian for sparse backends

### DIFF
--- a/DifferentiationInterface/docs/src/backends.md
+++ b/DifferentiationInterface/docs/src/backends.md
@@ -63,6 +63,9 @@ AutoZygote
 
 ### Sparse
 
+!!! warning
+    For sparse backends, only the Jacobian and Hessian operators are implemented.
+
 ```@docs
 AutoSparseFastDifferentiation
 AutoSparseFiniteDiff

--- a/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -11,6 +11,7 @@ ruleconfig(backend::AutoChainRules) = backend.ruleconfig
 const AutoForwardChainRules = AutoChainRules{<:RuleConfig{>:HasForwardsMode}}
 const AutoReverseChainRules = AutoChainRules{<:RuleConfig{>:HasReverseMode}}
 
+DI.check_available(::AutoChainRules) = true
 DI.supports_mutation(::AutoChainRules) = DI.MutationNotSupported()
 DI.mode(::AutoForwardChainRules) = ADTypes.AbstractForwardMode
 DI.mode(::AutoReverseChainRules) = ADTypes.AbstractReverseMode

--- a/DifferentiationInterface/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
@@ -5,6 +5,7 @@ import DifferentiationInterface as DI
 using DifferentiationInterface: NoPushforwardExtras
 using Diffractor: DiffractorRuleConfig, TaylorTangentIndex, ZeroBundle, bundle, ∂☆
 
+DI.check_available(::AutoDiffractor) = true
 DI.supports_mutation(::AutoDiffractor) = DI.MutationNotSupported()
 DI.mode(::AutoDiffractor) = ADTypes.AbstractForwardMode
 DI.mode(::AutoChainRules{<:DiffractorRuleConfig}) = ADTypes.AbstractForwardMode

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -38,6 +38,8 @@ AutoEnzyme
 const AutoForwardEnzyme = AutoEnzyme{<:ForwardMode}
 const AutoReverseEnzyme = AutoEnzyme{<:ReverseMode}
 
+DI.check_available(::AutoEnzyme) = true
+
 function DI.mode(::AutoEnzyme)
     return error(
         "You need to specify the Enzyme mode with `AutoEnzyme(Enzyme.Forward)` or `AutoEnzyme(Enzyme.Reverse)`",

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/DifferentiationInterfaceFastDifferentiationExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/DifferentiationInterfaceFastDifferentiationExt.jl
@@ -31,6 +31,7 @@ const AnyAutoFastDifferentiation = Union{
     AutoFastDifferentiation,AutoSparseFastDifferentiation
 }
 
+DI.check_available(::AutoFastDifferentiation) = true
 DI.mode(::AnyAutoFastDifferentiation) = ADTypes.AbstractSymbolicDifferentiationMode
 DI.pushforward_performance(::AnyAutoFastDifferentiation) = DI.PushforwardFast()
 DI.pullback_performance(::AnyAutoFastDifferentiation) = DI.PullbackSlow()

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/DifferentiationInterfaceFiniteDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/DifferentiationInterfaceFiniteDiffExt.jl
@@ -23,7 +23,7 @@ using FiniteDiff:
     finite_difference_jacobian!
 using LinearAlgebra: dot, mul!
 
-const AnyAutoFiniteDiff = Union{AutoFiniteDiff,AutoSparseFiniteDiff}
+DI.check_available(::AutoFiniteDiff) = true
 
 # see https://github.com/SciML/ADTypes.jl/issues/33
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/onearg.jl
@@ -1,16 +1,14 @@
 ## Pushforward
 
-DI.prepare_pushforward(f, ::AnyAutoFiniteDiff, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f, ::AutoFiniteDiff, x) = NoPushforwardExtras()
 
-function DI.pushforward(f, backend::AnyAutoFiniteDiff, x, dx, ::NoPushforwardExtras)
+function DI.pushforward(f, backend::AutoFiniteDiff, x, dx, ::NoPushforwardExtras)
     step(t::Number) = f(x .+ t .* dx)
     new_dy = finite_difference_derivative(step, zero(eltype(x)), fdtype(backend))
     return new_dy
 end
 
-function DI.value_and_pushforward(
-    f, backend::AnyAutoFiniteDiff, x, dx, ::NoPushforwardExtras
-)
+function DI.value_and_pushforward(f, backend::AutoFiniteDiff, x, dx, ::NoPushforwardExtras)
     y = f(x)
     step(t::Number) = f(x .+ t .* dx)
     new_dy = finite_difference_derivative(
@@ -25,7 +23,7 @@ struct FiniteDiffOneArgDerivativeExtras{C}
     cache::C
 end
 
-function DI.prepare_derivative(f, backend::AnyAutoFiniteDiff, x)
+function DI.prepare_derivative(f, backend::AutoFiniteDiff, x)
     y = f(x)
     cache = if y isa Number
         nothing
@@ -39,26 +37,26 @@ end
 ### Scalar to scalar
 
 function DI.derivative(
-    f, backend::AnyAutoFiniteDiff, x, ::FiniteDiffOneArgDerivativeExtras{Nothing}
+    f, backend::AutoFiniteDiff, x, ::FiniteDiffOneArgDerivativeExtras{Nothing}
 )
     return finite_difference_derivative(f, x, fdtype(backend))
 end
 
 function DI.derivative!(
-    f, der, backend::AnyAutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{Nothing}
+    f, der, backend::AutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{Nothing}
 )
     return copyto!(der, DI.derivative(f, backend, x, extras))
 end
 
 function DI.value_and_derivative(
-    f, backend::AnyAutoFiniteDiff, x, ::FiniteDiffOneArgDerivativeExtras{Nothing}
+    f, backend::AutoFiniteDiff, x, ::FiniteDiffOneArgDerivativeExtras{Nothing}
 )
     y = f(x)
     return y, finite_difference_derivative(f, x, fdtype(backend), eltype(y), y)
 end
 
 function DI.value_and_derivative!(
-    f, der, backend::AnyAutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{Nothing}
+    f, der, backend::AutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{Nothing}
 )
     y, new_der = DI.value_and_derivative(f, backend, x, extras)
     return y, copyto!(der, new_der)
@@ -67,34 +65,26 @@ end
 ### Scalar to array
 
 function DI.derivative(
-    f, ::AnyAutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{<:GradientCache}
+    f, ::AutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{<:GradientCache}
 )
     return finite_difference_gradient(f, x, extras.cache)
 end
 
 function DI.derivative!(
-    f,
-    der,
-    ::AnyAutoFiniteDiff,
-    x,
-    extras::FiniteDiffOneArgDerivativeExtras{<:GradientCache},
+    f, der, ::AutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{<:GradientCache}
 )
     return finite_difference_gradient!(der, f, x, extras.cache)
 end
 
 function DI.value_and_derivative(
-    f, ::AnyAutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{<:GradientCache}
+    f, ::AutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{<:GradientCache}
 )
     y = f(x)
     return y, finite_difference_gradient(f, x, extras.cache)
 end
 
 function DI.value_and_derivative!(
-    f,
-    der,
-    ::AnyAutoFiniteDiff,
-    x,
-    extras::FiniteDiffOneArgDerivativeExtras{<:GradientCache},
+    f, der, ::AutoFiniteDiff, x, extras::FiniteDiffOneArgDerivativeExtras{<:GradientCache}
 )
     return f(x), finite_difference_gradient!(der, f, x, extras.cache)
 end
@@ -105,7 +95,7 @@ struct FiniteDiffGradientExtras{C}
     cache::C
 end
 
-function DI.prepare_gradient(f, backend::AnyAutoFiniteDiff, x)
+function DI.prepare_gradient(f, backend::AutoFiniteDiff, x)
     y = f(x)
     df = zero(y) .* x
     cache = GradientCache(df, x, fdtype(backend))
@@ -113,25 +103,25 @@ function DI.prepare_gradient(f, backend::AnyAutoFiniteDiff, x)
 end
 
 function DI.gradient(
-    f, ::AnyAutoFiniteDiff, x::AbstractArray, extras::FiniteDiffGradientExtras
+    f, ::AutoFiniteDiff, x::AbstractArray, extras::FiniteDiffGradientExtras
 )
     return finite_difference_gradient(f, x, extras.cache)
 end
 
 function DI.value_and_gradient(
-    f, ::AnyAutoFiniteDiff, x::AbstractArray, extras::FiniteDiffGradientExtras
+    f, ::AutoFiniteDiff, x::AbstractArray, extras::FiniteDiffGradientExtras
 )
     return f(x), finite_difference_gradient(f, x, extras.cache)
 end
 
 function DI.gradient!(
-    f, grad, ::AnyAutoFiniteDiff, x::AbstractArray, extras::FiniteDiffGradientExtras
+    f, grad, ::AutoFiniteDiff, x::AbstractArray, extras::FiniteDiffGradientExtras
 )
     return finite_difference_gradient!(grad, f, x, extras.cache)
 end
 
 function DI.value_and_gradient!(
-    f, grad, ::AnyAutoFiniteDiff, x::AbstractArray, extras::FiniteDiffGradientExtras
+    f, grad, ::AutoFiniteDiff, x::AbstractArray, extras::FiniteDiffGradientExtras
 )
     return f(x), finite_difference_gradient!(grad, f, x, extras.cache)
 end
@@ -142,7 +132,7 @@ struct FiniteDiffOneArgJacobianExtras{C}
     cache::C
 end
 
-function DI.prepare_jacobian(f, backend::AnyAutoFiniteDiff, x)
+function DI.prepare_jacobian(f, backend::AutoFiniteDiff, x)
     y = f(x)
     x1 = similar(x)
     fx = similar(y)
@@ -151,25 +141,23 @@ function DI.prepare_jacobian(f, backend::AnyAutoFiniteDiff, x)
     return FiniteDiffOneArgJacobianExtras(cache)
 end
 
-function DI.jacobian(f, ::AnyAutoFiniteDiff, x, extras::FiniteDiffOneArgJacobianExtras)
+function DI.jacobian(f, ::AutoFiniteDiff, x, extras::FiniteDiffOneArgJacobianExtras)
     return finite_difference_jacobian(f, x, extras.cache)
 end
 
 function DI.value_and_jacobian(
-    f, ::AnyAutoFiniteDiff, x, extras::FiniteDiffOneArgJacobianExtras
+    f, ::AutoFiniteDiff, x, extras::FiniteDiffOneArgJacobianExtras
 )
     y = f(x)
     return y, finite_difference_jacobian(f, x, extras.cache, y)
 end
 
-function DI.jacobian!(
-    f, jac, ::AnyAutoFiniteDiff, x, extras::FiniteDiffOneArgJacobianExtras
-)
+function DI.jacobian!(f, jac, ::AutoFiniteDiff, x, extras::FiniteDiffOneArgJacobianExtras)
     return copyto!(jac, finite_difference_jacobian(f, x, extras.cache; jac_prototype=jac))
 end
 
 function DI.value_and_jacobian!(
-    f, jac, ::AnyAutoFiniteDiff, x, extras::FiniteDiffOneArgJacobianExtras
+    f, jac, ::AutoFiniteDiff, x, extras::FiniteDiffOneArgJacobianExtras
 )
     y = f(x)
     return y,
@@ -182,15 +170,15 @@ struct FiniteDiffHessianExtras{C}
     cache::C
 end
 
-function DI.prepare_hessian(f, backend::AnyAutoFiniteDiff, x)
+function DI.prepare_hessian(f, backend::AutoFiniteDiff, x)
     cache = HessianCache(x, fdhtype(backend))
     return FiniteDiffHessianExtras(cache)
 end
 
-function DI.hessian(f, ::AnyAutoFiniteDiff, x, extras::FiniteDiffHessianExtras)
+function DI.hessian(f, ::AutoFiniteDiff, x, extras::FiniteDiffHessianExtras)
     return finite_difference_hessian(f, x, extras.cache)
 end
 
-function DI.hessian!(f, hess, ::AnyAutoFiniteDiff, x, extras::FiniteDiffHessianExtras)
+function DI.hessian!(f, hess, ::AutoFiniteDiff, x, extras::FiniteDiffHessianExtras)
     return finite_difference_hessian!(hess, f, x, extras.cache)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/twoarg.jl
@@ -1,9 +1,9 @@
 ## Pushforward
 
-DI.prepare_pushforward(f!, y, ::AnyAutoFiniteDiff, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AutoFiniteDiff, x) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(
-    f!, y, backend::AnyAutoFiniteDiff, x, dx, ::NoPushforwardExtras
+    f!, y, backend::AutoFiniteDiff, x, dx, ::NoPushforwardExtras
 )
     function step(t::Number)::AbstractArray
         new_y = similar(y)
@@ -23,13 +23,13 @@ struct FiniteDiffTwoArgDerivativeExtras{C}
     cache::C
 end
 
-function DI.prepare_derivative(f!, y, ::AnyAutoFiniteDiff, x)
+function DI.prepare_derivative(f!, y, ::AutoFiniteDiff, x)
     cache = nothing
     return FiniteDiffTwoArgDerivativeExtras(cache)
 end
 
 function DI.value_and_derivative(
-    f!, y, backend::AnyAutoFiniteDiff, x, ::FiniteDiffTwoArgDerivativeExtras
+    f!, y, backend::AutoFiniteDiff, x, ::FiniteDiffTwoArgDerivativeExtras
 )
     f!(y, x)
     der = finite_difference_gradient(f!, x, fdtype(backend), eltype(y), FUNCTION_INPLACE, y)
@@ -37,7 +37,7 @@ function DI.value_and_derivative(
 end
 
 function DI.value_and_derivative!(
-    f!, y, der, backend::AnyAutoFiniteDiff, x, ::FiniteDiffTwoArgDerivativeExtras
+    f!, y, der, backend::AutoFiniteDiff, x, ::FiniteDiffTwoArgDerivativeExtras
 )
     f!(y, x)
     finite_difference_gradient!(der, f!, x, fdtype(backend), eltype(y), FUNCTION_INPLACE, y)
@@ -45,7 +45,7 @@ function DI.value_and_derivative!(
 end
 
 function DI.derivative(
-    f!, y, backend::AnyAutoFiniteDiff, x, ::FiniteDiffTwoArgDerivativeExtras
+    f!, y, backend::AutoFiniteDiff, x, ::FiniteDiffTwoArgDerivativeExtras
 )
     f!(y, x)
     der = finite_difference_gradient(f!, x, fdtype(backend), eltype(y), FUNCTION_INPLACE, y)
@@ -53,7 +53,7 @@ function DI.derivative(
 end
 
 function DI.derivative!(
-    f!, y, der, backend::AnyAutoFiniteDiff, x, ::FiniteDiffTwoArgDerivativeExtras
+    f!, y, der, backend::AutoFiniteDiff, x, ::FiniteDiffTwoArgDerivativeExtras
 )
     finite_difference_gradient!(der, f!, x, fdtype(backend), eltype(y), FUNCTION_INPLACE)
     return der
@@ -65,7 +65,7 @@ struct FiniteDiffTwoArgJacobianExtras{C}
     cache::C
 end
 
-function DI.prepare_jacobian(f!, y, backend::AnyAutoFiniteDiff, x)
+function DI.prepare_jacobian(f!, y, backend::AutoFiniteDiff, x)
     x1 = similar(x)
     fx = similar(y)
     fx1 = similar(y)
@@ -74,7 +74,7 @@ function DI.prepare_jacobian(f!, y, backend::AnyAutoFiniteDiff, x)
 end
 
 function DI.value_and_jacobian(
-    f!, y, ::AnyAutoFiniteDiff, x, extras::FiniteDiffTwoArgJacobianExtras
+    f!, y, ::AutoFiniteDiff, x, extras::FiniteDiffTwoArgJacobianExtras
 )
     jac = similar(y, length(y), length(x))
     finite_difference_jacobian!(jac, f!, x, extras.cache)
@@ -83,21 +83,21 @@ function DI.value_and_jacobian(
 end
 
 function DI.value_and_jacobian!(
-    f!, y, jac, ::AnyAutoFiniteDiff, x, extras::FiniteDiffTwoArgJacobianExtras
+    f!, y, jac, ::AutoFiniteDiff, x, extras::FiniteDiffTwoArgJacobianExtras
 )
     finite_difference_jacobian!(jac, f!, x, extras.cache)
     f!(y, x)
     return y, jac
 end
 
-function DI.jacobian(f!, y, ::AnyAutoFiniteDiff, x, extras::FiniteDiffTwoArgJacobianExtras)
+function DI.jacobian(f!, y, ::AutoFiniteDiff, x, extras::FiniteDiffTwoArgJacobianExtras)
     jac = similar(y, length(y), length(x))
     finite_difference_jacobian!(jac, f!, x, extras.cache)
     return jac
 end
 
 function DI.jacobian!(
-    f!, y, jac, ::AnyAutoFiniteDiff, x, extras::FiniteDiffTwoArgJacobianExtras
+    f!, y, jac, ::AutoFiniteDiff, x, extras::FiniteDiffTwoArgJacobianExtras
 )
     finite_difference_jacobian!(jac, f!, x, extras.cache)
     return jac

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
@@ -8,6 +8,7 @@ using FillArrays: OneElement
 using FiniteDifferences: FiniteDifferences, grad, jacobian, jvp, j′vp
 using LinearAlgebra: dot
 
+DI.check_available(::AutoFiniteDifferences) = true
 DI.supports_mutation(::AutoFiniteDifferences) = DI.MutationNotSupported()
 
 function FiniteDifferences.to_vec(a::OneElement)  # TODO: remove type piracy (https://github.com/JuliaDiff/FiniteDifferences.jl/issues/141)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -32,7 +32,7 @@ using ForwardDiff:
     value
 using LinearAlgebra: dot, mul!
 
-const AnyAutoForwardDiff{C,T} = Union{AutoForwardDiff{C,T},AutoSparseForwardDiff{C,T}}
+DI.check_available(::AutoForwardDiff) = true
 
 include("utils.jl")
 include("onearg.jl")

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -1,8 +1,8 @@
 ## Pushforward
 
-DI.prepare_pushforward(f, ::AnyAutoForwardDiff, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f, ::AutoForwardDiff, x) = NoPushforwardExtras()
 
-function DI.value_and_pushforward(f, ::AnyAutoForwardDiff, x, dx, ::NoPushforwardExtras)
+function DI.value_and_pushforward(f, ::AutoForwardDiff, x, dx, ::NoPushforwardExtras)
     T = tag_type(f, x)
     xdual = make_dual(T, x, dx)
     ydual = f(xdual)
@@ -17,14 +17,14 @@ struct ForwardDiffGradientExtras{C} <: GradientExtras
     config::C
 end
 
-function DI.prepare_gradient(f, backend::AnyAutoForwardDiff, x::AbstractArray)
+function DI.prepare_gradient(f, backend::AutoForwardDiff, x::AbstractArray)
     return ForwardDiffGradientExtras(GradientConfig(f, x, choose_chunk(backend, x)))
 end
 
 function DI.value_and_gradient!(
     f,
     grad::AbstractArray,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffGradientExtras,
 )
@@ -34,7 +34,7 @@ function DI.value_and_gradient!(
 end
 
 function DI.value_and_gradient(
-    f, backend::AnyAutoForwardDiff, x::AbstractArray, extras::ForwardDiffGradientExtras
+    f, backend::AutoForwardDiff, x::AbstractArray, extras::ForwardDiffGradientExtras
 )
     grad = similar(x)
     return DI.value_and_gradient!(f, grad, backend, x, extras)
@@ -43,7 +43,7 @@ end
 function DI.gradient!(
     f,
     grad::AbstractArray,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffGradientExtras,
 )
@@ -51,7 +51,7 @@ function DI.gradient!(
 end
 
 function DI.gradient(
-    f, ::AnyAutoForwardDiff, x::AbstractArray, extras::ForwardDiffGradientExtras
+    f, ::AutoForwardDiff, x::AbstractArray, extras::ForwardDiffGradientExtras
 )
     return gradient(f, x, extras.config)
 end
@@ -62,14 +62,14 @@ struct ForwardDiffOneArgJacobianExtras{C} <: JacobianExtras
     config::C
 end
 
-function DI.prepare_jacobian(f, backend::AnyAutoForwardDiff, x::AbstractArray)
+function DI.prepare_jacobian(f, backend::AutoForwardDiff, x::AbstractArray)
     return ForwardDiffOneArgJacobianExtras(JacobianConfig(f, x, choose_chunk(backend, x)))
 end
 
 function DI.value_and_jacobian!(
     f,
     jac::AbstractMatrix,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffOneArgJacobianExtras,
 )
@@ -80,7 +80,7 @@ function DI.value_and_jacobian!(
 end
 
 function DI.value_and_jacobian(
-    f, ::AnyAutoForwardDiff, x::AbstractArray, extras::ForwardDiffOneArgJacobianExtras
+    f, ::AutoForwardDiff, x::AbstractArray, extras::ForwardDiffOneArgJacobianExtras
 )
     return f(x), jacobian(f, x, extras.config)
 end
@@ -88,7 +88,7 @@ end
 function DI.jacobian!(
     f,
     jac::AbstractMatrix,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffOneArgJacobianExtras,
 )
@@ -96,7 +96,7 @@ function DI.jacobian!(
 end
 
 function DI.jacobian(
-    f, ::AnyAutoForwardDiff, x::AbstractArray, extras::ForwardDiffOneArgJacobianExtras
+    f, ::AutoForwardDiff, x::AbstractArray, extras::ForwardDiffOneArgJacobianExtras
 )
     return jacobian(f, x, extras.config)
 end
@@ -107,14 +107,14 @@ struct ForwardDiffHessianExtras{C} <: HessianExtras
     config::C
 end
 
-function DI.prepare_hessian(f, backend::AnyAutoForwardDiff, x::AbstractArray)
+function DI.prepare_hessian(f, backend::AutoForwardDiff, x::AbstractArray)
     return ForwardDiffHessianExtras(HessianConfig(f, x, choose_chunk(backend, x)))
 end
 
 function DI.hessian!(
     f,
     hess::AbstractMatrix,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffHessianExtras,
 )
@@ -122,7 +122,7 @@ function DI.hessian!(
 end
 
 function DI.hessian(
-    f, ::AnyAutoForwardDiff, x::AbstractArray, extras::ForwardDiffHessianExtras
+    f, ::AutoForwardDiff, x::AbstractArray, extras::ForwardDiffHessianExtras
 )
     return hessian(f, x, extras.config)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -1,6 +1,6 @@
-DI.prepare_pushforward(f!, y, ::AnyAutoForwardDiff, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AutoForwardDiff, x) = NoPushforwardExtras()
 
-function DI.value_and_pushforward(f!, y, ::AnyAutoForwardDiff, x, dx, ::NoPushforwardExtras)
+function DI.value_and_pushforward(f!, y, ::AutoForwardDiff, x, dx, ::NoPushforwardExtras)
     T = tag_type(f!, x)
     xdual = make_dual(T, x, dx)
     ydual = make_dual(T, y, similar(y))
@@ -16,14 +16,14 @@ struct ForwardDiffTwoArgDerivativeExtras{C} <: DerivativeExtras
     config::C
 end
 
-function DI.prepare_derivative(f!, y::AbstractArray, ::AnyAutoForwardDiff, x::Number)
+function DI.prepare_derivative(f!, y::AbstractArray, ::AutoForwardDiff, x::Number)
     return ForwardDiffTwoArgDerivativeExtras(DerivativeConfig(f!, y, x))
 end
 
 function DI.value_and_derivative(
     f!,
     y::AbstractArray,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::Number,
     extras::ForwardDiffTwoArgDerivativeExtras,
 )
@@ -36,7 +36,7 @@ function DI.value_and_derivative!(
     f!,
     y::AbstractArray,
     der::AbstractArray,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::Number,
     extras::ForwardDiffTwoArgDerivativeExtras,
 )
@@ -48,7 +48,7 @@ end
 function DI.derivative(
     f!,
     y::AbstractArray,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::Number,
     extras::ForwardDiffTwoArgDerivativeExtras,
 )
@@ -60,7 +60,7 @@ function DI.derivative!(
     f!,
     y::AbstractArray,
     der::AbstractArray,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::Number,
     extras::ForwardDiffTwoArgDerivativeExtras,
 )
@@ -75,7 +75,7 @@ struct ForwardDiffTwoArgJacobianExtras{C} <: JacobianExtras
 end
 
 function DI.prepare_jacobian(
-    f!, y::AbstractArray, backend::AnyAutoForwardDiff, x::AbstractArray
+    f!, y::AbstractArray, backend::AutoForwardDiff, x::AbstractArray
 )
     return ForwardDiffTwoArgJacobianExtras(
         JacobianConfig(f!, y, x, choose_chunk(backend, x))
@@ -85,7 +85,7 @@ end
 function DI.value_and_jacobian(
     f!,
     y::AbstractArray,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffTwoArgJacobianExtras,
 )
@@ -99,7 +99,7 @@ function DI.value_and_jacobian!(
     f!,
     y::AbstractArray,
     jac::AbstractMatrix,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffTwoArgJacobianExtras,
 )
@@ -111,7 +111,7 @@ end
 function DI.jacobian(
     f!,
     y::AbstractArray,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffTwoArgJacobianExtras,
 )
@@ -123,7 +123,7 @@ function DI.jacobian!(
     f!,
     y::AbstractArray,
     jac::AbstractMatrix,
-    ::AnyAutoForwardDiff,
+    ::AutoForwardDiff,
     x::AbstractArray,
     extras::ForwardDiffTwoArgJacobianExtras,
 )

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -1,6 +1,6 @@
 
-choose_chunk(::AnyAutoForwardDiff{nothing}, x) = Chunk(x)
-choose_chunk(::AnyAutoForwardDiff{C}, x) where {C} = Chunk{C}()
+choose_chunk(::AutoForwardDiff{nothing}, x) = Chunk(x)
+choose_chunk(::AutoForwardDiff{C}, x) where {C} = Chunk{C}()
 
 tag_type(::F, x::Number) where {F} = Tag{F,typeof(x)}
 tag_type(::F, x::AbstractArray) where {F} = Tag{F,eltype(x)}

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
@@ -22,9 +22,7 @@ using PolyesterForwardDiff: threaded_gradient!, threaded_jacobian!
 using PolyesterForwardDiff.ForwardDiff: Chunk
 using PolyesterForwardDiff.ForwardDiff.DiffResults: DiffResults
 
-const AnyAutoPolyForwardDiff{C} = Union{
-    AutoPolyesterForwardDiff{C},AutoSparsePolyesterForwardDiff{C}
-}
+DI.check_available(::AutoPolyesterForwardDiff) = true
 
 function single_threaded(::AutoPolyesterForwardDiff{C}) where {C}
     return AutoForwardDiff{C,Nothing}(nothing)

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/onearg.jl
@@ -1,112 +1,114 @@
 
 ## Pushforward
 
-function DI.prepare_pushforward(f, backend::AnyAutoPolyForwardDiff, x)
+function DI.prepare_pushforward(f, backend::AutoPolyesterForwardDiff, x)
     return DI.prepare_pushforward(f, single_threaded(backend), x)
 end
 
 function DI.value_and_pushforward(
-    f, backend::AnyAutoPolyForwardDiff, x, dx, extras::PushforwardExtras
+    f, backend::AutoPolyesterForwardDiff, x, dx, extras::PushforwardExtras
 )
     return DI.value_and_pushforward(f, single_threaded(backend), x, dx, extras)
 end
 
 function DI.value_and_pushforward!(
-    f, dy, backend::AnyAutoPolyForwardDiff, x, dx, extras::PushforwardExtras
+    f, dy, backend::AutoPolyesterForwardDiff, x, dx, extras::PushforwardExtras
 )
     return DI.value_and_pushforward!(f, dy, single_threaded(backend), x, dx, extras)
 end
 
 function DI.pushforward(
-    f, backend::AnyAutoPolyForwardDiff, x, dx, extras::PushforwardExtras
+    f, backend::AutoPolyesterForwardDiff, x, dx, extras::PushforwardExtras
 )
     return DI.pushforward(f, single_threaded(backend), x, dx, extras)
 end
 
 function DI.pushforward!(
-    f, dy, backend::AnyAutoPolyForwardDiff, x, dx, extras::PushforwardExtras
+    f, dy, backend::AutoPolyesterForwardDiff, x, dx, extras::PushforwardExtras
 )
     return DI.pushforward!(f, dy, single_threaded(backend), x, dx, extras)
 end
 
 ## Derivative
 
-function DI.prepare_derivative(f, backend::AnyAutoPolyForwardDiff, x)
+function DI.prepare_derivative(f, backend::AutoPolyesterForwardDiff, x)
     return DI.prepare_derivative(f, single_threaded(backend), x)
 end
 
 function DI.value_and_derivative(
-    f, backend::AnyAutoPolyForwardDiff, x, extras::DerivativeExtras
+    f, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
 )
     return DI.value_and_derivative(f, single_threaded(backend), x, extras)
 end
 
 function DI.value_and_derivative!(
-    f, dy, backend::AnyAutoPolyForwardDiff, x, extras::DerivativeExtras
+    f, dy, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
 )
     return DI.value_and_derivative!(f, dy, single_threaded(backend), x, extras)
 end
 
-function DI.derivative(f, backend::AnyAutoPolyForwardDiff, x, extras::DerivativeExtras)
+function DI.derivative(f, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras)
     return DI.derivative(f, single_threaded(backend), x, extras)
 end
 
-function DI.derivative!(f, dy, backend::AnyAutoPolyForwardDiff, x, extras::DerivativeExtras)
+function DI.derivative!(
+    f, dy, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
+)
     return DI.derivative!(f, dy, single_threaded(backend), x, extras)
 end
 
 ## Gradient
 
-function DI.prepare_gradient(f, backend::AnyAutoPolyForwardDiff, x)
+function DI.prepare_gradient(f, backend::AutoPolyesterForwardDiff, x)
     return DI.prepare_gradient(f, single_threaded(backend), x)
 end
 
 function DI.value_and_gradient!(
-    f, grad, ::AnyAutoPolyForwardDiff{C}, x::AbstractVector, ::GradientExtras
+    f, grad, ::AutoPolyesterForwardDiff{C}, x::AbstractVector, ::GradientExtras
 ) where {C}
     threaded_gradient!(f, grad, x, Chunk{C}())
     return f(x), grad
 end
 
 function DI.gradient!(
-    f, grad, ::AnyAutoPolyForwardDiff{C}, x::AbstractVector, ::GradientExtras
+    f, grad, ::AutoPolyesterForwardDiff{C}, x::AbstractVector, ::GradientExtras
 ) where {C}
     threaded_gradient!(f, grad, x, Chunk{C}())
     return grad
 end
 
 function DI.value_and_gradient!(
-    f, grad, backend::AnyAutoPolyForwardDiff{C}, x::AbstractArray, extras::GradientExtras
+    f, grad, backend::AutoPolyesterForwardDiff{C}, x::AbstractArray, extras::GradientExtras
 ) where {C}
     return DI.value_and_gradient!(f, grad, single_threaded(backend), x, extras)
 end
 
 function DI.gradient!(
-    f, grad, backend::AnyAutoPolyForwardDiff{C}, x::AbstractArray, extras::GradientExtras
+    f, grad, backend::AutoPolyesterForwardDiff{C}, x::AbstractArray, extras::GradientExtras
 ) where {C}
     return DI.gradient!(f, grad, single_threaded(backend), x, extras)
 end
 
 function DI.value_and_gradient(
-    f, backend::AnyAutoPolyForwardDiff, x::AbstractArray, extras::GradientExtras
+    f, backend::AutoPolyesterForwardDiff, x::AbstractArray, extras::GradientExtras
 )
     return DI.value_and_gradient!(f, similar(x), backend, x, extras)
 end
 
 function DI.gradient(
-    f, backend::AnyAutoPolyForwardDiff, x::AbstractArray, extras::GradientExtras
+    f, backend::AutoPolyesterForwardDiff, x::AbstractArray, extras::GradientExtras
 )
     return DI.gradient!(f, similar(x), backend, x, extras)
 end
 
 ## Jacobian
 
-DI.prepare_jacobian(f, ::AnyAutoPolyForwardDiff, x) = NoJacobianExtras()
+DI.prepare_jacobian(f, ::AutoPolyesterForwardDiff, x) = NoJacobianExtras()
 
 function DI.value_and_jacobian!(
     f,
     jac::AbstractMatrix,
-    ::AnyAutoPolyForwardDiff{C},
+    ::AutoPolyesterForwardDiff{C},
     x::AbstractArray,
     ::NoJacobianExtras,
 ) where {C}
@@ -116,7 +118,7 @@ end
 function DI.jacobian!(
     f,
     jac::AbstractMatrix,
-    ::AnyAutoPolyForwardDiff{C},
+    ::AutoPolyesterForwardDiff{C},
     x::AbstractArray,
     ::NoJacobianExtras,
 ) where {C}
@@ -124,14 +126,14 @@ function DI.jacobian!(
 end
 
 function DI.value_and_jacobian(
-    f, backend::AnyAutoPolyForwardDiff, x::AbstractArray, extras::NoJacobianExtras
+    f, backend::AutoPolyesterForwardDiff, x::AbstractArray, extras::NoJacobianExtras
 )
     y = f(x)
     return DI.value_and_jacobian!(f, similar(y, length(y), length(x)), backend, x, extras)
 end
 
 function DI.jacobian(
-    f, backend::AnyAutoPolyForwardDiff, x::AbstractArray, extras::NoJacobianExtras
+    f, backend::AutoPolyesterForwardDiff, x::AbstractArray, extras::NoJacobianExtras
 )
     y = f(x)
     return DI.jacobian!(f, similar(y, length(y), length(x)), backend, x, extras)
@@ -139,14 +141,14 @@ end
 
 ## Hessian
 
-function DI.prepare_hessian(f, backend::AnyAutoPolyForwardDiff, x)
+function DI.prepare_hessian(f, backend::AutoPolyesterForwardDiff, x)
     return DI.prepare_hessian(f, single_threaded(backend), x)
 end
 
-function DI.hessian(f, backend::AnyAutoPolyForwardDiff, x, extras::HessianExtras)
+function DI.hessian(f, backend::AutoPolyesterForwardDiff, x, extras::HessianExtras)
     return DI.hessian(f, single_threaded(backend), x, extras)
 end
 
-function DI.hessian!(f, dy, backend::AnyAutoPolyForwardDiff, x, extras::HessianExtras)
+function DI.hessian!(f, dy, backend::AutoPolyesterForwardDiff, x, extras::HessianExtras)
     return DI.hessian!(f, dy, single_threaded(backend), x, extras)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/twoarg.jl
@@ -1,67 +1,69 @@
 ## Pushforward
 
-function DI.prepare_pushforward(f!, y, backend::AnyAutoPolyForwardDiff, x)
+function DI.prepare_pushforward(f!, y, backend::AutoPolyesterForwardDiff, x)
     return DI.prepare_pushforward(f!, y, single_threaded(backend), x)
 end
 
 function DI.value_and_pushforward(
-    f!, y, backend::AnyAutoPolyForwardDiff, x, dx, extras::PushforwardExtras
+    f!, y, backend::AutoPolyesterForwardDiff, x, dx, extras::PushforwardExtras
 )
     return DI.value_and_pushforward(f!, y, single_threaded(backend), x, dx, extras)
 end
 
 function DI.value_and_pushforward!(
-    f!, y, dy, backend::AnyAutoPolyForwardDiff, x, dx, extras::PushforwardExtras
+    f!, y, dy, backend::AutoPolyesterForwardDiff, x, dx, extras::PushforwardExtras
 )
     return DI.value_and_pushforward!(f!, y, dy, single_threaded(backend), x, dx, extras)
 end
 
 function DI.pushforward(
-    f!, y, backend::AnyAutoPolyForwardDiff, x, dx, extras::PushforwardExtras
+    f!, y, backend::AutoPolyesterForwardDiff, x, dx, extras::PushforwardExtras
 )
     return DI.pushforward(f!, y, single_threaded(backend), x, dx, extras)
 end
 
 function DI.pushforward!(
-    f!, y, dy, backend::AnyAutoPolyForwardDiff, x, dx, extras::PushforwardExtras
+    f!, y, dy, backend::AutoPolyesterForwardDiff, x, dx, extras::PushforwardExtras
 )
     return DI.pushforward!(f!, y, dy, single_threaded(backend), x, dx, extras)
 end
 
 ## Derivative
 
-function DI.prepare_derivative(f!, y, backend::AnyAutoPolyForwardDiff, x)
+function DI.prepare_derivative(f!, y, backend::AutoPolyesterForwardDiff, x)
     return DI.prepare_derivative(f!, y, single_threaded(backend), x)
 end
 
 function DI.value_and_derivative(
-    f!, y, backend::AnyAutoPolyForwardDiff, x, extras::DerivativeExtras
+    f!, y, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
 )
     return DI.value_and_derivative(f!, y, single_threaded(backend), x, extras)
 end
 
 function DI.value_and_derivative!(
-    f!, y, der, backend::AnyAutoPolyForwardDiff, x, extras::DerivativeExtras
+    f!, y, der, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
 )
     return DI.value_and_derivative!(f!, y, der, single_threaded(backend), x, extras)
 end
 
-function DI.derivative(f!, y, backend::AnyAutoPolyForwardDiff, x, extras::DerivativeExtras)
+function DI.derivative(
+    f!, y, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
+)
     return DI.derivative(f!, y, single_threaded(backend), x, extras)
 end
 
 function DI.derivative!(
-    f!, y, der, backend::AnyAutoPolyForwardDiff, x, extras::DerivativeExtras
+    f!, y, der, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
 )
     return DI.derivative!(f!, y, der, single_threaded(backend), x, extras)
 end
 
 ## Jacobian
 
-DI.prepare_jacobian(f!, y, ::AnyAutoPolyForwardDiff, x) = NoJacobianExtras()
+DI.prepare_jacobian(f!, y, ::AutoPolyesterForwardDiff, x) = NoJacobianExtras()
 
 function DI.value_and_jacobian(
-    f!, y, ::AnyAutoPolyForwardDiff{C}, x, ::NoJacobianExtras
+    f!, y, ::AutoPolyesterForwardDiff{C}, x, ::NoJacobianExtras
 ) where {C}
     jac = similar(y, length(y), length(x))
     threaded_jacobian!(f!, y, jac, x, Chunk{C}())
@@ -70,21 +72,21 @@ function DI.value_and_jacobian(
 end
 
 function DI.value_and_jacobian!(
-    f!, y, jac, ::AnyAutoPolyForwardDiff{C}, x, ::NoJacobianExtras
+    f!, y, jac, ::AutoPolyesterForwardDiff{C}, x, ::NoJacobianExtras
 ) where {C}
     threaded_jacobian!(f!, y, jac, x, Chunk{C}())
     f!(y, x)
     return y, jac
 end
 
-function DI.jacobian(f!, y, ::AnyAutoPolyForwardDiff{C}, x, ::NoJacobianExtras) where {C}
+function DI.jacobian(f!, y, ::AutoPolyesterForwardDiff{C}, x, ::NoJacobianExtras) where {C}
     jac = similar(y, length(y), length(x))
     threaded_jacobian!(f!, y, jac, x, Chunk{C}())
     return jac
 end
 
 function DI.jacobian!(
-    f!, y, jac, ::AnyAutoPolyForwardDiff{C}, x, ::NoJacobianExtras
+    f!, y, jac, ::AutoPolyesterForwardDiff{C}, x, ::NoJacobianExtras
 ) where {C}
     threaded_jacobian!(f!, y, jac, x, Chunk{C}())
     return jac

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/DifferentiationInterfaceReverseDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/DifferentiationInterfaceReverseDiffExt.jl
@@ -25,7 +25,7 @@ using ReverseDiff:
     jacobian,
     jacobian!
 
-const AnyAutoReverseDiff = Union{AutoReverseDiff,AutoSparseReverseDiff}
+DI.check_available(::AutoReverseDiff) = true
 
 include("onearg.jl")
 include("twoarg.jl")

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
@@ -1,9 +1,9 @@
 ## Pullback
 
-DI.prepare_pullback(f, ::AnyAutoReverseDiff, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoReverseDiff, x) = NoPullbackExtras()
 
 function DI.value_and_pullback(
-    f, ::AnyAutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
+    f, ::AutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
 )
     y = f(x)
     dx = if y isa Number
@@ -15,7 +15,7 @@ function DI.value_and_pullback(
 end
 
 function DI.value_and_pullback!(
-    f, dx, ::AnyAutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
+    f, dx, ::AutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
 )
     y = f(x)
     dx = if y isa Number
@@ -28,7 +28,7 @@ function DI.value_and_pullback!(
 end
 
 function DI.value_and_pullback(
-    f, backend::AnyAutoReverseDiff, x::Number, dy, ::NoPullbackExtras
+    f, backend::AutoReverseDiff, x::Number, dy, ::NoPullbackExtras
 )
     x_array = [x]
     f_array = f ∘ only
@@ -42,7 +42,7 @@ struct ReverseDiffGradientExtras{T} <: GradientExtras
     tape::T
 end
 
-function DI.prepare_gradient(f, backend::AnyAutoReverseDiff, x::AbstractArray)
+function DI.prepare_gradient(f, backend::AutoReverseDiff, x::AbstractArray)
     tape = GradientTape(f, x)
     if backend.compile
         tape = compile(tape)
@@ -53,7 +53,7 @@ end
 function DI.value_and_gradient!(
     _f,
     grad::AbstractArray,
-    ::AnyAutoReverseDiff,
+    ::AutoReverseDiff,
     x::AbstractArray,
     extras::ReverseDiffGradientExtras,
 )
@@ -63,7 +63,7 @@ function DI.value_and_gradient!(
 end
 
 function DI.value_and_gradient(
-    f, backend::AnyAutoReverseDiff, x::AbstractArray, extras::ReverseDiffGradientExtras
+    f, backend::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffGradientExtras
 )
     grad = similar(x)
     return DI.value_and_gradient!(f, grad, backend, x, extras)
@@ -72,7 +72,7 @@ end
 function DI.gradient!(
     _f,
     grad::AbstractArray,
-    ::AnyAutoReverseDiff,
+    ::AutoReverseDiff,
     x::AbstractArray,
     extras::ReverseDiffGradientExtras,
 )
@@ -80,7 +80,7 @@ function DI.gradient!(
 end
 
 function DI.gradient(
-    _f, ::AnyAutoReverseDiff, x::AbstractArray, extras::ReverseDiffGradientExtras
+    _f, ::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffGradientExtras
 )
     return gradient!(extras.tape, x)
 end
@@ -91,7 +91,7 @@ struct ReverseDiffOneArgJacobianExtras{T} <: JacobianExtras
     tape::T
 end
 
-function DI.prepare_jacobian(f, backend::AnyAutoReverseDiff, x::AbstractArray)
+function DI.prepare_jacobian(f, backend::AutoReverseDiff, x::AbstractArray)
     tape = JacobianTape(f, x)
     if backend.compile
         tape = compile(tape)
@@ -102,7 +102,7 @@ end
 function DI.value_and_jacobian!(
     f,
     jac::AbstractMatrix,
-    ::AnyAutoReverseDiff,
+    ::AutoReverseDiff,
     x::AbstractArray,
     extras::ReverseDiffOneArgJacobianExtras,
 )
@@ -113,7 +113,7 @@ function DI.value_and_jacobian!(
 end
 
 function DI.value_and_jacobian(
-    f, ::AnyAutoReverseDiff, x::AbstractArray, extras::ReverseDiffOneArgJacobianExtras
+    f, ::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffOneArgJacobianExtras
 )
     return f(x), jacobian!(extras.tape, x)
 end
@@ -121,7 +121,7 @@ end
 function DI.jacobian!(
     _f,
     jac::AbstractMatrix,
-    ::AnyAutoReverseDiff,
+    ::AutoReverseDiff,
     x::AbstractArray,
     extras::ReverseDiffOneArgJacobianExtras,
 )
@@ -129,7 +129,7 @@ function DI.jacobian!(
 end
 
 function DI.jacobian(
-    f, ::AnyAutoReverseDiff, x::AbstractArray, extras::ReverseDiffOneArgJacobianExtras
+    f, ::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffOneArgJacobianExtras
 )
     return jacobian!(extras.tape, x)
 end
@@ -140,7 +140,7 @@ struct ReverseDiffHessianExtras{T} <: HessianExtras
     tape::T
 end
 
-function DI.prepare_hessian(f, backend::AnyAutoReverseDiff, x::AbstractArray)
+function DI.prepare_hessian(f, backend::AutoReverseDiff, x::AbstractArray)
     tape = HessianTape(f, x)
     if backend.compile
         tape = compile(tape)
@@ -151,7 +151,7 @@ end
 function DI.hessian!(
     _f,
     hess::AbstractMatrix,
-    ::AnyAutoReverseDiff,
+    ::AutoReverseDiff,
     x::AbstractArray,
     extras::ReverseDiffHessianExtras,
 )
@@ -159,7 +159,7 @@ function DI.hessian!(
 end
 
 function DI.hessian(
-    _f, ::AnyAutoReverseDiff, x::AbstractArray, extras::ReverseDiffHessianExtras
+    _f, ::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffHessianExtras
 )
     return hessian!(extras.tape, x)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
@@ -1,11 +1,11 @@
 ## Pullback
 
-DI.prepare_pullback(f!, y, ::AnyAutoReverseDiff, x) = NoPullbackExtras()
+DI.prepare_pullback(f!, y, ::AutoReverseDiff, x) = NoPullbackExtras()
 
 ### Array in
 
 function DI.value_and_pullback(
-    f!, y, ::AnyAutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
+    f!, y, ::AutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
 )
     function dotproduct_closure(x)
         y_copy = similar(y, eltype(x))
@@ -18,7 +18,7 @@ function DI.value_and_pullback(
 end
 
 function DI.value_and_pullback!(
-    f!, y, dx, ::AnyAutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
+    f!, y, dx, ::AutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
 )
     function dotproduct_closure(x)
         y_copy = similar(y, eltype(x))
@@ -30,7 +30,7 @@ function DI.value_and_pullback!(
     return y, dx
 end
 
-function DI.pullback(f!, y, ::AnyAutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras)
+function DI.pullback(f!, y, ::AutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras)
     function dotproduct_closure(x)
         y_copy = similar(y, eltype(x))
         f!(y_copy, x)
@@ -41,7 +41,7 @@ function DI.pullback(f!, y, ::AnyAutoReverseDiff, x::AbstractArray, dy, ::NoPull
 end
 
 function DI.pullback!(
-    f!, y, dx, ::AnyAutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
+    f!, y, dx, ::AutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras
 )
     function dotproduct_closure(x)
         y_copy = similar(y, eltype(x))
@@ -55,7 +55,7 @@ end
 ### Number in, not supported
 
 function DI.value_and_pullback(
-    f!, y, backend::AnyAutoReverseDiff, x::Number, dy, ::NoPullbackExtras
+    f!, y, backend::AutoReverseDiff, x::Number, dy, ::NoPullbackExtras
 )
     x_array = [x]
     dx_array = similar(x_array)
@@ -72,7 +72,7 @@ struct ReverseDiffTwoArgJacobianExtras{T} <: JacobianExtras
 end
 
 function DI.prepare_jacobian(
-    f!, y::AbstractArray, backend::AnyAutoReverseDiff, x::AbstractArray
+    f!, y::AbstractArray, backend::AutoReverseDiff, x::AbstractArray
 )
     tape = JacobianTape(f!, y, x)
     if backend.compile
@@ -82,7 +82,7 @@ function DI.prepare_jacobian(
 end
 
 function DI.value_and_jacobian(
-    _f!, y, ::AnyAutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
+    _f!, y, ::AutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
 )
     jac = similar(y, length(y), length(x))
     result = DiffResults.DiffResult(y, jac)
@@ -91,22 +91,20 @@ function DI.value_and_jacobian(
 end
 
 function DI.value_and_jacobian!(
-    _f!, y, jac, ::AnyAutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
+    _f!, y, jac, ::AutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
 )
     result = DiffResults.DiffResult(y, jac)
     result = jacobian!(result, extras.tape, x)
     return DiffResults.value(result), DiffResults.derivative(result)
 end
 
-function DI.jacobian(
-    _f!, _y, ::AnyAutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
-)
+function DI.jacobian(_f!, _y, ::AutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras)
     jac = jacobian!(extras.tape, x)
     return jac
 end
 
 function DI.jacobian!(
-    _f!, _y, jac, ::AnyAutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
+    _f!, _y, jac, ::AutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
 )
     jac = jacobian!(jac, extras.tape, x)
     return jac

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/DifferentiationInterfaceSparseDiffToolsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/DifferentiationInterfaceSparseDiffToolsExt.jl
@@ -5,7 +5,6 @@ import DifferentiationInterface as DI
 using DifferentiationInterface:
     HessianExtras, JacobianExtras, NoHessianExtras, SecondOrder, inner, outer
 using SparseDiffTools:
-    AutoSparseEnzyme,
     JacPrototypeSparsityDetection,
     SymbolicsSparsityDetection,
     sparse_jacobian,
@@ -13,15 +12,34 @@ using SparseDiffTools:
     sparse_jacobian_cache
 using Symbolics: Symbolics
 
-# used with @eval to avoid Unions and thus ambiguities
-SPARSE_BACKENDS = [
-    AutoSparseEnzyme,
+AnyOneArgAutoSparse = Union{
     AutoSparseFiniteDiff,
     AutoSparseForwardDiff,
     AutoSparsePolyesterForwardDiff,
     AutoSparseReverseDiff,
     AutoSparseZygote,
-]
+}
+
+AnyTwoArgAutoSparse = Union{
+    AutoSparseFiniteDiff,
+    AutoSparseForwardDiff,
+    AutoSparsePolyesterForwardDiff,
+    AutoSparseReverseDiff,
+}
+
+DI.check_available(::AnyOneArgAutoSparse) = true
+
+dense(::AutoSparseFiniteDiff) = AutoFiniteDiff()
+dense(backend::AutoSparseReverseDiff) = AutoReverseDiff(backend.compile)
+dense(::AutoSparseZygote) = AutoZygote()
+
+function dense(backend::AutoSparseForwardDiff{chunksize,T}) where {chunksize,T}
+    return AutoForwardDiff{chunksize,T}(backend.tag)
+end
+
+function dense(::AutoSparsePolyesterForwardDiff{chunksize}) where {chunksize}
+    return AutoSparsePolyesterForwardDiff{chunksize}()
+end
 
 include("onearg.jl")
 include("twoarg.jl")

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseDiffToolsExt/twoarg.jl
@@ -2,47 +2,41 @@ struct SparseDiffToolsTwoArgJacobianExtras{C} <: JacobianExtras
     cache::C
 end
 
-for AutoSparse in SPARSE_BACKENDS
-    @eval begin
-        ## Jacobian
+## Jacobian
 
-        function DI.prepare_jacobian(
-            f!, y::AbstractArray, backend::$AutoSparse, x::AbstractArray
-        )
-            cache = sparse_jacobian_cache(
-                backend, SymbolicsSparsityDetection(), f!, similar(y), x
-            )
-            return SparseDiffToolsTwoArgJacobianExtras(cache)
-        end
+function DI.prepare_jacobian(
+    f!, y::AbstractArray, backend::AnyTwoArgAutoSparse, x::AbstractArray
+)
+    cache = sparse_jacobian_cache(backend, SymbolicsSparsityDetection(), f!, similar(y), x)
+    return SparseDiffToolsTwoArgJacobianExtras(cache)
+end
 
-        function DI.value_and_jacobian(
-            f!, y, backend::$AutoSparse, x, extras::SparseDiffToolsTwoArgJacobianExtras
-        )
-            jac = sparse_jacobian(backend, extras.cache, f!, y, x)
-            f!(y, x)
-            return y, jac
-        end
+function DI.value_and_jacobian(
+    f!, y, backend::AnyTwoArgAutoSparse, x, extras::SparseDiffToolsTwoArgJacobianExtras
+)
+    jac = sparse_jacobian(backend, extras.cache, f!, y, x)
+    f!(y, x)
+    return y, jac
+end
 
-        function DI.value_and_jacobian!(
-            f!, y, jac, backend::$AutoSparse, x, extras::SparseDiffToolsTwoArgJacobianExtras
-        )
-            sparse_jacobian!(jac, backend, extras.cache, f!, y, x)
-            f!(y, x)
-            return y, jac
-        end
+function DI.value_and_jacobian!(
+    f!, y, jac, backend::AnyTwoArgAutoSparse, x, extras::SparseDiffToolsTwoArgJacobianExtras
+)
+    sparse_jacobian!(jac, backend, extras.cache, f!, y, x)
+    f!(y, x)
+    return y, jac
+end
 
-        function DI.jacobian(
-            f!, y, backend::$AutoSparse, x, extras::SparseDiffToolsTwoArgJacobianExtras
-        )
-            jac = sparse_jacobian(backend, extras.cache, f!, y, x)
-            return jac
-        end
+function DI.jacobian(
+    f!, y, backend::AnyTwoArgAutoSparse, x, extras::SparseDiffToolsTwoArgJacobianExtras
+)
+    jac = sparse_jacobian(backend, extras.cache, f!, y, x)
+    return jac
+end
 
-        function DI.jacobian!(
-            f!, y, jac, backend::$AutoSparse, x, extras::SparseDiffToolsTwoArgJacobianExtras
-        )
-            sparse_jacobian!(jac, backend, extras.cache, f!, y, x)
-            return jac
-        end
-    end
+function DI.jacobian!(
+    f!, y, jac, backend::AnyTwoArgAutoSparse, x, extras::SparseDiffToolsTwoArgJacobianExtras
+)
+    sparse_jacobian!(jac, backend, extras.cache, f!, y, x)
+    return jac
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/DifferentiationInterfaceTapirExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/DifferentiationInterfaceTapirExt.jl
@@ -17,6 +17,8 @@ using Tapir:
     zero_codual,
     zero_tangent
 
+DI.check_available(::AutoTapir) = true
+
 include("onearg.jl")
 include("twoarg.jl")
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -5,6 +5,7 @@ import DifferentiationInterface as DI
 using DifferentiationInterface: NoGradientExtras, NoPullbackExtras
 using Tracker: Tracker, back, data, forward, gradient, jacobian, param, withgradient
 
+DI.check_available(::AutoTracker) = true
 DI.supports_mutation(::AutoTracker) = DI.MutationNotSupported()
 
 ## Pullback

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -8,87 +8,82 @@ using DocStringExtensions
 using Zygote:
     ZygoteRuleConfig, gradient, hessian, jacobian, pullback, withgradient, withjacobian
 
-const AnyAutoZygote = Union{AutoZygote,AutoSparseZygote}
-
-DI.supports_mutation(::AnyAutoZygote) = DI.MutationNotSupported()
+DI.check_available(::AutoZygote) = true
+DI.supports_mutation(::Union{AutoZygote,AutoSparseZygote}) = DI.MutationNotSupported()
 
 ## Pullback
 
-DI.prepare_pullback(f, ::AnyAutoZygote, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoZygote, x) = NoPullbackExtras()
 
-function DI.value_and_pullback_split(f, ::AnyAutoZygote, x, ::NoPullbackExtras)
+function DI.value_and_pullback_split(f, ::AutoZygote, x, ::NoPullbackExtras)
     y, back = pullback(f, x)
     pullbackfunc(dy) = only(back(dy))
     return y, pullbackfunc
 end
 
-function DI.value_and_pullback!_split(
-    f, backend::AnyAutoZygote, x, extras::NoPullbackExtras
-)
+function DI.value_and_pullback!_split(f, backend::AutoZygote, x, extras::NoPullbackExtras)
     y, pullbackfunc = DI.value_and_pullback_split(f, backend, x, extras)
     pullbackfunc!(dx, dy) = copyto!(dx, pullbackfunc(dy))
     return y, pullbackfunc!
 end
 
-function DI.value_and_pullback(f, backend::AnyAutoZygote, x, dy, extras::NoPullbackExtras)
+function DI.value_and_pullback(f, backend::AutoZygote, x, dy, extras::NoPullbackExtras)
     y, pullbackfunc = DI.value_and_pullback_split(f, backend, x, extras)
     return y, pullbackfunc(dy)
 end
 
 ## Gradient
 
-DI.prepare_gradient(f, ::AnyAutoZygote, x) = NoGradientExtras()
+DI.prepare_gradient(f, ::AutoZygote, x) = NoGradientExtras()
 
-function DI.value_and_gradient(f, ::AnyAutoZygote, x, ::NoGradientExtras)
+function DI.value_and_gradient(f, ::AutoZygote, x, ::NoGradientExtras)
     (; val, grad) = withgradient(f, x)
     return val, only(grad)
 end
 
-function DI.gradient(f, ::AnyAutoZygote, x, ::NoGradientExtras)
+function DI.gradient(f, ::AutoZygote, x, ::NoGradientExtras)
     return only(gradient(f, x))
 end
 
-function DI.value_and_gradient!(
-    f, grad, backend::AnyAutoZygote, x, extras::NoGradientExtras
-)
+function DI.value_and_gradient!(f, grad, backend::AutoZygote, x, extras::NoGradientExtras)
     y, new_grad = DI.value_and_gradient(f, backend, x, extras)
     return y, copyto!(grad, new_grad)
 end
 
-function DI.gradient!(f, grad, backend::AnyAutoZygote, x, extras::NoGradientExtras)
+function DI.gradient!(f, grad, backend::AutoZygote, x, extras::NoGradientExtras)
     return copyto!(grad, DI.gradient(f, backend, x, extras))
 end
 
 ## Jacobian
 
-DI.prepare_jacobian(f, ::AnyAutoZygote, x) = NoJacobianExtras()
+DI.prepare_jacobian(f, ::AutoZygote, x) = NoJacobianExtras()
 
-function DI.value_and_jacobian(f, ::AnyAutoZygote, x, ::NoJacobianExtras)
+function DI.value_and_jacobian(f, ::AutoZygote, x, ::NoJacobianExtras)
     return f(x), only(jacobian(f, x))  # https://github.com/FluxML/Zygote.jl/issues/1506
 end
 
-function DI.jacobian(f, ::AnyAutoZygote, x, ::NoJacobianExtras)
+function DI.jacobian(f, ::AutoZygote, x, ::NoJacobianExtras)
     return only(jacobian(f, x))
 end
 
-function DI.value_and_jacobian!(f, jac, backend::AnyAutoZygote, x, extras::NoJacobianExtras)
+function DI.value_and_jacobian!(f, jac, backend::AutoZygote, x, extras::NoJacobianExtras)
     y, new_jac = DI.value_and_jacobian(f, backend, x, extras)
     return y, copyto!(jac, new_jac)
 end
 
-function DI.jacobian!(f, jac, backend::AnyAutoZygote, x, extras::NoJacobianExtras)
+function DI.jacobian!(f, jac, backend::AutoZygote, x, extras::NoJacobianExtras)
     return copyto!(jac, DI.jacobian(f, backend, x, extras))
 end
 
 ## Hessian
 
-DI.prepare_hessian(f, ::AnyAutoZygote, x) = NoHessianExtras()
+DI.prepare_hessian(f, ::AutoZygote, x) = NoHessianExtras()
 
-function DI.hessian(f, ::AnyAutoZygote, x, ::NoHessianExtras)
+function DI.hessian(f, ::AutoZygote, x, ::NoHessianExtras)
     return hessian(f, x)
 end
 
-function DI.hessian!(f, hess, backend::AnyAutoZygote, x, extras::NoHessianExtras)
+function DI.hessian!(f, hess, backend::AutoZygote, x, extras::NoHessianExtras)
     return copyto!(hess, DI.hessian(f, backend, x, extras))
 end
 

--- a/DifferentiationInterface/src/backends.jl
+++ b/DifferentiationInterface/src/backends.jl
@@ -1,54 +1,23 @@
 """
     check_available(backend)
 
-Check whether `backend` is available by trying a gradient.
-
-!!! warning
-    Might take a while due to compilation time.
+Check whether `backend` is available (i.e. whether the extension is loaded).
 """
-function check_available(backend::AbstractADType)
-    try
-        value_and_gradient(sum, backend, [1.0])
-        return true
-    catch exception
-        @warn "Backend $backend not available" exception
-        if exception isa MethodError
-            return false
-        else
-            throw(exception)
-        end
-    end
-end
-
-function square!(y, x)
-    y .= x .^ 2
-    return nothing
-end
+check_available(backend::AbstractADType) = false
 
 """
     check_mutation(backend)
 
-Check whether `backend` supports differentiation of mutating functions by trying a jacobian.
-
-!!! warning
-    Might take a while due to compilation time.
+Check whether `backend` supports differentiation of mutating functions.
 """
-function check_mutation(backend::AbstractADType)
-    try
-        y, jac = value_and_jacobian!(square!, [0.0], [0.0;;], backend, [3.0])
-        return isapprox(y, [9.0]; rtol=1e-3) && isapprox(jac, [6.0;;]; rtol=1e-3)
-    catch exception
-        @warn "Backend $backend does not support mutation" exception
-        return false
-    end
-end
+check_mutation(backend::AbstractADType) = Bool(supports_mutation(backend))
 
 sqnorm(x::AbstractArray) = sum(abs2, x)
 
 """
     check_hessian(backend)
 
-Check whether `backend` supports second order differentiation by trying a hessian.
+Check whether `backend` supports second order differentiation by trying to compute a hessian.
 
 !!! warning
     Might take a while due to compilation time.

--- a/DifferentiationInterface/test/sparsity.jl
+++ b/DifferentiationInterface/test/sparsity.jl
@@ -3,7 +3,6 @@ sparse_backends = [
     AutoSparseForwardDiff(),
     AutoSparseFiniteDiff(),
     AutoSparseZygote(),
-    SparseDiffTools.AutoSparseEnzyme(),
 ]
 
 sparse_second_order_backends = [

--- a/DifferentiationInterface/test/sparsity.jl
+++ b/DifferentiationInterface/test/sparsity.jl
@@ -11,51 +11,18 @@ sparse_second_order_backends = [
     SecondOrder(AutoSparseFiniteDiff(), AutoZygote()),
 ]
 
-##
-
-abs2diff(x) = abs2.(diff(x))
-abs2diff!(y, x) = y .= abs2.(diff(x))
-
-sumabs2diff(x) = sum(abs2diff(x))
-
-function abs2diff_jacobian(x)
-    n = length(x)
-    return SparseArrays.spdiagm(n - 1, n, 0 => -2 * diff(x), 1 => 2 * diff(x))
-end
-
-function sumabs2diff_hessian(x)
-    n = length(x)
-    return SparseArrays.spdiagm(
-        0 => vcat(2.0, fill(4.0, n - 2), 2.0),
-        1 => fill(-2.0, n - 1),
-        -1 => fill(-2.0, n - 1),
-    )
-end
-
 test_differentiation(
     sparse_backends,
-    [
-        JacobianScenario(abs2diff; x=rand(5), ref=abs2diff_jacobian, operator=:outofplace),
-        JacobianScenario(abs2diff; x=rand(5), ref=abs2diff_jacobian, operator=:inplace),
-        JacobianScenario(
-            abs2diff!; x=rand(5), y=zeros(4), ref=abs2diff_jacobian, operator=:outofplace
-        ),
-        JacobianScenario(
-            abs2diff!; x=rand(5), y=zeros(4), ref=abs2diff_jacobian, operator=:inplace
-        ),
-    ];
+    sparse_scenarios(rand(5));
     sparsity=true,
+    second_order=false,
     logging=get(ENV, "CI", "false") == "false",
 )
 
 test_differentiation(
     sparse_second_order_backends,
-    [
-        HessianScenario(
-            sumabs2diff; x=rand(5), ref=sumabs2diff_hessian, operator=:outofplace
-        ),
-        HessianScenario(sumabs2diff; x=rand(5), ref=sumabs2diff_hessian, operator=:inplace),
-    ];
+    sparse_scenarios(rand(5));
     sparsity=true,
+    first_order=false,
     logging=get(ENV, "CI", "false") == "false",
 )

--- a/DifferentiationInterfaceTest/docs/src/api.md
+++ b/DifferentiationInterfaceTest/docs/src/api.md
@@ -20,6 +20,7 @@ benchmark_differentiation
 
 ```@docs
 default_scenarios
+sparse_scenarios
 component_scenarios
 gpu_scenarios
 static_scenarios

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -35,12 +35,13 @@ using JET: @test_call, @test_opt
 using JLArrays: jl
 using LinearAlgebra: Diagonal, dot
 using ProgressMeter: ProgressUnknown, next!
-using SparseArrays: SparseArrays, nnz, SparseMatrixCSC
+using SparseArrays: SparseArrays, SparseMatrixCSC, nnz, spdiagm
 using StaticArrays: MMatrix, MVector, SMatrix, SVector
 using Test: @testset, @test
 
 include("scenarios/scenario.jl")
 include("scenarios/default.jl")
+include("scenarios/sparse.jl")
 include("scenarios/static.jl")
 include("scenarios/component.jl")
 include("scenarios/gpu.jl")
@@ -64,7 +65,7 @@ export PushforwardScenario,
     SecondDerivativeScenario,
     HVPScenario,
     HessianScenario
-export default_scenarios
+export default_scenarios, sparse_scenarios
 export static_scenarios, component_scenarios, gpu_scenarios
 export test_differentiation, benchmark_differentiation
 

--- a/DifferentiationInterfaceTest/src/scenarios/sparse.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/sparse.jl
@@ -1,0 +1,52 @@
+## Vector to vector
+
+abs2diff(x) = abs2.(diff(x))
+
+function abs2diff!(y, x)
+    y .= abs2.(diff(x))
+    return nothing
+end
+
+function abs2diff_jacobian(x)
+    n = length(x)
+    return spdiagm(n - 1, n, 0 => -2 * diff(x), 1 => 2 * diff(x))
+end
+
+## Vector to scalar
+
+sumabs2diff(x) = sum(abs2diff(x))
+
+function sumabs2diff_hessian(x)
+    T = eltype(x)
+    n = length(x)
+    return spdiagm(
+        0 => vcat(2 * one(T), fill(4 * one(T), n - 2), 2 * one(T)),
+        1 => fill(-2 * one(T), n - 1),
+        -1 => fill(-2 * one(T), n - 1),
+    )
+end
+
+## Gather
+
+"""
+    sparse_scenarios()
+
+Create a vector of [`AbstractScenario`](@ref)s with sparse array types, focused on sparse Jacobians and Hessians.
+"""
+function sparse_scenarios(x::AbstractVector)
+    n = length(x)
+    scens = AbstractScenario[]
+    for op in (:outofplace, :inplace)
+        append!(
+            scens,
+            [
+                JacobianScenario(abs2diff; x=x, ref=abs2diff_jacobian, operator=op),
+                JacobianScenario(
+                    abs2diff!; x=x, y=similar(x, n - 1), ref=abs2diff_jacobian, operator=op
+                ),
+                HessianScenario(sumabs2diff; x=x, ref=sumabs2diff_hessian, operator=op),
+            ],
+        )
+    end
+    return scens
+end

--- a/DifferentiationInterfaceTest/src/utils/zero_backends.jl
+++ b/DifferentiationInterfaceTest/src/utils/zero_backends.jl
@@ -10,6 +10,7 @@ Used in testing and benchmarking.
 """
 struct AutoZeroForward <: ADTypes.AbstractForwardMode end
 
+DI.check_available(::AutoZeroForward) = true
 DI.supports_mutation(::AutoZeroForward) = DI.MutationSupported()
 
 DI.prepare_pushforward(f, ::AutoZeroForward, x) = NoPushforwardExtras()
@@ -51,6 +52,7 @@ Used in testing and benchmarking.
 """
 struct AutoZeroReverse <: ADTypes.AbstractReverseMode end
 
+DI.check_available(::AutoZeroReverse) = true
 DI.supports_mutation(::AutoZeroReverse) = DI.MutationSupported()
 
 DI.prepare_pullback(f, ::AutoZeroReverse, x) = NoPullbackExtras()


### PR DESCRIPTION
**Core**

- Change `check_available` and `check_mutation` to avoid relying on a test

**Extensions**

- Only define Jacobian and Hessian for sparse backends