### PR TITLE
Less allocs in ForwardDiff

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -11,14 +11,18 @@ function DI.prepare_pushforward(f, ::AutoForwardDiff, x, dx)
 end
 
 function compute_ydual_onearg(
+    f, x::Number, dx, extras::ForwardDiffOneArgPushforwardExtras{T}
+) where {T}
+    xdual_tmp = make_dual(T, x, dx)
+    ydual = f(xdual_tmp)
+    return ydual
+end
+
+function compute_ydual_onearg(
     f, x, dx, extras::ForwardDiffOneArgPushforwardExtras{T}
 ) where {T}
     (; xdual_tmp) = extras
-    xdual_tmp = if x isa Number
-        make_dual(T, x, dx)
-    else
-        make_dual!(T, xdual_tmp, x, dx)
-    end
+    make_dual!(T, xdual_tmp, x, dx)
     ydual = f(xdual_tmp)
     return ydual
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -7,16 +7,35 @@ tag_type(::F, x::AbstractArray) where {F} = Tag{F,eltype(x)}
 make_dual(::Type{T}, x::Number, dx) where {T} = Dual{T}(x, dx)
 make_dual(::Type{T}, x::AbstractArray, dx) where {T} = Dual{T}.(x, dx)
 
-make_dual!(::Type{T}, xdual, x::AbstractArray, dx) where {T} = xdual .= Dual{T}.(x, dx)
+function make_dual!(::Type{T}, xdual, x::AbstractArray, dx) where {T}
+    for i in eachindex(xdual, x, dx)
+        xdual[i] = Dual{T}(x[i], dx[i])
+    end
+    return nothing
+end
 
 myvalue(::Type{T}, ydual::Number) where {T} = value(T, ydual)
 myvalue(::Type{T}, ydual::AbstractArray) where {T} = value.(T, ydual)
 
-myvalue!(::Type{T}, y::AbstractArray, ydual) where {T} = y .= value.(T, ydual)
+function myvalue!(::Type{T}, y::AbstractArray, ydual) where {T}
+    for i in eachindex(y, ydual)
+        y[i] = value(T, ydual[i])
+    end
+    return nothing
+end
 
 myderivative(::Type{T}, ydual::Number) where {T} = extract_derivative(T, ydual)
 myderivative(::Type{T}, ydual::AbstractArray) where {T} = extract_derivative(T, ydual)
 
 function myderivative!(::Type{T}, dy, ydual::AbstractArray) where {T}
-    return extract_derivative!(T, dy, ydual)
+    extract_derivative!(T, dy, ydual)
+    return nothing
+end
+
+function myvalueandderivative!(::Type{T}, y, dy, ydual::AbstractArray) where {T}
+    for i in eachindex(y, dy, ydual)
+        y[i] = value(T, ydual[i])
+        dy[i] = extract_derivative(T, ydual[i])
+    end
+    return nothing
 end


### PR DESCRIPTION
**Extensions**

- Replace `xdual .= Dual{T}(x, dx)` with an explicit iteration to shave one allocation
- There is still one allocation in `value_and_pushforward!(f!, ...)`, it's fixed size so probably type instability but JET doesn't catch it