### PR TITLE
Generate table of overloads in docs

### DIFF
--- a/DifferentiationInterface/docs/make.jl
+++ b/DifferentiationInterface/docs/make.jl
@@ -45,7 +45,7 @@ makedocs(;
         "Home" => "index.md", #
         "Start here" => ["tutorial.md", "overview.md", "backends.md"],
         "API reference" => "api.md",
-        "Advanced" => ["design.md", "extensions.md"],
+        "Advanced" => ["design.md", "extensions.md", "overloads.md"],
     ],
 )
 

--- a/DifferentiationInterface/docs/src/design.md
+++ b/DifferentiationInterface/docs/src/design.md
@@ -1,6 +1,6 @@
 # Package design
 
-## Backend requirements
+## [Backend requirements](@id ssec-requirements)
 
 To be usable with DifferentiationInterface.jl, an AD backend needs an object subtyping `ADTypes.AbstractADType`.
 In addition, some operators must be defined:

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -1,11 +1,11 @@
 # Table of overloads
 
 This table recaps the features of each extension, with respect to high-level operators.
-Each cell can have three values
+Each cell can have three values:
 
 - ❌: the backend does not support this operator
 - ✅: our extension calls the backend operator and handles preparation if possible
-- NA: The operator is not available (e.g. because mutation on scalar function outputs isn't possible).
+- NA: the operator is not available (e.g. because mutation on scalar function outputs isn't possible).
 
 Checkmarks (✅) are clickable and link to the source code.
 
@@ -13,8 +13,18 @@ Checkmarks (✅) are clickable and link to the source code.
 using ADTypes
 using DifferentiationInterface
 using DifferentiationInterface: backend_string
-import Markdown
-import Diffractor, Enzyme, FastDifferentiation, FiniteDiff, FiniteDifferences, ForwardDiff, PolyesterForwardDiff, ReverseDiff, Tapir, Tracker, Zygote
+using Markdown: Markdown
+using Diffractor: Diffractor
+using Enzyme: Enzyme
+using FastDifferentiation: FastDifferentiation
+using FiniteDiff: FiniteDiff
+using FiniteDifferences: FiniteDifferences
+using ForwardDiff: ForwardDiff
+using PolyesterForwardDiff: PolyesterForwardDiff
+using ReverseDiff: ReverseDiff
+using Tapir: Tapir
+using Tracker: Tracker
+using Zygote: Zygote
 
 ext_module(ext::Symbol) = Base.get_extension(DifferentiationInterface, ext)
 
@@ -23,11 +33,11 @@ function all_backends_and_extensions()
         (AutoDiffractor(), ext_module(:DifferentiationInterfaceDiffractorExt)),
         (AutoEnzyme(; mode=Enzyme.Forward), ext_module(:DifferentiationInterfaceEnzymeExt)),
         (AutoEnzyme(; mode=Enzyme.Reverse), ext_module(:DifferentiationInterfaceEnzymeExt)),
-        (AutoFastDifferentiation(), ext_module(:DifferentiationInterfaceFastDifferentiationExt)),
+        (AutoFastDifferentiation(), ext_module(:DifferentiationInterfaceFastDifferentiationExt),),
         (AutoFiniteDiff(), ext_module(:DifferentiationInterfaceFiniteDiffExt)),
-        (AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)), ext_module(:DifferentiationInterfaceFiniteDifferencesExt)),
+        (AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),ext_module(:DifferentiationInterfaceFiniteDifferencesExt),),
         (AutoForwardDiff(), ext_module(:DifferentiationInterfaceForwardDiffExt)),
-        (AutoPolyesterForwardDiff(; chunksize=1), ext_module(:DifferentiationInterfacePolyesterForwardDiffExt)),
+        (AutoPolyesterForwardDiff(; chunksize=1),ext_module(:DifferentiationInterfacePolyesterForwardDiffExt),),
         (AutoReverseDiff(), ext_module(:DifferentiationInterfaceReverseDiffExt)),
         (AutoTapir(), ext_module(:DifferentiationInterfaceTapirExt)),
         (AutoTracker(), ext_module(:DifferentiationInterfaceTrackerExt)),
@@ -35,25 +45,104 @@ function all_backends_and_extensions()
     ]
 end
 
