### PR TITLE
Add type annotations on f in DI

### DIFF
--- a/DifferentiationInterface/src/first_order/derivative.jl
+++ b/DifferentiationInterface/src/first_order/derivative.jl
@@ -49,12 +49,12 @@ struct PushforwardDerivativeExtras{E<:PushforwardExtras} <: DerivativeExtras
     pushforward_extras::E
 end
 
-function prepare_derivative(f, backend::AbstractADType, x)
+function prepare_derivative(f::F, backend::AbstractADType, x) where {F}
     dx = one(x)
     return PushforwardDerivativeExtras(prepare_pushforward(f, backend, x, dx))
 end
 
-function prepare_derivative(f!, y, backend::AbstractADType, x)
+function prepare_derivative(f!::F, y, backend::AbstractADType, x) where {F}
     dx = one(x)
     pushforward_extras = prepare_pushforward(f!, y, backend, x, dx)
     return PushforwardDerivativeExtras(pushforward_extras)
@@ -63,83 +63,83 @@ end
 ## One argument
 
 function value_and_derivative(
-    f,
+    f::F,
     backend::AbstractADType,
     x,
     extras::DerivativeExtras=prepare_derivative(f, backend, x),
-)
+) where {F}
     return value_and_pushforward(f, backend, x, one(x), extras.pushforward_extras)
 end
 
 function value_and_derivative!(
-    f,
+    f::F,
     der,
     backend::AbstractADType,
     x,
     extras::DerivativeExtras=prepare_derivative(f, backend, x),
-)
+) where {F}
     return value_and_pushforward!(f, der, backend, x, one(x), extras.pushforward_extras)
 end
 
 function derivative(
-    f,
+    f::F,
     backend::AbstractADType,
     x,
     extras::DerivativeExtras=prepare_derivative(f, backend, x),
-)
+) where {F}
     return pushforward(f, backend, x, one(x), extras.pushforward_extras)
 end
 
 function derivative!(
-    f,
+    f::F,
     der,
     backend::AbstractADType,
     x,
     extras::DerivativeExtras=prepare_derivative(f, backend, x),
-)
+) where {F}
     return pushforward!(f, der, backend, x, one(x), extras.pushforward_extras)
 end
 
 ## Two arguments
 
 function value_and_derivative(
-    f!,
+    f!::F,
     y,
     backend::AbstractADType,
     x,
     extras::DerivativeExtras=prepare_derivative(f!, y, backend, x),
-)
+) where {F}
     return value_and_pushforward(f!, y, backend, x, one(x), extras.pushforward_extras)
 end
 
 function value_and_derivative!(
-    f!,
+    f!::F,
     y,
     der,
     backend::AbstractADType,
     x,
     extras::DerivativeExtras=prepare_derivative(f!, y, backend, x),
-)
+) where {F}
     return value_and_pushforward!(f!, y, der, backend, x, one(x), extras.pushforward_extras)
 end
 
 function derivative(
-    f!,
+    f!::F,
     y,
     backend::AbstractADType,
     x,
     extras::DerivativeExtras=prepare_derivative(f!, y, backend, x),
-)
+) where {F}
     return pushforward(f!, y, backend, x, one(x), extras.pushforward_extras)
 end
 
 function derivative!(
-    f!,
+    f!::F,
     y,
     der,
     backend::AbstractADType,
     x,
     extras::DerivativeExtras=prepare_derivative(f!, y, backend, x),
-)
+) where {F}
     return pushforward!(f!, y, der, backend, x, one(x), extras.pushforward_extras)
 end

--- a/DifferentiationInterface/src/first_order/gradient.jl
+++ b/DifferentiationInterface/src/first_order/gradient.jl
@@ -42,7 +42,7 @@ struct PullbackGradientExtras{E<:PullbackExtras} <: GradientExtras
     pullback_extras::E
 end
 
-function prepare_gradient(f, backend::AbstractADType, x)
+function prepare_gradient(f::F, backend::AbstractADType, x) where {F}
     y = f(x)
     dy = one(y)
     pullback_extras = prepare_pullback(f, backend, x, dy)
