### PR TITLE
Improve Enzyme in forward mode with chunk size

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -7,7 +7,8 @@ using DifferentiationInterface:
     NoGradientExtras,
     NoJacobianExtras,
     NoPullbackExtras,
-    NoPushforwardExtras
+    NoPushforwardExtras,
+    pick_chunksize
 using DocStringExtensions
 using Enzyme:
     Active,
@@ -22,6 +23,7 @@ using Enzyme:
     ReverseMode,
     autodiff,
     autodiff_thunk,
+    chunkedonehot,
     gradient,
     gradient!,
     jacobian,

--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -57,6 +57,7 @@ include("hessian.jl")
 
 include("check.jl")
 include("sparse.jl")
+include("chunk.jl")
 
 export AutoChainRules,
     AutoDiffractor,

--- a/DifferentiationInterface/src/chunk.jl
+++ b/DifferentiationInterface/src/chunk.jl
@@ -1,0 +1,22 @@
+#=
+This heuristic is taken from ForwardDiff.jl.
+Source file: https://github.com/JuliaDiff/ForwardDiff.jl/blob/master/src/prelude.jl
+=#
+
+const DEFAULT_CHUNKSIZE = 8
+
+"""
+    pick_chunksize(input_length)
+
+Pick a reasonable chunk size for chunked derivative evaluation with an input of length `input_length`.
+    
+The result cannot be larger than `DEFAULT_CHUNKSIZE=$DEFAULT_CHUNKSIZE`.
+"""
+function pick_chunksize(input_length::Integer; threshold::Integer=DEFAULT_CHUNKSIZE)
+    if input_length <= threshold
+        return input_length
+    else
+        nchunks = round(Int, input_length / threshold, RoundUp)
+        return round(Int, input_length / nchunks, RoundUp)
+    end
+end

--- a/DifferentiationInterface/test/chunk.jl
+++ b/DifferentiationInterface/test/chunk.jl
@@ -1,0 +1,9 @@
+using DifferentiationInterface: pick_chunksize, DEFAULT_CHUNKSIZE
+
+@test pick_chunksize.(1:DEFAULT_CHUNKSIZE) == 1:DEFAULT_CHUNKSIZE
+@test all(
+    pick_chunksize.((DEFAULT_CHUNKSIZE + 1):(5DEFAULT_CHUNKSIZE)) .<= DEFAULT_CHUNKSIZE
+)
+@test all(
+    pick_chunksize.((DEFAULT_CHUNKSIZE + 1):(5DEFAULT_CHUNKSIZE)) .>= DEFAULT_CHUNKSIZE / 2
+)

--- a/DifferentiationInterface/test/runtests.jl
+++ b/DifferentiationInterface/test/runtests.jl
@@ -43,5 +43,9 @@ include("test_imports.jl")
         @testset "Weird arrays" begin
             include("weird_arrays.jl")
         end
+
+        @testset "Chunks" begin
+            include("chunk.jl")
+        end
     end
 end;

--- a/DifferentiationInterface/test/type_stability.jl
+++ b/DifferentiationInterface/test/type_stability.jl
@@ -1,4 +1,6 @@
-type_stable_backends = [AutoForwardDiff(), AutoEnzyme(Enzyme.Reverse)]
+type_stable_backends = [
+    AutoForwardDiff(), AutoEnzyme(Enzyme.Forward), AutoEnzyme(Enzyme.Reverse)
+]
 
 test_differentiation(
     type_stable_backends;


### PR DESCRIPTION
**Core**

- Add a `pick_chunksize` heuristic lifted from ForwardDiff.jl

**Extensions**

- Enzyme forward: Use this chunk size selector to prepare `gradient` and `jacobian`
- Enzyme reverse: Try to do the same for `jacobian` but I ran into https://github.com/EnzymeAD/Enzyme.jl/issues/1391

**Tests**

- Add `AutoEnzyme(Enzyme.Forward)` to the type-stable backends