### PR TITLE
Fix mode for second order

### DIFF
--- a/DifferentiationInterface/src/second_order/second_order.jl
+++ b/DifferentiationInterface/src/second_order/second_order.jl
@@ -26,3 +26,10 @@ outer(backend::SecondOrder) = backend.outer
 function Base.show(io::IO, backend::SecondOrder)
     return print(io, "SecondOrder($(outer(backend)) / $(inner(backend)))")
 end
+
+"""
+    mode(backend::SecondOrder)
+
+Return the _outer_ mode of the second-order backend.
+"""
+ADTypes.mode(backend::SecondOrder) = mode(outer(backend))

--- a/DifferentiationInterface/test/second_order.jl
+++ b/DifferentiationInterface/test/second_order.jl
@@ -29,6 +29,7 @@ for backend in vcat(
     dense_second_order_backends, sparse_second_order_backends, mixed_second_order_backends
 )
     @test check_hessian(backend)
+    @test mode(backend) isa ADTypes.AbstractMode
 end
 
 test_differentiation(

--- a/DifferentiationInterface/test/second_order.jl
+++ b/DifferentiationInterface/test/second_order.jl
@@ -29,7 +29,7 @@ for backend in vcat(
     dense_second_order_backends, sparse_second_order_backends, mixed_second_order_backends
 )
     @test check_hessian(backend)
-    @test mode(backend) isa ADTypes.AbstractMode
+    @test ADTypes.mode(backend) isa ADTypes.AbstractMode
 end
 
 test_differentiation(

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -56,7 +56,7 @@ data1 = benchmark_differentiation(
 );
 
 data2 = benchmark_differentiation(
-    SecondOrder(AutoZeroForward(), AutoZeroReverse());
+    [SecondOrder(AutoZeroForward(), AutoZeroReverse())];
     first_order=false,
     logging=get(ENV, "CI", "false") == "false",
 );

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -51,11 +51,18 @@ test_differentiation(
 
 ## Benchmark
 
-data = benchmark_differentiation(
+data1 = benchmark_differentiation(
     [AutoZeroForward(), AutoZeroReverse()]; logging=get(ENV, "CI", "false") == "false"
 );
 
-df = DataFrames.DataFrame(data)
+data2 = benchmark_differentiation(
+    SecondOrder(AutoZeroForward(), AutoZeroReverse());
+    first_order=false,
+    logging=get(ENV, "CI", "false") == "false",
+);
+
+df1 = DataFrames.DataFrame(data1)
+df2 = DataFrames.DataFrame(data2)
 
 ## Weird arrays
 


### PR DESCRIPTION
Fix #204 

**Core**

- Define `mode` for `SecondOrder` by taking the mode of the outer backend

**Tests**

- Add a benchmarking test for `SecondOrder` to avoid regressions