### PR TITLE
Throw informative errors when backends are not loaded

### DIFF
--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -41,6 +41,7 @@ include("utils/basis.jl")
 include("utils/printing.jl")
 include("utils/chunk.jl")
 include("utils/check.jl")
+include("utils/exceptions.jl")
 
 include("first_order/pushforward.jl")
 include("first_order/pullback.jl")

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -84,6 +84,20 @@ function prepare_pullback_aux(f!, y, backend, x, dy, ::PullbackSlow)
     return PushforwardPullbackExtras(pushforward_extras)
 end
 
+# Throw error if backend isn't loaded
+function PREPARE_PULLBACK_ERROR(backend)
+    return ErrorException(
+        """Failed to prepare pullback for $(backend_string(backend)) backend. 
+        This usually due to the backend not being loaded. To fix, specify
+
+            using $(backend_package_name(backend))
+        """
+    )
+end
+
+prepare_pullback_aux(f, backend, x, dy, ::PullbackFast)     = throw(PREPARE_PULLBACK_ERROR(backend))
+prepare_pullback_aux(f!, y, backend, x, dy, ::PullbackFast) = throw(PREPARE_PULLBACK_ERROR(backend))
+
 ## One argument
 
 function value_and_pullback(

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -84,19 +84,9 @@ function prepare_pullback_aux(f!, y, backend, x, dy, ::PullbackSlow)
     return PushforwardPullbackExtras(pushforward_extras)
 end
 
-# Throw error if backend isn't loaded
-function PREPARE_PULLBACK_ERROR(backend)
-    return ErrorException(
-        """Failed to prepare pullback for $(backend_string(backend)) backend. 
-        This usually due to the backend not being loaded. To fix, specify
-
-            using $(backend_package_name(backend))
-        """
-    )
-end
-
-prepare_pullback_aux(f, backend, x, dy, ::PullbackFast)     = throw(PREPARE_PULLBACK_ERROR(backend))
-prepare_pullback_aux(f!, y, backend, x, dy, ::PullbackFast) = throw(PREPARE_PULLBACK_ERROR(backend))
+# Throw error if backend is missing
+prepare_pullback_aux(f, backend, x, dy, ::PullbackFast)     = throw(MissingBackendError(backend))
+prepare_pullback_aux(f!, y, backend, x, dy, ::PullbackFast) = throw(MissingBackendError(backend))
 
 ## One argument
 

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -73,19 +73,9 @@ function prepare_pushforward_aux(f!, y, backend, x, dx, ::PushforwardSlow)
     return PullbackPushforwardExtras(pullback_extras)
 end
 
-# Throw error if backend isn't loaded
-function PREPARE_PUSHFORWARD_ERROR(backend)
-    return ErrorException(
-        """Failed to prepare pushforward for $(backend_string(backend)) backend. 
-        This usually due to the backend not being loaded. To fix, specify
-
-            using $(backend_package_name(backend))
-        """
-    )
-end
-
-prepare_pushforward_aux(f, backend, x, dy, ::PushforwardFast)     = throw(PREPARE_PUSHFORWARD_ERROR(backend))
-prepare_pushforward_aux(f!, y, backend, x, dy, ::PushforwardFast) = throw(PREPARE_PUSHFORWARD_ERROR(backend))
+# Throw error if backend is missing
+prepare_pushforward_aux(f, backend, x, dy, ::PushforwardFast)     = throw(MissingBackendError(backend))
+prepare_pushforward_aux(f!, y, backend, x, dy, ::PushforwardFast) = throw(MissingBackendError(backend))
 
 ## One argument
 

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -73,6 +73,20 @@ function prepare_pushforward_aux(f!, y, backend, x, dx, ::PushforwardSlow)
     return PullbackPushforwardExtras(pullback_extras)
 end
 
+# Throw error if backend isn't loaded
+function PREPARE_PUSHFORWARD_ERROR(backend)
+    return ErrorException(
+        """Failed to prepare pushforward for $(backend_string(backend)) backend. 
+        This usually due to the backend not being loaded. To fix, specify
+
+            using $(backend_package_name(backend))
+        """
+    )
+end
+
+prepare_pushforward_aux(f, backend, x, dy, ::PushforwardFast)     = throw(PREPARE_PUSHFORWARD_ERROR(backend))
+prepare_pushforward_aux(f!, y, backend, x, dy, ::PushforwardFast) = throw(PREPARE_PUSHFORWARD_ERROR(backend))
+
 ## One argument
 
 function value_and_pushforward(

--- a/DifferentiationInterface/src/utils/exceptions.jl
+++ b/DifferentiationInterface/src/utils/exceptions.jl
@@ -1,0 +1,14 @@
+struct MissingBackendError <: Exception
+    backend::AbstractADType
+end
+function Base.showerror(io::IO, e::MissingBackendError)
+    println(io, "failed to use $(backend_string(e.backend)) backend.")
+    if !check_available(e.backend)
+        print(io, """Backend package is not loaded. To fix, run
+
+          using $(backend_package_name(e.backend))
+        """)
+    else
+        print(io, "Please open an issue: https://github.com/gdalle/DifferentiationInterface.jl/issues/new")
+    end
+end

--- a/DifferentiationInterface/src/utils/exceptions.jl
+++ b/DifferentiationInterface/src/utils/exceptions.jl
@@ -4,11 +4,17 @@ end
 function Base.showerror(io::IO, e::MissingBackendError)
     println(io, "failed to use $(backend_string(e.backend)) backend.")
     if !check_available(e.backend)
-        print(io, """Backend package is not loaded. To fix, run
+        print(
+            io,
+            """Backend package is not loaded. To fix, run
 
-          using $(backend_package_name(e.backend))
-        """)
+              using $(backend_package_name(e.backend))
+            """,
+        )
     else
-        print(io, "Please open an issue: https://github.com/gdalle/DifferentiationInterface.jl/issues/new")
+        print(
+            io,
+            "Please open an issue: https://github.com/gdalle/DifferentiationInterface.jl/issues/new",
+        )
     end
 end

--- a/DifferentiationInterface/src/utils/printing.jl
+++ b/DifferentiationInterface/src/utils/printing.jl
@@ -1,4 +1,4 @@
-backend_package_name(b::AbstractADType) = string(b)
+backend_package_name(b::AbstractADType) = strip(string(b), ['(', ')'])
 
 backend_package_name(::AutoChainRules) = "ChainRules"
 backend_package_name(::AutoDiffractor) = "Diffractor"

--- a/DifferentiationInterface/src/utils/printing.jl
+++ b/DifferentiationInterface/src/utils/printing.jl
@@ -1,18 +1,21 @@
-backend_string_aux(b::AbstractADType) = string(b)
+backend_package_name(b::AbstractADType) = string(b)
 
-backend_string_aux(::AutoChainRules) = "ChainRules"
-backend_string_aux(::AutoDiffractor) = "Diffractor"
-backend_string_aux(::AutoEnzyme) = "Enzyme"
-backend_string_aux(::AutoFastDifferentiation) = "FastDifferentiation"
-backend_string_aux(::AutoFiniteDiff) = "FiniteDiff"
-backend_string_aux(::AutoFiniteDifferences) = "FiniteDifferences"
-backend_string_aux(::AutoForwardDiff) = "ForwardDiff"
-backend_string_aux(::AutoPolyesterForwardDiff) = "PolyesterForwardDiff"
+backend_package_name(::AutoChainRules) = "ChainRules"
+backend_package_name(::AutoDiffractor) = "Diffractor"
+backend_package_name(::AutoEnzyme) = "Enzyme"
+backend_package_name(::AutoFastDifferentiation) = "FastDifferentiation"
+backend_package_name(::AutoFiniteDiff) = "FiniteDiff"
+backend_package_name(::AutoFiniteDifferences) = "FiniteDifferences"
+backend_package_name(::AutoForwardDiff) = "ForwardDiff"
+backend_package_name(::AutoPolyesterForwardDiff) = "PolyesterForwardDiff"
+backend_package_name(::AutoSymbolics) = "Symbolics"
+backend_package_name(::AutoTapir) = "Tapir"
+backend_package_name(::AutoTracker) = "Tracker"
+backend_package_name(::AutoZygote) = "Zygote"
+backend_package_name(::AutoReverseDiff) = "ReverseDiff"
+
+backend_string_aux(b::AbstractADType) = backend_package_name(b)
 backend_string_aux(b::AutoReverseDiff) = "ReverseDiff$(b.compile ? "{compiled}" : "")"
-backend_string_aux(::AutoSymbolics) = "Symbolics"
-backend_string_aux(::AutoTapir) = "Tapir"
-backend_string_aux(::AutoTracker) = "Tracker"
-backend_string_aux(::AutoZygote) = "Zygote"
 
 function backend_string(backend::AbstractADType)
     bs = backend_string_aux(backend)

--- a/DifferentiationInterface/test/runtests.jl
+++ b/DifferentiationInterface/test/runtests.jl
@@ -23,6 +23,9 @@ include("test_imports.jl")
 
     Documenter.doctest(DifferentiationInterface)
 
+    @testset verbose = true "Exception handling" begin
+        include("test_exceptions.jl")
+    end
     @testset verbose = true "First order" begin
         include("first_order.jl")
     end

--- a/DifferentiationInterface/test/test_exceptions.jl
+++ b/DifferentiationInterface/test/test_exceptions.jl
@@ -1,0 +1,33 @@
+using DifferentiationInterface: MissingBackendError
+
+"""
+    AutoBrokenForward <: ADTypes.AbstractADType
+
+Available forward-mode backend with no pushforward implementation.
+Used to test error messages.
+"""
+struct AutoBrokenForward <: AbstractADType end
+ADTypes.mode(::AutoBrokenForward) = ADTypes.ForwardMode()
+DifferentiationInterface.check_available(::AutoBrokenForward) = true
+
+"""
+    AutoBrokenReverse <: ADTypes.AbstractADType
+
+Available reverse-mode backend with no pullback implementation.
+Used to test error messages. 
+"""
+struct AutoBrokenReverse <: AbstractADType end
+ADTypes.mode(::AutoBrokenReverse) = ADTypes.ReverseMode()
+DifferentiationInterface.check_available(::AutoBrokenReverse) = true
+
+## Test exceptions
+@testset "MissingBackendError" begin
+    f(x::AbstractArray) = sum(abs2, x)
+    x = [1.0, 2.0, 3.0]
+
+    @test_throws MissingBackendError gradient(f, AutoBrokenForward(), x)
+    @test_throws MissingBackendError gradient(f, AutoBrokenReverse(), x)
+
+    @test_throws MissingBackendError hvp(f, AutoBrokenForward(), x, x)
+    @test_throws MissingBackendError hvp(f, AutoBrokenReverse(), x, x)
+end


### PR DESCRIPTION
When forgetting to load a backend package, most operators error at either `prepare_pullback_aux` or `prepare_pushforward_aux`, resulting in an uninformative `MethodError`:

```Julia
julia> gradient(f, backend, x)
ERROR: MethodError: no method matching prepare_pushforward_aux(::typeof(f), ::AutoForwardDiff{…}, ::Vector{…}, ::FillArrays.OneElement{…}, ::DifferentiationInterface.PushforwardFast)
```

This PR adds these missing methods, throwing an informative error that suggests loading the respective backend.

## New errors
```Julia
julia> gradient(f, AutoEnzyme(), x)
ERROR: Failed to prepare pullback for Enzyme (forward/reverse) backend. 
This usually due to the backend not being loaded. To fix, specify

    using Enzyme

Stacktrace:
 [1] prepare_pullback_aux(f::Function, backend::AutoEnzyme{Nothing}, x::Vector{Float64}, dy::Float64, ::DifferentiationInterface.PullbackFast)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pullback.jl:98
 [2] prepare_pullback(f::Function, backend::AutoEnzyme{Nothing}, x::Vector{Float64}, dy::Float64)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pullback.jl:68
 [3] prepare_gradient(f::typeof(f), backend::AutoEnzyme{Nothing}, x::Vector{Float64})
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/gradient.jl:48
 [4] gradient(f::Function, backend::AutoEnzyme{Nothing}, x::Vector{Float64})
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/gradient.jl:73
 [5] top-level scope
   @ REPL[21]:1
```

```Julia
julia> gradient(f, AutoForwardDiff(), x)
ERROR: Failed to prepare pushforward for ForwardDiff (forward) backend. 
This usually due to the backend not being loaded. To fix, specify

    using ForwardDiff

Stacktrace:
 [1] prepare_pushforward_aux(f::Function, backend::AutoForwardDiff{…}, x::Vector{…}, dy::FillArrays.OneElement{…}, ::DifferentiationInterface.PushforwardFast)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pushforward.jl:87
 [2] prepare_pushforward(f::Function, backend::AutoForwardDiff{…}, x::Vector{…}, dx::FillArrays.OneElement{…})
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pushforward.jl:56
 [3] prepare_pullback_aux(f::Function, backend::AutoForwardDiff{…}, x::Vector{…}, dy::Float64, ::DifferentiationInterface.PullbackSlow)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pullback.jl:77
 [4] prepare_pullback(f::Function, backend::AutoForwardDiff{nothing, Nothing}, x::Vector{Float64}, dy::Float64)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pullback.jl:68
 [5] prepare_gradient(f::typeof(f), backend::AutoForwardDiff{nothing, Nothing}, x::Vector{Float64})
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/gradient.jl:48
 [6] gradient(f::Function, backend::AutoForwardDiff{nothing, Nothing}, x::Vector{Float64})
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/gradient.jl:73
 [7] top-level scope
   @ REPL[24]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

## Previous errors

<details>

```Julia
julia> gradient(f, backend, x)
ERROR: MethodError: no method matching prepare_pushforward_aux(::typeof(f), ::AutoForwardDiff{…}, ::Vector{…}, ::FillArrays.OneElement{…}, ::DifferentiationInterface.PushforwardFast)

Closest candidates are:
  prepare_pushforward_aux(::Any, ::Any, ::Any, ::Any, ::Any, ::DifferentiationInterface.PushforwardSlow)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pushforward.jl:70
  prepare_pushforward_aux(::Any, ::Any, ::Any, ::Any, ::DifferentiationInterface.PushforwardSlow)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pushforward.jl:63

Stacktrace:
 [1] prepare_pushforward(f::Function, backend::AutoForwardDiff{…}, x::Vector{…}, dx::FillArrays.OneElement{…})
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pushforward.jl:56
 [2] prepare_pullback_aux(f::Function, backend::AutoForwardDiff{…}, x::Vector{…}, dy::Float64, ::DifferentiationInterface.PullbackSlow)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pullback.jl:77
 [3] prepare_pullback(f::Function, backend::AutoForwardDiff{nothing, Nothing}, x::Vector{Float64}, dy::Float64)
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/pullback.jl:68
 [4] prepare_gradient(f::typeof(f), backend::AutoForwardDiff{nothing, Nothing}, x::Vector{Float64})
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/gradient.jl:48
 [5] gradient(f::Function, backend::AutoForwardDiff{nothing, Nothing}, x::Vector{Float64})
   @ DifferentiationInterface ~/Developer/DifferentiationInterface.jl/DifferentiationInterface/src/first_order/gradient.jl:73
 [6] top-level scope
   @ REPL[8]:1
Some type information was truncated. Use `show(err)` to see complete types.
```

</details>