-function operators(backend::T) where {T<:AbstractADType} 
+function operators_and_types_f(backend::T) where {T<:AbstractADType}
     return (
-        # (operator, signature_f, signature_f!)
-        (:value_and_derivative!, (Any, Any, T, Any, Any), (Any, Any, Any, T, Any, Any)), 
-        (:value_and_derivative, (Any, T, Any, Any), (Any, Any, T, Any, Any)), 
-        (:derivative!, (Any, Any, T, Any, Any), (Any, Any, Any, T, Any, Any)), 
-        (:derivative, (Any, T, Any, Any), (Any, Any, T, Any, Any)),   
-        (:value_and_gradient!, (Any, Any, T, Any, Any), nothing), 
-        (:value_and_gradient, (Any, T, Any, Any), nothing), 
-        (:gradient!, (Any, Any, T, Any, Any), nothing), 
-        (:gradient, (Any, T, Any, Any), nothing), 
-        (:value_and_jacobian!, (Any, Any, T, Any, Any), (Any, Any, Any, T, Any, Any)), 
-        (:value_and_jacobian, (Any, T, Any, Any), (Any, Any, T, Any, Any)), 
-        (:jacobian!, (Any, Any, T, Any, Any), (Any, Any, Any, T, Any, Any)), 
-        (:jacobian, (Any, T, Any, Any), (Any, Any, T, Any, Any)), 
-        (:hvp!, (Any, Any, T, Any, Any, Any), nothing), 
-        (:hvp, (Any, T, Any, Any, Any), nothing), 
-        (:hessian!, (Any, Any, T, Any, Any), nothing),
-        (:hessian, (Any, T, Any, Any), nothing), 
+        # (op,          types_op), 
+        # (op!,         types_op!), 
+        # (val_and_op,  types_val_and_op),
+        # (val_and_op!, types_val_and_op!),
+        (
+            (:derivative, (Any, T, Any, Any)),
+            (:derivative!, (Any, Any, T, Any, Any)),
+            (:value_and_derivative, (Any, T, Any, Any)),
+            (:value_and_derivative!, (Any, Any, T, Any, Any)),
+        ),
+        (
+            (:gradient, (Any, T, Any, Any)),
+            (:gradient!, (Any, Any, T, Any, Any)),
+            (:value_and_gradient, (Any, T, Any, Any)),
+            (:value_and_gradient!, (Any, Any, T, Any, Any)),
+        ),
+        (
+            (:jacobian, (Any, T, Any, Any)),
+            (:jacobian!, (Any, Any, T, Any, Any)),
+            (:value_and_jacobian, (Any, T, Any, Any)),
+            (:value_and_jacobian!, (Any, Any, T, Any, Any)),
+        ),
+        (
+            (:hessian, (Any, T, Any, Any)),
+            (:hessian!, (Any, Any, T, Any, Any)),
+            (nothing, nothing),
+            (nothing, nothing),
+        ),
+        (
+            (:hvp, (Any, T, Any, Any, Any)),
+            (:hvp!, (Any, Any, T, Any, Any, Any)),
+            (nothing, nothing),
+            (nothing, nothing),
+        ),
+        (
+            (:pushforward, (Any, T, Any, Any, Any)),
+            (:pushforward!, (Any, Any, T, Any, Any, Any)),
+            (:value_and_pushforward, (Any, T, Any, Any, Any)),
+            (:value_and_pushforward!, (Any, Any, T, Any, Any, Any)),
+        ),
+        (
+            (:pullback, (Any, T, Any, Any, Any)),
+            (:pullback!, (Any, Any, T, Any, Any, Any)),
+            (:value_and_pullback, (Any, T, Any, Any, Any)),
+            (:value_and_pullback!, (Any, Any, T, Any, Any, Any)),
+        ),
+    )
+end
+function operators_and_types_f!(backend::T) where {T<:AbstractADType}
+    return (
+        # (op,          types_op), 
+        # (op!,         types_op!), 
+        # (val_and_op,  types_val_and_op),
+        # (val_and_op!, types_val_and_op!),
+        (
+            (:derivative, (Any, Any, T, Any, Any)),
+            (:derivative!, (Any, Any, Any, T, Any, Any)),
+            (:value_and_derivative, (Any, Any, T, Any, Any)),
+            (:value_and_derivative!, (Any, Any, Any, T, Any, Any)),
+        ),
+        (
+            (:gradient, (Any, Any, T, Any, Any)),
+            (:gradient!, (Any, Any, Any, T, Any, Any)),
+            (:value_and_gradient, (Any, Any, T, Any, Any)),
+            (:value_and_gradient!, (Any, Any, Any, T, Any, Any)),
+        ),
+        (
+            (:jacobian, (Any, Any, T, Any, Any)),
+            (:jacobian!, (Any, Any, Any, T, Any, Any)),
+            (:value_and_jacobian, (Any, Any, T, Any, Any)),
+            (:value_and_jacobian!, (Any, Any, Any, T, Any, Any)),
+        ),
+        (
+            (:hessian, (Any, Any, T, Any, Any)),
+            (:hessian!, (Any, Any, Any, T, Any, Any)),
+            (nothing, nothing),
+            (nothing, nothing),
+        ),
+        (
+            (:hvp, (Any, Any, T, Any, Any, Any)),
+            (:hvp!, (Any, Any, Any, T, Any, Any, Any)),
+            (nothing, nothing),
+            (nothing, nothing),
+        ),
+        (
+            (:pushforward, (Any, Any, T, Any, Any, Any)),
+            (:pushforward!, (Any, Any, Any, T, Any, Any, Any)),
+            (:value_and_pushforward, (Any, Any, T, Any, Any, Any)),
+            (:value_and_pushforward!, (Any, Any, Any, T, Any, Any, Any)),
+        ),
+        (
+            (:pullback, (Any, Any, T, Any, Any, Any)),
+            (:pullback!, (Any, Any, Any, T, Any, Any, Any)),
+            (:value_and_pullback, (Any, Any, T, Any, Any, Any)),
+            (:value_and_pullback!, (Any, Any, Any, T, Any, Any, Any)),
+        ),
     )
 end
 
