### PR TITLE
Alloc-free pushforward with ForwardDiff

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -8,7 +8,7 @@ using DifferentiationInterface:
     HessianExtras,
     JacobianExtras,
     NoDerivativeExtras,
-    NoPushforwardExtras
+    PushforwardExtras
 using ForwardDiff.DiffResults: DiffResults, DiffResult, GradientResult, MutableDiffResult
 using ForwardDiff:
     Chunk,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -1,12 +1,13 @@
-
 choose_chunk(::AutoForwardDiff{nothing}, x) = Chunk(x)
 choose_chunk(::AutoForwardDiff{C}, x) where {C} = Chunk{C}()
 
 tag_type(::F, x::Number) where {F} = Tag{F,typeof(x)}
 tag_type(::F, x::AbstractArray) where {F} = Tag{F,eltype(x)}
 
-make_dual(::Type{T}, x::Number, dx::Number) where {T} = Dual{T}(x, dx)
+make_dual(::Type{T}, x::Number, dx) where {T} = Dual{T}(x, dx)
 make_dual(::Type{T}, x::AbstractArray, dx) where {T} = Dual{T}.(x, dx)
+
+make_dual!(::Type{T}, xdual, x::AbstractArray, dx) where {T} = xdual .= Dual{T}.(x, dx)
 
 myvalue(::Type{T}, ydual::Number) where {T} = value(T, ydual)
 myvalue(::Type{T}, ydual::AbstractArray) where {T} = value.(T, ydual)
@@ -16,6 +17,6 @@ myvalue!(::Type{T}, y::AbstractArray, ydual) where {T} = y .= value.(T, ydual)
 myderivative(::Type{T}, ydual::Number) where {T} = extract_derivative(T, ydual)
 myderivative(::Type{T}, ydual::AbstractArray) where {T} = extract_derivative(T, ydual)
 
-function myderivative!(::Type{T}, dy::AbstractArray, ydual::AbstractArray) where {T}
+function myderivative!(::Type{T}, dy, ydual::AbstractArray) where {T}
     return extract_derivative!(T, dy, ydual)
 end


### PR DESCRIPTION
**Extensions**

- Create appropriate extras to store `xdual` and `ydual` with ForwardDiff