@@ -52,33 +52,33 @@ end
 ## One argument
 
 function value_and_gradient(
-    f, backend::AbstractADType, x, extras::GradientExtras=prepare_gradient(f, backend, x)
-)
+    f::F, backend::AbstractADType, x, extras::GradientExtras=prepare_gradient(f, backend, x)
+) where {F}
     return value_and_pullback(f, backend, x, one(eltype(x)), extras.pullback_extras)
 end
 
 function value_and_gradient!(
-    f,
+    f::F,
     grad,
     backend::AbstractADType,
     x,
     extras::GradientExtras=prepare_gradient(f, backend, x),
-)
+) where {F}
     return value_and_pullback!(f, grad, backend, x, one(eltype(x)), extras.pullback_extras)
 end
 
 function gradient(
-    f, backend::AbstractADType, x, extras::GradientExtras=prepare_gradient(f, backend, x)
-)
+    f::F, backend::AbstractADType, x, extras::GradientExtras=prepare_gradient(f, backend, x)
+) where {F}
     return pullback(f, backend, x, one(eltype(x)), extras.pullback_extras)
 end
 
 function gradient!(
-    f,
+    f::F,
     grad,
     backend::AbstractADType,
     x,
     extras::GradientExtras=prepare_gradient(f, backend, x),
-)
+) where {F}
     return pullback!(f, grad, backend, x, one(eltype(x)), extras.pullback_extras)
 end

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -32,7 +32,7 @@ struct HVPHessianExtras{E<:HVPExtras} <: HessianExtras
     hvp_extras::E
 end
 
-function prepare_hessian(f, backend::AbstractADType, x)
+function prepare_hessian(f::F, backend::AbstractADType, x) where {F}
     v = basis(backend, x, first(CartesianIndices(x)))
     hvp_extras = prepare_hvp(f, backend, x, v)
     return HVPHessianExtras(hvp_extras)
@@ -41,16 +41,16 @@ end
 ## One argument
 
 function hessian(
-    f, backend::AbstractADType, x, extras::HessianExtras=prepare_hessian(f, backend, x)
-)
+    f::F, backend::AbstractADType, x, extras::HessianExtras=prepare_hessian(f, backend, x)
+) where {F}
     new_backend = SecondOrder(backend)
     new_extras = prepare_hessian(f, new_backend, x)
     return hessian(f, new_backend, x, new_extras)
 end
 
 function hessian(
-    f, backend::SecondOrder, x, extras::HessianExtras=prepare_hessian(f, backend, x)
-)
+    f::F, backend::SecondOrder, x, extras::HessianExtras=prepare_hessian(f, backend, x)
+) where {F}
     hess = stack(vec(CartesianIndices(x))) do j
         hess_col_j = hvp(f, backend, x, basis(backend, x, j), extras.hvp_extras)
         vec(hess_col_j)
@@ -59,20 +59,24 @@ function hessian(
 end
 
 function hessian!(
-    f,
+    f::F,
     hess,
     backend::AbstractADType,
     x,
     extras::HessianExtras=prepare_hessian(f, backend, x),
-)
+) where {F}
     new_backend = SecondOrder(backend)
     new_extras = prepare_hessian(f, new_backend, x)
     return hessian!(f, hess, new_backend, x, new_extras)
 end
 
 function hessian!(
-    f, hess, backend::SecondOrder, x, extras::HessianExtras=prepare_hessian(f, backend, x)
-)
+    f::F,
+    hess,
+    backend::SecondOrder,
+    x,
+    extras::HessianExtras=prepare_hessian(f, backend, x),
+) where {F}
     for (k, j) in enumerate(CartesianIndices(x))
         hess_col_j = reshape(view(hess, :, k), size(x))
         hvp!(f, hess_col_j, backend, x, basis(backend, x, j), extras.hvp_extras)

--- a/DifferentiationInterface/src/second_order/second_derivative.jl
+++ b/DifferentiationInterface/src/second_order/second_derivative.jl
@@ -33,9 +33,9 @@ struct ClosureSecondDerivativeExtras{C,E} <: SecondDerivativeExtras
     outer_derivative_extras::E
 end
 
-prepare_second_derivative(f, ::AbstractADType, x) = NoSecondDerivativeExtras()
+prepare_second_derivative(f::F, ::AbstractADType, x) where {F} = NoSecondDerivativeExtras()
 