@@ -77,17 +166,40 @@ for (backend, ext) in all_backends_and_extensions()
     println(io, "## $bname")
 
     # First-order table
-    println(io, "| Operator | `f(x)` | `f!(y, x)` |")
-    println(io, "|:---------|:------:|:----------:|")
-    for (op, signature_f, signature_f!) in operators(backend)
-        # First column: f(x)
-        print(io, "| `$op` |", method_overloaded(op, signature_f, ext), '|') 
-        # Second column: f!(y, x)
-        if isnothing(signature_f!)
-            println(io, "NA |")
-        else
-            println(io, method_overloaded(op, signature_f!, ext), '|')
+    println(io, "### Functions `f(x)`")
+    println(io)
+    println(io, "| Operator | `op` | `op!` | `value_and_op` | `value_and_op!` |")
+    println(io, "|:---------|:----:|:-----:|:--------------:|:---------------:|")
+    for variants in operators_and_types_f(backend)
+        opname = first(first(variants))
+        print(io, "| `$opname` |")
+        for (op, type_signature) in variants
+            if isnothing(op)
+                print(io, "NA")
+            else
+                print(io, method_overloaded(op, type_signature, ext))
+            end
+            print(io, '|')
         end
+        println(io)
+    end
+
+    println(io, "### Functions `f!(y, x)`")
+    println(io)
+    println(io, "| Operator | `op` | `op!` | `value_and_op` | `value_and_op!` |")
+    println(io, "|:---------|:----:|:-----:|:--------------:|:---------------:|")
+    for variants in operators_and_types_f!(backend)
+        opname = first(first(variants))
+        print(io, "| `$opname` |")
+        for (op, type_signature) in variants
+            if isnothing(op)
+                print(io, "NA")
+            else
+                print(io, method_overloaded(op, type_signature, ext))
+            end
+            print(io, '|')
+        end
+        println(io)
     end
 end
 

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -12,7 +12,7 @@ Check marks (✅) are clickable and link to the source code.
 ```@setup overloads
 using ADTypes
 using DifferentiationInterface
-using DifferentiationInterface: backend_string
+using DifferentiationInterface: backend_string, mutation_support, MutationSupported
 using Markdown: Markdown
 using Diffractor: Diffractor
 using Enzyme: Enzyme
@@ -137,13 +137,17 @@ function print_overloads(backend, ext::Symbol)
     io = IOBuffer()
     ext = Base.get_extension(DifferentiationInterface, ext)
 
-    println(io, "### `f(x)`")
+    println(io, "#### One-argument functions `y = f(x)`")
     println(io)
     print_overload_table(io, operators_and_types_f(backend), ext)
 
-    println(io, "### `f!(y, x)`")
+    println(io, "#### Two-argument functions `f!(y, x)`")
     println(io)
-    print_overload_table(io, operators_and_types_f!(backend), ext)
+    if mutation_support(backend) == MutationSupported()
+        print_overload_table(io, operators_and_types_f!(backend), ext)
+    else
+        println(io, "Backend doesn't support mutating functions.")
+    end
 
     return Markdown.parse(String(take!(io)))
 end

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -1,10 +1,9 @@
 # Table of overloads
 
 This table recaps the features of each extension, with respect to high-level operators.
-Each cell can have four values
+Each cell can have two values
 
 - ❌: the backend does not support this operator
-- ❔: the backend supports this operator but our extension doesn't call it yet / doesn't handle preparation
 - ✅: our extension calls the backend operator and handles preparation if possible
 
 Checkmarks (✅) are clickable and link to the source code.

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -14,8 +14,8 @@ When available, DifferentiationInterface **always** calls these backend-specific
 The following tables summarize all implemented overloads for each backend.
 Each cell can have three values:
 
-- ❌: the backend does not support this operator
-- ✅: our extension calls the backend operator and handles preparation if possible
+- ❌: the operator is not overloaded because the backend does not support it
+- ✅: the operator is overloaded
 - NA: the operator does not exist
 
 !!! tip

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -1,13 +1,25 @@
 # Table of overloads
 
-This table recaps the features of each extension, with respect to high-level operators.
+As described in the [overview](@ref sec-overview), DifferentiationInterface provides multiple high-level operators like [`jacobian`](@ref),
+each with several variants: 
+* **out-of-place** or **in-place** return values
+* **with** or **without primal** output value
+* support for **one-argument functions** `y = f(x)` or **two-argument functions** `f!(y, x)`
+
+To support a new backend, it is only required to [define either a pushforward or a pullback function](@ref ssec-requirements),
+since DifferentiationInterface provides default implementations of all operators using just these two primitives.
+However, backends sometimes provide their own implementations of operators, which can be more performant.
+When available, DifferentiationInterface **always** calls these backend-specific implementations, which we call *"overloads"*.
+
+The following tables summarize all implemented overloads for each backend.
 Each cell can have three values:
 
 - ❌: the backend does not support this operator
 - ✅: our extension calls the backend operator and handles preparation if possible
 - NA: the operator does not exist
 
-Check marks (✅) are clickable and link to the source code.
+!!! tip
+    Check marks (✅) are clickable and link to the source code.
 
 ```@setup overloads
 using ADTypes

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -1,0 +1,94 @@
+# Table of overloads
+
+This table recaps the features of each extension, with respect to high-level operators.
+Each cell can have four values
+
+- ❌: the backend does not support this operator
+- ❔: the backend supports this operator but our extension doesn't call it yet / doesn't handle preparation
+- ✅: our extension calls the backend operator and handles preparation if possible
+
+Checkmarks (✅) are clickable and link to the source code.
+
+```@setup overloads
+using ADTypes
+using DifferentiationInterface
+using DifferentiationInterface: backend_string
+import Markdown
+import Diffractor, Enzyme, FastDifferentiation, FiniteDiff, FiniteDifferences, ForwardDiff, PolyesterForwardDiff, ReverseDiff, Tapir, Tracker, Zygote
+
+ext_module(ext::Symbol) = Base.get_extension(DifferentiationInterface, ext)
+
+function all_backends_and_extensions()
+    return [
+        (AutoDiffractor(), ext_module(:DifferentiationInterfaceDiffractorExt)),
+        (AutoEnzyme(; mode=Enzyme.Forward), ext_module(:DifferentiationInterfaceEnzymeExt)),
+        (AutoEnzyme(; mode=Enzyme.Reverse), ext_module(:DifferentiationInterfaceEnzymeExt)),
+        (AutoFastDifferentiation(), ext_module(:DifferentiationInterfaceFastDifferentiationExt)),
+        (AutoFiniteDiff(), ext_module(:DifferentiationInterfaceFiniteDiffExt)),
+        (AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)), ext_module(:DifferentiationInterfaceFiniteDifferencesExt)),
+        (AutoForwardDiff(), ext_module(:DifferentiationInterfaceForwardDiffExt)),
+        (AutoPolyesterForwardDiff(; chunksize=1), ext_module(:DifferentiationInterfacePolyesterForwardDiffExt)),
+        (AutoReverseDiff(), ext_module(:DifferentiationInterfaceReverseDiffExt)),
+        (AutoTapir(), ext_module(:DifferentiationInterfaceTapirExt)),
+        (AutoTracker(), ext_module(:DifferentiationInterfaceTrackerExt)),
+        (AutoZygote(), ext_module(:DifferentiationInterfaceZygoteExt)),
+    ]
+end
+
+operators = (
+    :value_and_derivative!, 
+    :value_and_derivative, 
+    :derivative!, 
+    :derivative,   
+    :value_and_gradient!, 
+    :value_and_gradient, 
+    :gradient!, 
+    :gradient, 
+    :value_and_jacobian!, 
+    :value_and_jacobian, 
+    :jacobian!, 
+    :jacobian, 
+    :hvp!, 
+    :hvp, 
+    :hessian!,
+    :hessian, 
+)
+
+function method_overloaded(operator::Symbol, argtypes, m::Module)
+    f = @eval DifferentiationInterface.$operator
+    ms = methods(f, argtypes, m)
+
+    n = length(ms)
+    n == 0 && return "❌"
+    n == 1 && return "[✅]($(Base.url(only(ms))))"
+    return "✅"
+end
+
+io = IOBuffer()
+
+for (backend, ext) in all_backends_and_extensions()
+    bname = backend_string(backend)
+    btype = typeof(backend)
+
+    # Subsection title
+    println(io, "## $bname")
+    # Table header
+    println(io, "| Signature | `operator(f, backend, x, ...)`| `operator(f!, y, backend, x, ...)` |")
+    println(io, "|:---|:---:|:---:|")
+    # Table contents
+    for op in operators
+        println(io, "| `$op` | ", 
+            method_overloaded(op, (Any, btype, Any, Any), ext), 
+            "|",
+            method_overloaded(op, (Any, Any, btype, Any, Any), ext),
+            "|" 
+        )
+    end
+end
+
+overload_tables = Markdown.parse(String(take!(io)))
+```
+
+```@example overloads
+overload_tables # hide
+```

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -73,7 +73,7 @@ for (backend, ext) in all_backends_and_extensions()
     # Subsection title
     println(io, "## $bname")
     # Table header
