### PR TITLE
Safe benchmark

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -9,7 +9,7 @@ using DifferentiationInterface:
     JacobianExtras,
     NoDerivativeExtras,
     NoPushforwardExtras
-using ForwardDiff.DiffResults: DiffResults, DiffResult, GradientResult
+using ForwardDiff.DiffResults: DiffResults, DiffResult, GradientResult, MutableDiffResult
 using ForwardDiff:
     Chunk,
     Dual,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -28,7 +28,7 @@ function DI.value_and_gradient!(
     x::AbstractArray,
     extras::ForwardDiffGradientExtras,
 )
-    result = DiffResult(zero(eltype(x)), grad)
+    result = MutableDiffResult(zero(eltype(x)), (grad,))
     result = gradient!(result, f, x, extras.config)
     return DiffResults.value(result), DiffResults.gradient(result)
 end
@@ -74,7 +74,7 @@ function DI.value_and_jacobian!(
     extras::ForwardDiffOneArgJacobianExtras,
 )
     y = f(x)
-    result = DiffResult(y, jac)
+    result = MutableDiffResult(y, (jac,))
     result = jacobian!(result, f, x, extras.config)
     return DiffResults.value(result), DiffResults.jacobian(result)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -27,7 +27,7 @@ function DI.value_and_derivative(
     x::Number,
     extras::ForwardDiffTwoArgDerivativeExtras,
 )
-    result = DiffResult(y, similar(y))
+    result = MutableDiffResult(y, (similar(y),))
     result = derivative!(result, f!, y, x, extras.config)
     return DiffResults.value(result), DiffResults.derivative(result)
 end
@@ -40,7 +40,7 @@ function DI.value_and_derivative!(
     x::Number,
     extras::ForwardDiffTwoArgDerivativeExtras,
 )
-    result = DiffResult(y, der)
+    result = MutableDiffResult(y, (der,))
     result = derivative!(result, f!, y, x, extras.config)
     return DiffResults.value(result), DiffResults.derivative(result)
 end
@@ -90,7 +90,7 @@ function DI.value_and_jacobian(
     extras::ForwardDiffTwoArgJacobianExtras,
 )
     jac = similar(y, length(y), length(x))
-    result = DiffResult(y, jac)
+    result = MutableDiffResult(y, (jac,))
     result = jacobian!(result, f!, y, x, extras.config)
     return DiffResults.value(result), DiffResults.jacobian(result)
 end
@@ -103,7 +103,7 @@ function DI.value_and_jacobian!(
     x::AbstractArray,
     extras::ForwardDiffTwoArgJacobianExtras,
 )
-    result = DiffResult(y, jac)
+    result = MutableDiffResult(y, (jac,))
     result = jacobian!(result, f!, y, x, extras.config)
     return DiffResults.value(result), DiffResults.jacobian(result)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/DifferentiationInterfaceReverseDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/DifferentiationInterfaceReverseDiffExt.jl
@@ -4,7 +4,7 @@ using ADTypes: AutoReverseDiff
 import DifferentiationInterface as DI
 using DifferentiationInterface:
     DerivativeExtras, GradientExtras, HessianExtras, JacobianExtras, NoPullbackExtras
-using ReverseDiff.DiffResults: DiffResults, DiffResult, GradientResult
+using ReverseDiff.DiffResults: DiffResults, DiffResult, GradientResult, MutableDiffResult
 using DocStringExtensions
 using LinearAlgebra: dot, mul!
 using ReverseDiff:

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
@@ -57,7 +57,7 @@ function DI.value_and_gradient!(
     x::AbstractArray,
     extras::ReverseDiffGradientExtras,
 )
-    result = DiffResult(zero(eltype(x)), grad)
+    result = MutableDiffResult(zero(eltype(x)), (grad,))
     result = gradient!(result, extras.tape, x)
     return DiffResults.value(result), DiffResults.derivative(result)
 end
@@ -107,7 +107,7 @@ function DI.value_and_jacobian!(
     extras::ReverseDiffOneArgJacobianExtras,
 )
     y = f(x)
-    result = DiffResult(y, jac)
+    result = MutableDiffResult(y, (jac,))
     result = jacobian!(result, extras.tape, x)
     return DiffResults.value(result), DiffResults.derivative(result)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
@@ -85,7 +85,7 @@ function DI.value_and_jacobian(
     _f!, y, ::AutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
 )
     jac = similar(y, length(y), length(x))