-function prepare_second_derivative(f, backend::SecondOrder, x)
+function prepare_second_derivative(f::F, backend::SecondOrder, x) where {F}
     inner_derivative_closure(z) = derivative(f, inner(backend), z)
     outer_derivative_extras = prepare_derivative(
         inner_derivative_closure, outer(backend), x
@@ -46,45 +46,45 @@ end
 ## One argument
 
 function second_derivative(
-    f,
+    f::F,
     backend::AbstractADType,
     x,
     extras::SecondDerivativeExtras=prepare_second_derivative(f, backend, x),
-)
+) where {F}
     new_backend = SecondOrder(backend, backend)
     new_extras = prepare_second_derivative(f, new_backend, x)
     return second_derivative(f, new_backend, x, new_extras)
 end
 
 function second_derivative(
-    f,
+    f::F,
     backend::SecondOrder,
     x,
     extras::ClosureSecondDerivativeExtras=prepare_second_derivative(f, backend, x),
-)
+) where {F}
     (; inner_derivative_closure, outer_derivative_extras) = extras
     return derivative(inner_derivative_closure, outer(backend), x, outer_derivative_extras)
 end
 
 function second_derivative!(
-    f,
+    f::F,
     der2,
     backend::AbstractADType,
     x,
     extras::SecondDerivativeExtras=prepare_second_derivative(f, backend, x),
-)
+) where {F}
     new_backend = SecondOrder(backend, backend)
     new_extras = prepare_second_derivative(f, new_backend, x)
     return second_derivative!(f, der2, new_backend, x, new_extras)
 end
 
 function second_derivative!(
-    f,
+    f::F,
     der2,
     backend::SecondOrder,
     x,
     extras::SecondDerivativeExtras=prepare_second_derivative(f, backend, x),
-)
+) where {F}
     (; inner_derivative_closure, outer_derivative_extras) = extras
     return derivative!(
         inner_derivative_closure, der2, outer(backend), x, outer_derivative_extras

--- a/DifferentiationInterface/src/sparse/fallbacks.jl
+++ b/DifferentiationInterface/src/sparse/fallbacks.jl
@@ -27,28 +27,29 @@ for op in (:pushforward, :pullback, :hvp)
 
     ## One argument
     @eval begin
-        $prep(f, ba::AutoSparse, x, v) = $prep(f, dense_ad(ba), x, v)
-        $op(f, ba::AutoSparse, x, v, ex::$E=$prep(f, ba, x, v)) =
+        $prep(f::F, ba::AutoSparse, x, v) where {F} = $prep(f, dense_ad(ba), x, v)
+        $op(f::F, ba::AutoSparse, x, v, ex::$E=$prep(f, ba, x, v)) where {F} =
             $op(f, dense_ad(ba), x, v, ex)
-        $valop(f, ba::AutoSparse, x, v, ex::$E=$prep(f, ba, x, v)) =
+        $valop(f::F, ba::AutoSparse, x, v, ex::$E=$prep(f, ba, x, v)) where {F} =
             $valop(f, dense_ad(ba), x, v, ex)
-        $op!(f, res, ba::AutoSparse, x, v, ex::$E=$prep(f, ba, x, v)) =
+        $op!(f::F, res, ba::AutoSparse, x, v, ex::$E=$prep(f, ba, x, v)) where {F} =
             $op!(f, res, dense_ad(ba), x, v, ex)
-        $valop!(f, res, ba::AutoSparse, x, v, ex::$E=$prep(f, ba, x, v)) =
+        $valop!(f::F, res, ba::AutoSparse, x, v, ex::$E=$prep(f, ba, x, v)) where {F} =
             $valop!(f, res, dense_ad(ba), x, v, ex)
     end
 
     ## Two arguments
     @eval begin
-        $prep(f!, y, ba::AutoSparse, x, v) = $prep(f!, y, dense_ad(ba), x, v)
-        $op(f!, y, ba::AutoSparse, x, v, ex::$E=$prep(f!, y, ba, x, v)) =
+        $prep(f!::F, y, ba::AutoSparse, x, v) where {F} = $prep(f!, y, dense_ad(ba), x, v)
+        $op(f!::F, y, ba::AutoSparse, x, v, ex::$E=$prep(f!, y, ba, x, v)) where {F} =
             $op(f!, y, dense_ad(ba), x, v, ex)
-        $valop(f!, y, ba::AutoSparse, x, v, ex::$E=$prep(f!, y, ba, x, v)) =
+        $valop(f!::F, y, ba::AutoSparse, x, v, ex::$E=$prep(f!, y, ba, x, v)) where {F} =
             $valop(f!, y, dense_ad(ba), x, v, ex)
-        $op!(f!, y, res, ba::AutoSparse, x, v, ex::$E=$prep(f!, y, ba, x, v)) =
+        $op!(f!::F, y, res, ba::AutoSparse, x, v, ex::$E=$prep(f!, y, ba, x, v)) where {F} =
             $op!(f!, y, res, dense_ad(ba), x, v, ex)
-        $valop!(f!, y, res, ba::AutoSparse, x, v, ex::$E=$prep(f!, y, ba, x, v)) =
-            $valop!(f!, y, res, dense_ad(ba), x, v, ex)
+        $valop!(
+            f!::F, y, res, ba::AutoSparse, x, v, ex::$E=$prep(f!, y, ba, x, v)
+        ) where {F} = $valop!(f!, y, res, dense_ad(ba), x, v, ex)
     end
 
     ## Split
@@ -57,14 +58,16 @@ for op in (:pushforward, :pullback, :hvp)
         valop!_split = Symbol("value_and_", op!, "_split")
 
         @eval begin
-            $valop_split(f, ba::AutoSparse, x, ex::$E=$prep(f, ba, x, f(x))) =
+            $valop_split(f::F, ba::AutoSparse, x, ex::$E=$prep(f, ba, x, f(x))) where {F} =
                 $valop_split(f, dense_ad(ba), x, ex)
-            $valop!_split(f, ba::AutoSparse, x, ex::$E=$prep(f, ba, x, f(x))) =
+            $valop!_split(f::F, ba::AutoSparse, x, ex::$E=$prep(f, ba, x, f(x))) where {F} =
                 $valop!_split(f, dense_ad(ba), x, ex)
-            $valop_split(f!, y, ba::AutoSparse, x, ex::$E=$prep(f, ba, x, similar(y))) =
-                $valop_split(f!, y, dense_ad(ba), x, ex)
-            $valop!_split(f!, y, ba::AutoSparse, x, ex::$E=$prep(f, ba, x, similar(y))) =
-                $valop!_split(f!, y, dense_ad(ba), x, ex)
+            $valop_split(
+                f!::F, y, ba::AutoSparse, x, ex::$E=$prep(f, ba, x, similar(y))
+            ) where {F} = $valop_split(f!, y, dense_ad(ba), x, ex)
+            $valop!_split(
+                f!::F, y, ba::AutoSparse, x, ex::$E=$prep(f, ba, x, similar(y))
+            ) where {F} = $valop!_split(f!, y, dense_ad(ba), x, ex)
         end
     end
 end
@@ -84,28 +87,30 @@ for op in (:derivative, :gradient, :second_derivative)
 
     ## One argument
     @eval begin
-        $prep(f, ba::AutoSparse, x) = $prep(f, dense_ad(ba), x)
-        $op(f, ba::AutoSparse, x, ex::$E=$prep(f, ba, x)) = $op(f, dense_ad(ba), x, ex)
-        $valop(f, ba::AutoSparse, x, ex::$E=$prep(f, ba, x)) =
+        $prep(f::F, ba::AutoSparse, x) where {F} = $prep(f, dense_ad(ba), x)
+        $op(f::F, ba::AutoSparse, x, ex::$E=$prep(f, ba, x)) where {F} =
+            $op(f, dense_ad(ba), x, ex)
+        $valop(f::F, ba::AutoSparse, x, ex::$E=$prep(f, ba, x)) where {F} =
             $valop(f, dense_ad(ba), x, ex)
-        $op!(f, res, ba::AutoSparse, x, ex::$E=$prep(f, ba, x)) =
+        $op!(f::F, res, ba::AutoSparse, x, ex::$E=$prep(f, ba, x)) where {F} =
             $op!(f, res, dense_ad(ba), x, ex)
-        $valop!(f, res, ba::AutoSparse, x, ex::$E=$prep(f, ba, x)) =
+        $valop!(f::F, res, ba::AutoSparse, x, ex::$E=$prep(f, ba, x)) where {F} =
             $valop!(f, res, dense_ad(ba), x, ex)
     end
 
     ## Two arguments
     if op in (:derivative,)
         @eval begin
-            $prep(f!, y, ba::AutoSparse, x) = $prep(f!, y, dense_ad(ba), x)
-            $op(f!, y, ba::AutoSparse, x, ex::$E=$prep(f!, y, ba, x)) =
+            $prep(f!::F, y, ba::AutoSparse, x) where {F} = $prep(f!, y, dense_ad(ba), x)
+            $op(f!::F, y, ba::AutoSparse, x, ex::$E=$prep(f!, y, ba, x)) where {F} =
                 $op(f!, y, dense_ad(ba), x, ex)
-            $valop(f!, y, ba::AutoSparse, x, ex::$E=$prep(f!, y, ba, x)) =
+            $valop(f!::F, y, ba::AutoSparse, x, ex::$E=$prep(f!, y, ba, x)) where {F} =
                 $valop(f!, y, dense_ad(ba), x, ex)
-            $op!(f!, y, res, ba::AutoSparse, x, ex::$E=$prep(f!, y, ba, x)) =
+            $op!(f!::F, y, res, ba::AutoSparse, x, ex::$E=$prep(f!, y, ba, x)) where {F} =
                 $op!(f!, y, res, dense_ad(ba), x, ex)
-            $valop!(f!, y, res, ba::AutoSparse, x, ex::$E=$prep(f!, y, ba, x)) =
-                $valop!(f!, y, res, dense_ad(ba), x, ex)
+            $valop!(
+                f!::F, y, res, ba::AutoSparse, x, ex::$E=$prep(f!, y, ba, x)
+            ) where {F} = $valop!(f!, y, res, dense_ad(ba), x, ex)
         end
     end
 end

--- a/DifferentiationInterface/src/sparse/hessian.jl
+++ b/DifferentiationInterface/src/sparse/hessian.jl
@@ -9,7 +9,7 @@ end
 
 ## Hessian, one argument
 
-function prepare_hessian(f, backend::AutoSparse, x)
+function prepare_hessian(f::F, backend::AutoSparse, x) where {F}
     initial_sparsity = hessian_sparsity(f, x, sparsity_detector(backend))
     sparsity = col_major(initial_sparsity)
     colors = column_coloring(sparsity, coloring_algorithm(backend))
@@ -28,7 +28,7 @@ function prepare_hessian(f, backend::AutoSparse, x)
     return SparseHessianExtras(; compressed, seeds, products, hvp_extras)
 end
 
-function hessian!(f, hess, backend::AutoSparse, x, extras::SparseHessianExtras)
+function hessian!(f::F, hess, backend::AutoSparse, x, extras::SparseHessianExtras) where {F}
     (; compressed, seeds, products, hvp_extras) = extras
     for k in eachindex(seeds, products)
         hvp!(f, products[k], backend, x, seeds[k], hvp_extras)
@@ -38,7 +38,7 @@ function hessian!(f, hess, backend::AutoSparse, x, extras::SparseHessianExtras)
     return hess
 end
 
-function hessian(f, backend::AutoSparse, x, extras::SparseHessianExtras)
+function hessian(f::F, backend::AutoSparse, x, extras::SparseHessianExtras) where {F}
     hess = similar(extras.compressed.sparsity, eltype(x))
     return hessian!(f, hess, backend, x, extras)
 end

--- a/DifferentiationInterface/src/sparse/jacobian.jl
+++ b/DifferentiationInterface/src/sparse/jacobian.jl
@@ -94,7 +94,7 @@ function value_and_jacobian!(
 end
 
 function value_and_jacobian(
-    f, backend::AutoSparse, x, extras::SparseJacobianExtras{1}
+    f::F, backend::AutoSparse, x, extras::SparseJacobianExtras{1}
 ) where {F}
     return f(x), jacobian(f, backend, x, extras)
 end

--- a/DifferentiationInterface/src/sparse/jacobian.jl
+++ b/DifferentiationInterface/src/sparse/jacobian.jl
@@ -21,7 +21,7 @@ end
 
 ## Jacobian, one argument
 
-function prepare_jacobian(f, backend::AutoSparse, x)
+function prepare_jacobian(f::F, backend::AutoSparse, x) where {F}
     y = f(x)
     initial_sparsity = jacobian_sparsity(f, x, sparsity_detector(backend))
     if Bool(pushforward_performance(backend))
@@ -58,7 +58,9 @@ function prepare_jacobian(f, backend::AutoSparse, x)
     return SparseJacobianExtras{1}(; compressed, seeds, products, jp_extras)
 end
 
-function jacobian!(f, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{1,:col})
+function jacobian!(
+    f::F, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{1,:col}
+) where {F}
     (; compressed, seeds, products, jp_extras) = extras
     for k in eachindex(seeds, products)
         pushforward!(f, products[k], backend, x, seeds[k], jp_extras)
@@ -68,7 +70,9 @@ function jacobian!(f, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{
     return jac
 end
 
-function jacobian!(f, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{1,:row})
+function jacobian!(
+    f::F, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{1,:row}
+) where {F}
     (; compressed, seeds, products, jp_extras) = extras
     for k in eachindex(seeds, products)
         pullback!(f, products[k], backend, x, seeds[k], jp_extras)
@@ -78,24 +82,26 @@ function jacobian!(f, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{
     return jac
 end
 
-function jacobian(f, backend::AutoSparse, x, extras::SparseJacobianExtras{1})
+function jacobian(f::F, backend::AutoSparse, x, extras::SparseJacobianExtras{1}) where {F}
     jac = major_respecting_similar(extras.compressed.sparsity, eltype(x))
     return jacobian!(f, jac, backend, x, extras)
 end
 
 function value_and_jacobian!(
-    f, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{1}
-)
+    f::F, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{1}
+) where {F}
     return f(x), jacobian!(f, jac, backend, x, extras)
 end
 
-function value_and_jacobian(f, backend::AutoSparse, x, extras::SparseJacobianExtras{1})
+function value_and_jacobian(
+    f, backend::AutoSparse, x, extras::SparseJacobianExtras{1}
+) where {F}
     return f(x), jacobian(f, backend, x, extras)
 end
 
 ## Jacobian, two arguments
 
-function prepare_jacobian(f!, y, backend::AutoSparse, x)
+function prepare_jacobian(f!::F, y, backend::AutoSparse, x) where {F}
     initial_sparsity = jacobian_sparsity(f!, y, x, sparsity_detector(backend))
     if Bool(pushforward_performance(backend))
         sparsity = col_major(initial_sparsity)
@@ -131,7 +137,9 @@ function prepare_jacobian(f!, y, backend::AutoSparse, x)
     return SparseJacobianExtras{2}(; compressed, seeds, products, jp_extras)
 end
 
-function jacobian!(f!, y, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{2,:col})
+function jacobian!(
+    f!::F, y, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{2,:col}
+) where {F}
     (; compressed, seeds, products, jp_extras) = extras
     for k in eachindex(seeds, products)
         pushforward!(f!, y, products[k], backend, x, seeds[k], jp_extras)
@@ -141,7 +149,9 @@ function jacobian!(f!, y, jac, backend::AutoSparse, x, extras::SparseJacobianExt
     return jac
 end
 
-function jacobian!(f!, y, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{2,:row})
+function jacobian!(
+    f!::F, y, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{2,:row}
+) where {F}
     (; compressed, seeds, products, jp_extras) = extras
     for k in eachindex(seeds, products)
         pullback!(f!, y, products[k], backend, x, seeds[k], jp_extras)
@@ -151,20 +161,24 @@ function jacobian!(f!, y, jac, backend::AutoSparse, x, extras::SparseJacobianExt
     return jac
 end
 
-function jacobian(f!, y, backend::AutoSparse, x, extras::SparseJacobianExtras{2})
+function jacobian(
+    f!::F, y, backend::AutoSparse, x, extras::SparseJacobianExtras{2}
+) where {F}
     jac = major_respecting_similar(extras.compressed.sparsity, eltype(x))
     return jacobian!(f!, y, jac, backend, x, extras)
 end
 
 function value_and_jacobian!(
-    f!, y, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{2}
-)
+    f!::F, y, jac, backend::AutoSparse, x, extras::SparseJacobianExtras{2}
+) where {F}
     jacobian!(f!, y, jac, backend, x, extras)
     f!(y, x)
     return y, jac
 end
 
-function value_and_jacobian(f!, y, backend::AutoSparse, x, extras::SparseJacobianExtras{2})
+function value_and_jacobian(
+    f!::F, y, backend::AutoSparse, x, extras::SparseJacobianExtras{2}
+) where {F}
     jac = jacobian(f!, y, backend, x, extras)
     f!(y, x)
     return y, jac


### PR DESCRIPTION
**Core**

- Add `f::F` and `where {F}` to the signature of every single operator, in order to force specialization