### PR TITLE
Rename `mutation_support` into `twoarg_support`

### DIFF
--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -24,7 +24,7 @@ Each cell can have three values:
 ```@setup overloads
 using ADTypes: AbstractADType
 using DifferentiationInterface
-using DifferentiationInterface: backend_str, mutation_support, MutationSupported
+using DifferentiationInterface: backend_str, twoarg_support, TwoArgSupported
 using Markdown: Markdown
 using Diffractor: Diffractor
 using Enzyme: Enzyme
@@ -155,7 +155,7 @@ function print_overloads(backend, ext::Symbol)
 
     println(io, "#### Two-argument functions `f!(y, x)`")
     println(io)
-    if mutation_support(backend) == MutationSupported()
+    if twoarg_support(backend) == TwoArgSupported()
         print_overload_table(io, operators_and_types_f!(backend), ext)
     else
         println(io, "Backend doesn't support mutating functions.")

--- a/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/DifferentiationInterfaceChainRulesCoreExt.jl
@@ -18,7 +18,7 @@ const AutoForwardChainRules = AutoChainRules{<:RuleConfig{>:HasForwardsMode}}
 const AutoReverseChainRules = AutoChainRules{<:RuleConfig{>:HasReverseMode}}
 
 DI.check_available(::AutoChainRules) = true
-DI.mutation_support(::AutoChainRules) = DI.MutationNotSupported()
+DI.twoarg_support(::AutoChainRules) = DI.TwoArgNotSupported()
 
 include("reverse_onearg.jl")
 include("differentiate_with.jl")

--- a/DifferentiationInterface/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceDiffractorExt/DifferentiationInterfaceDiffractorExt.jl
@@ -6,7 +6,7 @@ using DifferentiationInterface: NoPushforwardExtras
 using Diffractor: DiffractorRuleConfig, TaylorTangentIndex, ZeroBundle, bundle, ∂☆
 
 DI.check_available(::AutoDiffractor) = true
-DI.mutation_support(::AutoDiffractor) = DI.MutationNotSupported()
+DI.twoarg_support(::AutoDiffractor) = DI.TwoArgNotSupported()
 DI.pullback_performance(::AutoDiffractor) = DI.PullbackSlow()
 
 ## Pushforward

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
@@ -9,7 +9,7 @@ using FiniteDifferences: FiniteDifferences, grad, jacobian, jvp, j′vp
 using LinearAlgebra: dot
 
 DI.check_available(::AutoFiniteDifferences) = true
-DI.mutation_support(::AutoFiniteDifferences) = DI.MutationNotSupported()
+DI.twoarg_support(::AutoFiniteDifferences) = DI.TwoArgNotSupported()
 
 function FiniteDifferences.to_vec(a::OneElement)  # TODO: remove type piracy (https://github.com/JuliaDiff/FiniteDifferences.jl/issues/141)
     return FiniteDifferences.to_vec(collect(a))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -6,7 +6,7 @@ using DifferentiationInterface: NoGradientExtras, NoPullbackExtras
 using Tracker: Tracker, back, data, forward, gradient, jacobian, param, withgradient
 
 DI.check_available(::AutoTracker) = true
-DI.mutation_support(::AutoTracker) = DI.MutationNotSupported()
+DI.twoarg_support(::AutoTracker) = DI.TwoArgNotSupported()
 
 ## Pullback
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -9,7 +9,7 @@ using Zygote:
     ZygoteRuleConfig, gradient, hessian, jacobian, pullback, withgradient, withjacobian
 
 DI.check_available(::AutoZygote) = true
-DI.mutation_support(::AutoZygote) = DI.MutationNotSupported()
+DI.twoarg_support(::AutoZygote) = DI.TwoArgNotSupported()
 
 ## Pullback
 

--- a/DifferentiationInterface/src/sparse/fallbacks.jl
+++ b/DifferentiationInterface/src/sparse/fallbacks.jl
@@ -2,7 +2,7 @@
 
 for trait in (
     :check_available,
-    :mutation_support,
+    :twoarg_support,
     :pushforward_performance,
     :pullback_performance,
     :hvp_mode,

--- a/DifferentiationInterface/src/utils/check.jl
+++ b/DifferentiationInterface/src/utils/check.jl
@@ -14,7 +14,7 @@ end
 
 Check whether `backend` supports differentiation of two-argument functions.
 """
-check_twoarg(backend::AbstractADType) = Bool(mutation_support(backend))
+check_twoarg(backend::AbstractADType) = Bool(twoarg_support(backend))
 
 sqnorm(x::AbstractArray) = sum(abs2, x)
 

--- a/DifferentiationInterface/src/utils/traits.jl
+++ b/DifferentiationInterface/src/utils/traits.jl
@@ -3,25 +3,25 @@
 abstract type MutationBehavior end
 
 """
-    MutationSupported
+    TwoArgSupported
 
 Trait identifying backends that support two-argument functions `f!(y, x)`.
 """
-struct MutationSupported <: MutationBehavior end
+struct TwoArgSupported <: MutationBehavior end
 
 """
-    MutationNotSupported
+    TwoArgNotSupported
 
 Trait identifying backends that do not support two-argument functions `f!(y, x)`.
 """
-struct MutationNotSupported <: MutationBehavior end
+struct TwoArgNotSupported <: MutationBehavior end
 
 """
-    mutation_support(backend)
+    twoarg_support(backend)
 
-Return [`MutationSupported`](@ref) or [`MutationNotSupported`](@ref) in a statically predictable way.
+Return [`TwoArgSupported`](@ref) or [`TwoArgNotSupported`](@ref) in a statically predictable way.
 """
-mutation_support(::AbstractADType) = MutationSupported()
+twoarg_support(::AbstractADType) = TwoArgSupported()
 
 ## Pushforward
 
@@ -132,8 +132,8 @@ end
 
 ## Conversions
 
-Base.Bool(::MutationSupported) = true
-Base.Bool(::MutationNotSupported) = false
+Base.Bool(::TwoArgSupported) = true
+Base.Bool(::TwoArgNotSupported) = false
 
 Base.Bool(::PushforwardFast) = true
 Base.Bool(::PushforwardSlow) = false

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -26,7 +26,7 @@ using DifferentiationInterface:
     inner,
     mode,
     outer,
-    mutation_support,
+    twoarg_support,
     pushforward_performance,
     pullback_performance
 using DifferentiationInterface:

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -49,7 +49,7 @@ operator_place(::AbstractScenario{args,op}) where {args,op} = op
 
 function compatible(backend::AbstractADType, scen::AbstractScenario)
     if nb_args(scen) == 2
-        return Bool(mutation_support(backend))
+        return Bool(twoarg_support(backend))
     end
     return true
 end

--- a/DifferentiationInterfaceTest/src/utils/zero_backends.jl
+++ b/DifferentiationInterfaceTest/src/utils/zero_backends.jl
@@ -12,7 +12,7 @@ struct AutoZeroForward <: AbstractADType end
 
 ADTypes.mode(::AutoZeroForward) = ForwardMode()
 DI.check_available(::AutoZeroForward) = true
-DI.mutation_support(::AutoZeroForward) = DI.MutationSupported()
+DI.twoarg_support(::AutoZeroForward) = DI.TwoArgSupported()
 
 DI.prepare_pushforward(f, ::AutoZeroForward, x, dx) = NoPushforwardExtras()
 DI.prepare_pushforward(f!, y, ::AutoZeroForward, x, dx) = NoPushforwardExtras()
@@ -55,7 +55,7 @@ struct AutoZeroReverse <: AbstractADType end
 
 ADTypes.mode(::AutoZeroReverse) = ReverseMode()
 DI.check_available(::AutoZeroReverse) = true
-DI.mutation_support(::AutoZeroReverse) = DI.MutationSupported()
+DI.twoarg_support(::AutoZeroReverse) = DI.TwoArgSupported()
 
 DI.prepare_pullback(f, ::AutoZeroReverse, x, dy) = NoPullbackExtras()
 DI.prepare_pullback(f!, y, ::AutoZeroReverse, x, dy) = NoPullbackExtras()


### PR DESCRIPTION
**Core**

- Rename `mutation_support` into `twoarg_support`
- Rename `Mutation(Not)Supported` into `TwoArg(Not)Supported`