-    result = DiffResults.DiffResult(y, jac)
+    result = MutableDiffResult(y, jac)
     result = jacobian!(result, extras.tape, x)
     return DiffResults.value(result), DiffResults.derivative(result)
 end
@@ -93,7 +93,7 @@ end
 function DI.value_and_jacobian!(
     _f!, y, jac, ::AutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
 )
-    result = DiffResults.DiffResult(y, jac)
+    result = MutableDiffResult(y, (jac,))
     result = jacobian!(result, extras.tape, x)
     return DiffResults.value(result), DiffResults.derivative(result)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/twoarg.jl
@@ -85,7 +85,7 @@ function DI.value_and_jacobian(
     _f!, y, ::AutoReverseDiff, x, extras::ReverseDiffTwoArgJacobianExtras
 )
     jac = similar(y, length(y), length(x))
-    result = MutableDiffResult(y, jac)
+    result = MutableDiffResult(y, (jac,))
     result = jacobian!(result, extras.tape, x)
     return DiffResults.value(result), DiffResults.derivative(result)
 end

--- a/DifferentiationInterfaceTest/src/scenarios/static.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/static.jl
@@ -26,7 +26,7 @@ function static_scenarios()
         mat_to_mat_scenarios_twoarg(MMatrix{2,3}(randn(2, 3))),
     )
     scens = filter(scens) do s
-        operator(s) == :outofplace || typeof(s.x) isa Union{Number,MVector,MMatrix}
+        operator_place(s) == :outofplace || s.x isa Union{Number,MVector,MMatrix}
     end
     return scens
 end

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -77,10 +77,10 @@ function test_differentiation(
                         (:backend, "$(backend_string(backend)) - $i/$(length(backends))"),
                         (
                             :scenario,
-                            "$(typeof(scen).name.name) - $j/$(length(filtered_scenarios))",
+                            "$(scen_type(scen)) - $j/$(length(filtered_scenarios))",
                         ),
-                        (:arguments, typeof(scen).parameters[1]),
-                        (:operator, typeof(scen).parameters[2]),
+                        (:arguments, nb_args(scen)),
+                        (:operator, operator_place(scen)),
                         (:function, scen.f),
                         (:input, typeof(scen.x)),
                         (:output, typeof(scen.y)),
@@ -145,12 +145,9 @@ function benchmark_differentiation(
                 prog;
                 showvalues=[
                     (:backend, "$(backend_string(backend)) - $i/$(length(backends))"),
-                    (
-                        :scenario,
-                        "$(typeof(scen).name.name) - $j/$(length(filtered_scenarios))",
-                    ),
-                    (:arguments, typeof(scen).parameters[1]),
-                    (:operator, typeof(scen).parameters[2]),
+                    (:scenario, "$(scen_type(scen)) - $j/$(length(filtered_scenarios))"),
+                    (:arguments, nb_args(scen)),
+                    (:operator, operator_place(scen)),
                     (:function, scen.f),
                     (:input, typeof(scen.x)),
                     (:output, typeof(scen.y)),

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -63,6 +63,28 @@ data2 = benchmark_differentiation(
 
 df1 = DataFrames.DataFrame(data1)
 df2 = DataFrames.DataFrame(data2)
+df = vcat(df1, df2)
+
+for col in eachcol(vcat(df1, df2))
+    if eltype(col) <: AbstractFloat
+        @test !any(isnan, col)
+    end
+end
+
+struct FakeBackend <: ADTypes.AbstractADType end
+ADTypes.mode(::FakeBackend) = ADTypes.ForwardMode()
+
+data3 = benchmark_differentiation(
+    [FakeBackend()]; logging=get(ENV, "CI", "false") == "false"
+);
+
+df3 = DataFrames.DataFrame(data3)
+
+for col in eachcol(df3)
+    if eltype(col) <: AbstractFloat
+        @test all(isnan, col)
+    end
+end
 
 ## Weird arrays
 


### PR DESCRIPTION
**Tests**

- Add `try-catch` to every benchmark in case the operators error
- Define failed `Benchmark` results with everything set to `NaN`, and set call counts to `-1`
- Test that there are no `NaN`s for the `AutoZero` backends
- Test that there are only `NaN`s for a trivial backend with no implem
- Rename `Scenario` valued type parameters from `A,O` to `args,op`
- Rename accessor functions for `Scenario` and use them in progress meter
- Fix an error in the filtering of static array scenarios, which was forgetting the `:inplace` scenarios for `MArray`s

**Extensions**

- Use `MutableDiffResult` explicitly for ForwardDiff and ReverseDiff to avoid creation of an `ImmutableDiffResult`