### PR TITLE
Prepare pushforward and pullback with seed

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -18,7 +18,7 @@ DI.mode(::AutoReverseChainRules) = ADTypes.AbstractReverseMode
 
 ## Pullback
 
-DI.prepare_pullback(f, ::AutoReverseChainRules, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoReverseChainRules, x, dy) = NoPullbackExtras()
 
 function DI.value_and_pullback_split(
     f, backend::AutoReverseChainRules, x, ::NoPullbackExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
@@ -12,7 +12,7 @@ DI.mode(::AutoChainRules{<:DiffractorRuleConfig}) = ADTypes.AbstractForwardMode
 
 ## Pushforward
 
-DI.prepare_pushforward(f, ::AutoDiffractor, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f, ::AutoDiffractor, x, dx) = NoPushforwardExtras()
 
 function DI.pushforward(f, ::AutoDiffractor, x, dx, ::NoPushforwardExtras)
     # code copied from Diffractor.jl

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -1,6 +1,6 @@
 ## Pushforward
 
-DI.prepare_pushforward(f, ::AutoForwardEnzyme, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f, ::AutoForwardEnzyme, x, dx) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(
     f, backend::AutoForwardEnzyme, x, dx, ::NoPushforwardExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -1,6 +1,6 @@
 ## Pushforward
 
-DI.prepare_pushforward(f!, y, ::AutoForwardEnzyme, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AutoForwardEnzyme, x, dx) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(
     f!, y, backend::AutoForwardEnzyme, x, dx, ::NoPushforwardExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -1,6 +1,6 @@
 ## Pullback
 
-DI.prepare_pullback(f, ::AutoReverseEnzyme, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoReverseEnzyme, x, dy) = NoPullbackExtras()
 
 ### Out-of-place
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -1,6 +1,6 @@
 ## Pullback
 
-DI.prepare_pullback(f!, y, ::AutoReverseEnzyme, x) = NoPullbackExtras()
+DI.prepare_pullback(f!, y, ::AutoReverseEnzyme, x, dy) = NoPullbackExtras()
 
 function DI.value_and_pullback(
     f!, y, ::AutoReverseEnzyme, x::Number, dy, ::NoPullbackExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
@@ -6,7 +6,7 @@ struct FastDifferentiationOneArgPushforwardExtras{Y,E1,E2} <: PushforwardExtras
     jvp_exe!::E2
 end
 
-function DI.prepare_pushforward(f, ::AnyAutoFastDifferentiation, x)
+function DI.prepare_pushforward(f, ::AnyAutoFastDifferentiation, x, dx)
     y_prototype = f(x)
     x_var = if x isa Number
         only(make_variables(:x))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/twoarg.jl
@@ -5,7 +5,7 @@ struct FastDifferentiationTwoArgPushforwardExtras{E1,E2} <: PushforwardExtras
     jvp_exe!::E2
 end
 
-function DI.prepare_pushforward(f!, y, ::AnyAutoFastDifferentiation, x)
+function DI.prepare_pushforward(f!, y, ::AnyAutoFastDifferentiation, x, dx)
     x_var = if x isa Number
         only(make_variables(:x))
     else

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/onearg.jl
@@ -1,6 +1,6 @@
 ## Pushforward
 
-DI.prepare_pushforward(f, ::AutoFiniteDiff, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f, ::AutoFiniteDiff, x, dx) = NoPushforwardExtras()
 
 function DI.pushforward(f, backend::AutoFiniteDiff, x, dx, ::NoPushforwardExtras)
     step(t::Number) = f(x .+ t .* dx)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/twoarg.jl
@@ -1,6 +1,6 @@
 ## Pushforward
 
-DI.prepare_pushforward(f!, y, ::AutoFiniteDiff, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AutoFiniteDiff, x, dx) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(
     f!, y, backend::AutoFiniteDiff, x, dx, ::NoPushforwardExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
@@ -17,7 +17,7 @@ end
 
 ## Pushforward
 
-DI.prepare_pushforward(f, ::AutoFiniteDifferences, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f, ::AutoFiniteDifferences, x, dx) = NoPushforwardExtras()
 
 function DI.pushforward(f, backend::AutoFiniteDifferences, x, dx, ::NoPushforwardExtras)
     return jvp(backend.fdm, f, (x, dx))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -1,6 +1,6 @@
 ## Pushforward
 
-DI.prepare_pushforward(f, ::AutoForwardDiff, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f, ::AutoForwardDiff, x, dx) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(f, ::AutoForwardDiff, x, dx, ::NoPushforwardExtras)
     T = tag_type(f, x)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -1,4 +1,4 @@
-DI.prepare_pushforward(f!, y, ::AutoForwardDiff, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AutoForwardDiff, x, dx) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(f!, y, ::AutoForwardDiff, x, dx, ::NoPushforwardExtras)
     T = tag_type(f!, x)

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/onearg.jl
@@ -1,8 +1,8 @@
 
 ## Pushforward
 
-function DI.prepare_pushforward(f, backend::AutoPolyesterForwardDiff, x)
-    return DI.prepare_pushforward(f, single_threaded(backend), x)
+function DI.prepare_pushforward(f, backend::AutoPolyesterForwardDiff, x, dx)
+    return DI.prepare_pushforward(f, single_threaded(backend), x, dx)
 end
 
 function DI.value_and_pushforward(

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/twoarg.jl
@@ -1,7 +1,7 @@
 ## Pushforward
 
-function DI.prepare_pushforward(f!, y, backend::AutoPolyesterForwardDiff, x)
-    return DI.prepare_pushforward(f!, y, single_threaded(backend), x)
+function DI.prepare_pushforward(f!, y, backend::AutoPolyesterForwardDiff, x, dx)
+    return DI.prepare_pushforward(f!, y, single_threaded(backend), x, dx)
 end
 
 function DI.value_and_pushforward(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
@@ -1,6 +1,6 @@
 ## Pullback
 
-DI.prepare_pullback(f, ::AutoReverseDiff, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoReverseDiff, x, dy) = NoPullbackExtras()
 
 function DI.value_and_pullback(
     f, ::AutoReverseDiff, x::AbstractArray, dy, ::NoPullbackExtras

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
@@ -1,6 +1,6 @@
 ## Pullback
 
-DI.prepare_pullback(f!, y, ::AutoReverseDiff, x) = NoPullbackExtras()
+DI.prepare_pullback(f!, y, ::AutoReverseDiff, x, dy) = NoPullbackExtras()
 
 ### Array in
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
@@ -60,7 +60,7 @@ function DI.value_and_pullback(
     x_array = [x]
     dx_array = similar(x_array)
     f!_array(_y::AbstractArray, _x_array) = f!(_y, only(_x_array))
-    new_extras = DI.prepare_pullback(f!_array, y, backend, x_array)
+    new_extras = DI.prepare_pullback(f!_array, y, backend, x_array, dy)
     y, dx_array = DI.value_and_pullback(f!_array, y, backend, x_array, dy, new_extras)
     return y, only(dx_array)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/onearg.jl
@@ -3,7 +3,7 @@ struct TapirOneArgPullbackExtras{Y,R} <: PullbackExtras
     rrule::R
 end
 
-function DI.prepare_pullback(f, ::AutoTapir, x)
+function DI.prepare_pullback(f, ::AutoTapir, x, dy)
     y = f(x)
     rrule = build_rrule(f, x)
     return TapirOneArgPullbackExtras(y, rrule)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTapirExt/twoarg.jl
@@ -2,7 +2,7 @@ struct TapirTwoArgPullbackExtras{R} <: PullbackExtras
     rrule::R
 end
 
-function DI.prepare_pullback(f!, y, ::AutoTapir, x)
+function DI.prepare_pullback(f!, y, ::AutoTapir, x, dy)
     return TapirTwoArgPullbackExtras(build_rrule(f!, y, x))
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -10,7 +10,7 @@ DI.mutation_support(::AutoTracker) = DI.MutationNotSupported()
 
 ## Pullback
 
-DI.prepare_pullback(f, ::AutoTracker, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoTracker, x, dy) = NoPullbackExtras()
 
 function DI.value_and_pullback_split(f, ::AutoTracker, x, ::NoPullbackExtras)
     y, back = forward(f, x)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -13,7 +13,7 @@ DI.mutation_support(::Union{AutoZygote,AutoSparseZygote}) = DI.MutationNotSuppor
 
 ## Pullback
 
-DI.prepare_pullback(f, ::AutoZygote, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoZygote, x, dy) = NoPullbackExtras()
 
 function DI.value_and_pullback_split(f, ::AutoZygote, x, ::NoPullbackExtras)
     y, back = pullback(f, x)

--- a/DifferentiationInterface/src/derivative.jl
+++ b/DifferentiationInterface/src/derivative.jl
@@ -50,11 +50,14 @@ struct PushforwardDerivativeExtras{E<:PushforwardExtras} <: DerivativeExtras
 end
 
 function prepare_derivative(f, backend::AbstractADType, x)
-    return PushforwardDerivativeExtras(prepare_pushforward(f, backend, x))
+    dx = one(x)
+    return PushforwardDerivativeExtras(prepare_pushforward(f, backend, x, dx))
 end
 
 function prepare_derivative(f!, y, backend::AbstractADType, x)
-    return PushforwardDerivativeExtras(prepare_pushforward(f!, y, backend, x))
+    dx = one(x)
+    pushforward_extras = prepare_pushforward(f!, y, backend, x, dx)
+    return PushforwardDerivativeExtras(pushforward_extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/gradient.jl
+++ b/DifferentiationInterface/src/gradient.jl
@@ -43,7 +43,10 @@ struct PullbackGradientExtras{E<:PullbackExtras} <: GradientExtras
 end
 
 function prepare_gradient(f, backend::AbstractADType, x)
-    return PullbackGradientExtras(prepare_pullback(f, backend, x))
+    y = f(x)
+    dy = one(y)
+    pullback_extras = prepare_pullback(f, backend, x, dy)
+    return PullbackGradientExtras(pullback_extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/hessian.jl
+++ b/DifferentiationInterface/src/hessian.jl
@@ -33,9 +33,9 @@ struct HVPHessianExtras{E<:HVPExtras} <: HessianExtras
 end
 
 function prepare_hessian(f, backend::AbstractADType, x)
-    return HVPHessianExtras(
-        prepare_hvp(f, backend, x, basis(backend, x, first(CartesianIndices(x))))
-    )
+    v = basis(backend, x, first(CartesianIndices(x)))
+    hvp_extras = prepare_hvp(f, backend, x, v)
+    return HVPHessianExtras(hvp_extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/jacobian.jl
+++ b/DifferentiationInterface/src/jacobian.jl
@@ -62,19 +62,28 @@ function prepare_jacobian(f!, y, backend::AbstractADType, x)
 end
 
 function prepare_jacobian_aux(f, backend, x, ::PushforwardFast)
-    return PushforwardJacobianExtras(prepare_pushforward(f, backend, x))
+    dx = basis(backend, x, first(CartesianIndices(x)))
+    pushforward_extras = prepare_pushforward(f, backend, x, dx)
+    return PushforwardJacobianExtras(pushforward_extras)
 end
 
 function prepare_jacobian_aux(f!, y, backend, x, ::PushforwardFast)
-    return PushforwardJacobianExtras(prepare_pushforward(f!, y, backend, x))
+    dx = basis(backend, x, first(CartesianIndices(x)))
+    pushforward_extras = prepare_pushforward(f!, y, backend, x, dx)
+    return PushforwardJacobianExtras(pushforward_extras)
 end
 
 function prepare_jacobian_aux(f, backend, x, ::PushforwardSlow)
-    return PullbackJacobianExtras(prepare_pullback(f, backend, x))
+    y = f(x)
+    dy = basis(backend, y, first(CartesianIndices(y)))
+    pullback_extras = prepare_pullback(f, backend, x, dy)
+    return PullbackJacobianExtras(pullback_extras)
 end
 
 function prepare_jacobian_aux(f!, y, backend, x, ::PushforwardSlow)
-    return PullbackJacobianExtras(prepare_pullback(f!, y, backend, x))
+    dy = basis(backend, y, first(CartesianIndices(y)))
+    pullback_extras = prepare_pullback(f!, y, backend, x, dy)
+    return PullbackJacobianExtras(pullback_extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/second_derivative.jl
+++ b/DifferentiationInterface/src/second_derivative.jl
@@ -62,9 +62,8 @@ function second_derivative(
     x,
     extras::ClosureSecondDerivativeExtras=prepare_second_derivative(f, backend, x),
 )
-    return derivative(
-        extras.inner_derivative_closure, outer(backend), x, extras.outer_derivative_extras
-    )
+    (; inner_derivative_closure, outer_derivative_extras) = extras
+    return derivative(inner_derivative_closure, outer(backend), x, outer_derivative_extras)
 end
 
 function second_derivative!(
@@ -86,11 +85,8 @@ function second_derivative!(
     x,
     extras::SecondDerivativeExtras=prepare_second_derivative(f, backend, x),
 )
+    (; inner_derivative_closure, outer_derivative_extras) = extras
     return derivative!(
-        extras.inner_derivative_closure,
-        der2,
-        outer(backend),
-        x,
-        extras.outer_derivative_extras,
+        inner_derivative_closure, der2, outer(backend), x, outer_derivative_extras
     )
 end

--- a/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -99,13 +99,13 @@ function run_benchmark!(
 )
     (; f, x, y, dx) = deepcopy(scen)
     # benchmark
-    extras = prepare_pushforward(f, ba, x)
-    bench0 = @be prepare_pushforward(f, ba, x) evals = 1 samples = 1
+    extras = prepare_pushforward(f, ba, x, dx)
+    bench0 = @be prepare_pushforward(f, ba, x, dx) evals = 1 samples = 1
     bench1 = @be value_and_pushforward(f, ba, x, dx, extras)
     bench2 = @be pushforward(f, ba, x, dx, extras)
     # count
     cc = CallCounter(f)
-    extras = prepare_pushforward(cc, ba, x)
+    extras = prepare_pushforward(cc, ba, x, dx)
     calls0 = reset_count!(cc)
     value_and_pushforward(cc, ba, x, dx, extras)
     calls1 = reset_count!(cc)
@@ -125,13 +125,13 @@ function run_benchmark!(
 )
     (; f, x, y, dx) = deepcopy(scen)
     # benchmark
-    extras = prepare_pushforward(f, ba, x)
-    bench0 = @be prepare_pushforward(f, ba, x) evals = 1 samples = 1
+    extras = prepare_pushforward(f, ba, x, dx)
+    bench0 = @be prepare_pushforward(f, ba, x, dx) evals = 1 samples = 1
     bench1 = @be mysimilar(y) value_and_pushforward!(f, _, ba, x, dx, extras)
     bench2 = @be mysimilar(y) pushforward!(f, _, ba, x, dx, extras)
     # count
     cc = CallCounter(f)
-    extras = prepare_pushforward(cc, ba, x)
+    extras = prepare_pushforward(cc, ba, x, dx)
     calls0 = reset_count!(cc)
     value_and_pushforward!(cc, mysimilar(y), ba, x, dx, extras)
     calls1 = reset_count!(cc)
@@ -152,13 +152,13 @@ function run_benchmark!(
     (; f, x, y, dx) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
-    bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x) evals = 1 samples = 1
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x, dx)
+    bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x, dx) evals = 1 samples = 1
     bench1 = @be mysimilar(y) value_and_pushforward(f!, _, ba, x, dx, extras)
     bench2 = @be mysimilar(y) pushforward(f!, _, ba, x, dx, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_pushforward(cc!, mysimilar(y), ba, x)
+    extras = prepare_pushforward(cc!, mysimilar(y), ba, x, dx)
     calls0 = reset_count!(cc!)
     value_and_pushforward(cc!, mysimilar(y), ba, x, dx, extras)
     calls1 = reset_count!(cc!)
@@ -179,8 +179,8 @@ function run_benchmark!(
     (; f, x, y, dx) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
-    bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x) evals = 1 samples = 1
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x, dx)
+    bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x, dx) evals = 1 samples = 1
     bench1 = @be (mysimilar(y), mysimilar(y)) value_and_pushforward!(
         f!, _[1], _[2], ba, x, dx, extras
     )
@@ -189,7 +189,7 @@ function run_benchmark!(
     )
     # count
     cc! = CallCounter(f!)
-    extras = prepare_pushforward(cc!, mysimilar(y), ba, x)
+    extras = prepare_pushforward(cc!, mysimilar(y), ba, x, dx)
     calls0 = reset_count!(cc!)
     value_and_pushforward!(cc!, mysimilar(y), mysimilar(y), ba, x, dx, extras)
     calls1 = reset_count!(cc!)
@@ -211,15 +211,15 @@ function run_benchmark!(
 )
     (; f, x, y, dy) = deepcopy(scen)
     # benchmark
-    extras = prepare_pullback(f, ba, x)
-    bench0 = @be prepare_pullback(f, ba, x) evals = 1 samples = 1
+    extras = prepare_pullback(f, ba, x, dy)
+    bench0 = @be prepare_pullback(f, ba, x, dy) evals = 1 samples = 1
     bench1 = @be value_and_pullback(f, ba, x, dy, extras)
     bench2 = @be pullback(f, ba, x, dy, extras)
     bench3 = @be value_and_pullback_split(f, ba, x, extras)
     bench4 = @be last(value_and_pullback_split(f, ba, x, extras)) _(dy)
     # count
     cc = CallCounter(f)
-    extras = prepare_pullback(cc, ba, x)
+    extras = prepare_pullback(cc, ba, x, dy)
     calls0 = reset_count!(cc)
     value_and_pullback(cc, ba, x, dy, extras)
     calls1 = reset_count!(cc)
@@ -243,8 +243,8 @@ function run_benchmark!(
 )
     (; f, x, y, dy) = deepcopy(scen)
     # benchmark
-    extras = prepare_pullback(f, ba, x)
-    bench0 = @be prepare_pullback(f, ba, x) evals = 1 samples = 1
+    extras = prepare_pullback(f, ba, x, dy)
+    bench0 = @be prepare_pullback(f, ba, x, dy) evals = 1 samples = 1
     bench1 = @be mysimilar(x) value_and_pullback!(f, _, ba, x, dy, extras)
     bench2 = @be mysimilar(x) pullback!(f, _, ba, x, dy, extras)
     bench3 = @be value_and_pullback!_split(f, ba, x, extras)
@@ -253,7 +253,7 @@ function run_benchmark!(
     )
     # count
     cc = CallCounter(f)
-    extras = prepare_pullback(cc, ba, x)
+    extras = prepare_pullback(cc, ba, x, dy)
     calls0 = reset_count!(cc)
     value_and_pullback!(cc, mysimilar(x), ba, x, dy, extras)
     calls1 = reset_count!(cc)
@@ -280,13 +280,13 @@ function run_benchmark!(
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_pullback(f!, mysimilar(y), ba, x)
-    bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x) evals = 1 samples = 1
+    extras = prepare_pullback(f!, mysimilar(y), ba, x, dy)
+    bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x, dy) evals = 1 samples = 1
     bench1 = @be mysimilar(y) value_and_pullback(f!, _, ba, x, dy, extras)
     bench2 = @be mysimilar(y) pullback(f!, _, ba, x, dy, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_pullback(cc!, mysimilar(y), ba, x)
+    extras = prepare_pullback(cc!, mysimilar(y), ba, x, dy)
     calls0 = reset_count!(cc!)
     value_and_pullback(cc!, mysimilar(y), ba, x, dy, extras)
     calls1 = reset_count!(cc!)
@@ -305,15 +305,15 @@ function run_benchmark!(
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
     # benchmark
-    extras = prepare_pullback(f!, mysimilar(y), ba, x)
-    bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x) evals = 1 samples = 1
+    extras = prepare_pullback(f!, mysimilar(y), ba, x, dy)
+    bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x, dy) evals = 1 samples = 1
     bench1 = @be (mysimilar(y), mysimilar(x)) value_and_pullback!(
         f!, _[1], _[2], ba, x, dy, extras
     )
     bench2 = @be (mysimilar(y), mysimilar(x)) pullback!(f!, _[1], _[2], ba, x, dy, extras)
     # count
     cc! = CallCounter(f!)
-    extras = prepare_pullback(cc!, mysimilar(y), ba, x)
+    extras = prepare_pullback(cc!, mysimilar(y), ba, x, dy)
     calls0 = reset_count!(cc!)
     value_and_pullback!(cc!, mysimilar(y), mysimilar(x), ba, x, dy, extras)
     calls1 = reset_count!(cc!)

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -2,13 +2,9 @@
 
 function test_scen_intact(new_scen, scen)
     @testset "Scenario intact" begin
-        @test new_scen.x == scen.x
-        @test new_scen.y == scen.y
-        if hasfield(typeof(scen), :dx)
-            @test new_scen.dx == scen.dx
-        end
-        if hasfield(typeof(scen), :dy)
-            @test new_scen.dy == scen.dy
+        for n in fieldnames(typeof(scen))
+            n in (:f, :ref) && continue
+            @test getfield(new_scen, n) == getfield(scen, n)
         end
     end
 end
@@ -24,7 +20,7 @@ function test_correctness(
     ref_backend,
 )
     (; f, x, y, dx) = new_scen = deepcopy(scen)
-    extras = prepare_pushforward(f, ba, x)
+    extras = prepare_pushforward(f, ba, x, dx)
     dy_true = if ref_backend isa AbstractADType
         pushforward(f, ref_backend, x, dx)
     else
@@ -56,7 +52,7 @@ function test_correctness(
     ref_backend,
 )
     (; f, x, y, dx) = new_scen = deepcopy(scen)
-    extras = prepare_pushforward(f, ba, x)
+    extras = prepare_pushforward(f, ba, x, dx)
     dy_true = if ref_backend isa AbstractADType
         pushforward(f, ref_backend, x, dx)
     else
@@ -94,7 +90,7 @@ function test_correctness(
 )
     (; f, x, y, dx) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x, dx)
     dy_true = if ref_backend isa AbstractADType
         pushforward(f!, mysimilar(y), ref_backend, x, dx)
     else
@@ -131,7 +127,7 @@ function test_correctness(
 )
     (; f, x, y, dx) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x, dx)
     dy_true = if ref_backend isa AbstractADType
         pushforward(f!, mysimilar(y), ref_backend, x, dx)
     else
@@ -171,7 +167,7 @@ function test_correctness(
     ref_backend,
 )
     (; f, x, y, dy) = new_scen = deepcopy(scen)
-    extras = prepare_pullback(f, ba, x)
+    extras = prepare_pullback(f, ba, x, dy)
     dx_true = if ref_backend isa AbstractADType
         pullback(f, ref_backend, x, dy)
     else
@@ -210,7 +206,7 @@ function test_correctness(
     ref_backend,
 )
     (; f, x, y, dy) = new_scen = deepcopy(scen)
-    extras = prepare_pullback(f, ba, x)
+    extras = prepare_pullback(f, ba, x, dy)
     dx_true = if ref_backend isa AbstractADType
         pullback(f, ref_backend, x, dy)
     else
@@ -256,7 +252,7 @@ function test_correctness(
 )
     (; f, x, y, dy) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_pullback(f!, mysimilar(y), ba, x)
+    extras = prepare_pullback(f!, mysimilar(y), ba, x, dy)
     dx_true = if ref_backend isa AbstractADType
         pullback(f!, mysimilar(y), ref_backend, x, dy)
     else
@@ -302,7 +298,7 @@ function test_correctness(
 )
     (; f, x, y, dy) = new_scen = deepcopy(scen)
     f! = f
-    extras = prepare_pullback(f!, mysimilar(y), ba, x)
+    extras = prepare_pullback(f!, mysimilar(y), ba, x, dy)
     dx_true = if ref_backend isa AbstractADType
         pullback(f!, mysimilar(y), ref_backend, x, dy)
     else

--- a/DifferentiationInterfaceTest/src/tests/type_stability.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability.jl
@@ -2,7 +2,7 @@
 
 function test_jet(ba::AbstractADType, scen::PushforwardScenario{1,:outofplace}; ref_backend)
     (; f, x, y, dx) = deepcopy(scen)
-    extras = prepare_pushforward(f, ba, x)
+    extras = prepare_pushforward(f, ba, x, dx)
 
     if Bool(pushforward_performance(ba))
         @test_opt value_and_pushforward(f, ba, x, dx, extras)
@@ -13,7 +13,7 @@ end
 
 function test_jet(ba::AbstractADType, scen::PushforwardScenario{1,:inplace}; ref_backend)
     (; f, x, y, dx) = deepcopy(scen)
-    extras = prepare_pushforward(f, ba, x)
+    extras = prepare_pushforward(f, ba, x, dx)
     dy_in = mysimilar(y)
 
     if Bool(pushforward_performance(ba))
@@ -26,7 +26,7 @@ end
 function test_jet(ba::AbstractADType, scen::PushforwardScenario{2,:outofplace}; ref_backend)
     (; f, x, y, dx) = deepcopy(scen)
     f! = f
-    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x, dx)
     y_in = mysimilar(y)
 
     if Bool(pushforward_performance(ba))
@@ -39,7 +39,7 @@ end
 function test_jet(ba::AbstractADType, scen::PushforwardScenario{2,:inplace}; ref_backend)
     (; f, x, y, dx) = deepcopy(scen)
     f! = f
-    extras = prepare_pushforward(f!, mysimilar(y), ba, x)
+    extras = prepare_pushforward(f!, mysimilar(y), ba, x, dx)
     y_in, dy_in = mysimilar(y), mysimilar(y)
 
     if Bool(pushforward_performance(ba))
@@ -53,7 +53,7 @@ end
 
 function test_jet(ba::AbstractADType, scen::PullbackScenario{1,:outofplace}; ref_backend)
     (; f, x, dy) = deepcopy(scen)
-    extras = prepare_pullback(f, ba, x)
+    extras = prepare_pullback(f, ba, x, dy)
 
     _, pullbackfunc = value_and_pullback_split(f, ba, x, extras)
 
@@ -67,7 +67,7 @@ end
 
 function test_jet(ba::AbstractADType, scen::PullbackScenario{1,:inplace}; ref_backend)
     (; f, x, dy) = deepcopy(scen)
-    extras = prepare_pullback(f, ba, x)
+    extras = prepare_pullback(f, ba, x, dy)
     dx_in = mysimilar(x)
 
     _, pullbackfunc! = value_and_pullback!_split(f, ba, x, extras)
@@ -83,7 +83,7 @@ end
 function test_jet(ba::AbstractADType, scen::PullbackScenario{2,:outofplace}; ref_backend)
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
-    extras = prepare_pullback(f!, mysimilar(y), ba, x)
+    extras = prepare_pullback(f!, mysimilar(y), ba, x, dy)
     y_in = mysimilar(y)
 
     _, pullbackfunc = value_and_pullback_split(f!, y, ba, x, extras)
@@ -99,7 +99,7 @@ end
 function test_jet(ba::AbstractADType, scen::PullbackScenario{2,:inplace}; ref_backend)
     (; f, x, y, dy) = deepcopy(scen)
     f! = f
-    extras = prepare_pullback(f!, mysimilar(y), ba, x)
+    extras = prepare_pullback(f!, mysimilar(y), ba, x, dy)
     y_in, dx_in = mysimilar(y), mysimilar(x)
 
     _, pullbackfunc! = value_and_pullback!_split(f!, y, ba, x, extras)

--- a/DifferentiationInterfaceTest/src/utils/zero_backends.jl
+++ b/DifferentiationInterfaceTest/src/utils/zero_backends.jl
@@ -13,8 +13,8 @@ struct AutoZeroForward <: ADTypes.AbstractForwardMode end
 DI.check_available(::AutoZeroForward) = true
 DI.mutation_support(::AutoZeroForward) = DI.MutationSupported()
 
-DI.prepare_pushforward(f, ::AutoZeroForward, x) = NoPushforwardExtras()
-DI.prepare_pushforward(f!, y, ::AutoZeroForward, x) = NoPushforwardExtras()
+DI.prepare_pushforward(f, ::AutoZeroForward, x, dx) = NoPushforwardExtras()
+DI.prepare_pushforward(f!, y, ::AutoZeroForward, x, dx) = NoPushforwardExtras()
 
 function DI.value_and_pushforward(f, ::AutoZeroForward, x, dx, ::NoPushforwardExtras)
     y = f(x)
@@ -55,8 +55,8 @@ struct AutoZeroReverse <: ADTypes.AbstractReverseMode end
 DI.check_available(::AutoZeroReverse) = true
 DI.mutation_support(::AutoZeroReverse) = DI.MutationSupported()
 
-DI.prepare_pullback(f, ::AutoZeroReverse, x) = NoPullbackExtras()
-DI.prepare_pullback(f!, y, ::AutoZeroReverse, x) = NoPullbackExtras()
+DI.prepare_pullback(f, ::AutoZeroReverse, x, dy) = NoPullbackExtras()
+DI.prepare_pullback(f!, y, ::AutoZeroReverse, x, dy) = NoPullbackExtras()
 
 function DI.value_and_pullback(f, ::AutoZeroReverse, x, dy, ::NoPullbackExtras)
     y = f(x)

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -1,5 +1,7 @@
 @test check_available(AutoZeroForward())
 @test check_available(AutoZeroReverse())
+@test check_twoarg(AutoZeroForward())
+@test check_twoarg(AutoZeroReverse())
 
 ## Correctness (vs oneself)
 


### PR DESCRIPTION
**Core**

- Replace `prepare_pushforward(f, backend, x)` with `prepare_pushforward(f, backend, x, dx)`
- Replace `prepare_pullback(f, backend, x)` with `prepare_pullback(f, backend, x, dy)`
- Tweak split reverse mode with an extra function eval to initialize `dy`

**Tests**

- More generic scenario intact test

**Extensions**

- Adjust all preparation functions