-    println(io, "| Signature | `operator(f, backend, x, ...)`| `operator(f!, y, backend, x, ...)` |")
+    println(io, "| Operator | `operator(f, backend, x, ...)`| `operator(f!, y, backend, x, ...)` |")
     println(io, "|:---|:---:|:---:|")
     # Table contents
     for op in operators

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -112,7 +112,7 @@ function method_overloaded(operator::Symbol, argtypes, ext::Module)
     n = length(ms)
     n == 0 && return "❌"
     n == 1 && return "[✅]($(Base.url(only(ms))))"
-    return "✅"
+    return "[✅]($(Base.url(first(ms))))" # Optional TODO: return all URLs?
 end
 
 function print_overload_table(io::IO, operators_and_types, ext::Module)

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -5,9 +5,9 @@ Each cell can have three values:
 
 - ❌: the backend does not support this operator
 - ✅: our extension calls the backend operator and handles preparation if possible
-- NA: the operator is not available
+- NA: the operator does not exist
 
-Checkmarks (✅) are clickable and link to the source code.
+Check marks (✅) are clickable and link to the source code.
 
 ```@setup overloads
 using ADTypes

--- a/DifferentiationInterface/docs/src/overview.md
+++ b/DifferentiationInterface/docs/src/overview.md
@@ -1,4 +1,4 @@
-# Overview
+# [Overview](@id sec-overview)
 
 ## Operators
 


### PR DESCRIPTION
Closes #115.

Generates more granular tables than issue #115.
Inside of the tables, checkmarks link to the respective source code.

Caveat: this doesn't include manual links to open issues.

### Preview
~~[Table of overloads.pdf](https://github.com/gdalle/DifferentiationInterface.jl/files/15097057/Table.of.overloads.pdf)~~
