### PR TITLE
Update backend documentation

### DIFF
--- a/DifferentiationInterface/docs/src/backends.md
+++ b/DifferentiationInterface/docs/src/backends.md
@@ -10,22 +10,38 @@ using DifferentiationInterface: backend_string
 import Markdown
 import Diffractor, Enzyme, FastDifferentiation, FiniteDiff, FiniteDifferences, ForwardDiff, PolyesterForwardDiff, ReverseDiff, Tapir, Tracker, Zygote
 
-function all_backends()
-    return [
-        AutoDiffractor(),
-        AutoEnzyme(; mode=Enzyme.Forward),
-        AutoEnzyme(; mode=Enzyme.Reverse),
-        AutoFastDifferentiation(),
-        AutoFiniteDiff(),
-        AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),
-        AutoForwardDiff(),
-        AutoPolyesterForwardDiff(; chunksize=1),
-        AutoReverseDiff(),
-        AutoTapir(),
-        AutoTracker(),
-        AutoZygote(),
-    ]
+const backend_examples = (
+    "AutoDiffractor()",
+    "AutoEnzyme(; mode=Enzyme.Forward)",
+    "AutoEnzyme(; mode=Enzyme.Reverse)",
+    "AutoFastDifferentiation()",
+    "AutoFiniteDiff()",
+    "AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1))",
+    "AutoForwardDiff()",
+    "AutoPolyesterForwardDiff(; chunksize=1)",
+    "AutoReverseDiff()",
+    "AutoTapir()",
+    "AutoTracker()",
+    "AutoZygote()",
+)
+
+checkmark(x::Bool) = x ? '✅' : '❌'
+unicode_check_available(backend) = checkmark(check_available(backend))
+unicode_check_hessian(backend)   = checkmark(check_hessian(backend))
+unicode_check_twoarg(backend)    = checkmark(check_twoarg(backend))
+
+io = IOBuffer()
+
+# Table header 
+println(io, "| Backend | Availability | Mutation support | Hessian support | Example |")
+println(io, "|:--------|:------------:|:----------------:|:---------------:|:--------|")
+
+for example in backend_examples
+    b = eval(Meta.parse(example)) # backend
+    join(io, [backend_string(b), unicode_check_available(b), unicode_check_twoarg(b), unicode_check_hessian(b), "`$example`"], '|')
+    println(io, '|' )
 end
+backend_table = Markdown.parse(String(take!(io)))
 ```
 
 # Backends
@@ -36,44 +52,21 @@ We support all dense backend choices from [ADTypes.jl](https://github.com/SciML/
 
 For sparse backends, only the Jacobian and Hessian operators are implemented differently, the other operators behave the same as for the corresponding dense backend.
 
+```@example backends
+backend_table #hide
+```
+
 ## Availability
 
-You can use [`check_available`](@ref) to verify whether a given backend is loaded, like we did below:
-
-```@example backends
-header = "| backend | available |"  # hide
-subheader = "|:---|:---:|"  # hide
-rows = map(all_backends()) do backend  # hide
-    "| `$(backend_string(backend))` | $(check_available(backend) ? '✅' : '❌') |"  # hide
-end  # hide
-Markdown.parse(join(vcat(header, subheader, rows...), "\n"))  # hide
-```
+You can use [`check_available`](@ref) to verify whether a given backend is loaded.
 
 ## Mutation support
 
 All backends are compatible with one-argument functions `f(x) = y`.
 Only some are compatible with two-argument functions `f!(y, x) = nothing`.
-You can use [`check_twoarg`](@ref) to check that feature, like we did below:
-
-```@example backends
-header = "| backend | mutation |"  # hide
-subheader = "|:---|:---:|"  # hide
-rows = map(all_backends()) do backend  # hide
-    "| `$(backend_string(backend))` | $(check_twoarg(backend) ? '✅' : '❌') |"  # hide
-end  # hide
-Markdown.parse(join(vcat(header, subheader, rows...), "\n"))  # hide
-```
+You can check this compatibility using [`check_twoarg`](@ref).
 
 ## Hessian support
 
 Only some backends are able to compute Hessians.
-You can use [`check_hessian`](@ref) to check that feature, like we did below:
-
-```@example backends
-header = "| backend | Hessian |"  # hide
-subheader = "|:---|:---:|"  # hide
-rows = map(all_backends()) do backend  # hide
-    "| `$(backend_string(backend))` | $(check_hessian(backend) ? '✅' : '❌') |"  # hide
-end  # hide
-Markdown.parse(join(vcat(header, subheader, rows...), "\n"))  # hide
-```
+You can use [`check_hessian`](@ref) to check this feature.

--- a/DifferentiationInterface/docs/src/backends.md
+++ b/DifferentiationInterface/docs/src/backends.md
@@ -33,8 +33,8 @@ unicode_check_twoarg(backend)    = checkmark(check_twoarg(backend))
 io = IOBuffer()
 
 # Table header 
-println(io, "| Backend | Availability | Mutation support | Hessian support | Example |")
-println(io, "|:--------|:------------:|:----------------:|:---------------:|:--------|")
+println(io, "| Backend | Availability | Two-argument functions | Hessian support | Example |")
+println(io, "|:--------|:------------:|:----------------------:|:---------------:|:--------|")
 
 for example in backend_examples
     b = eval(Meta.parse(example)) # backend
@@ -60,7 +60,7 @@ backend_table #hide
 
 You can use [`check_available`](@ref) to verify whether a given backend is loaded.
 
-## Mutation support
+## Support for two-argument functions
 
 All backends are compatible with one-argument functions `f(x) = y`.
 Only some are compatible with two-argument functions `f!(y, x) = nothing`.


### PR DESCRIPTION
* summarizes all `check_*` functions in one table
* adds examples on how to use ADTypes, e.g. to define forward- and reverse-mode in Enzyme

Preview: [Backends.pdf](https://github.com/gdalle/DifferentiationInterface.jl/files/15110923/Backends.pdf)
