### PR TITLE
Better benchmarking + type annotations for ForwardDiff

### DIFF
--- a/DifferentiationInterfaceTest/docs/src/tutorial.md
+++ b/DifferentiationInterfaceTest/docs/src/tutorial.md
@@ -42,8 +42,8 @@ There is one scenario per operator, and so here we will use [`GradientScenario`]
 
 ```@repl tuto
 scenarios = [
-    GradientScenario(f; x=rand(Float32, 3), ref=∇f, operator=:inplace),
-    GradientScenario(f; x=rand(Float64, 3, 2), ref=∇f, operator=:inplace)
+    GradientScenario(f; x=rand(Float32, 3), ref=∇f, place=:inplace),
+    GradientScenario(f; x=rand(Float64, 3, 2), ref=∇f, place=:inplace)
 ];
 ```
 

--- a/DifferentiationInterfaceTest/docs/src/tutorial.md
+++ b/DifferentiationInterfaceTest/docs/src/tutorial.md
@@ -84,9 +84,9 @@ Note that we only compare (possibly) in-place operators, because they are always
 
 ```@example tuto
 function formatter(v, i, j)
-    if j in (14, 15)  # time, bytes
+    if j in (15, 16)  # time, bytes
         return Printf.@sprintf("%.1e", v)
-    elseif j == 16  # allocs
+    elseif j == 17  # allocs
         return Printf.@sprintf("%.1f", v)
     else
         return v

--- a/DifferentiationInterfaceTest/src/scenarios/component.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/component.jl
@@ -18,12 +18,12 @@ end
 function comp_to_num_scenarios_onearg(x::ComponentVector)
     # pushforward stays out of place
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
-                PullbackScenario(comp_to_num; x=x, ref=comp_to_num_pullback, operator=op),
-                GradientScenario(comp_to_num; x=x, ref=comp_to_num_gradient, operator=op),
+                PullbackScenario(comp_to_num; x=x, ref=comp_to_num_pullback, place=place),
+                GradientScenario(comp_to_num; x=x, ref=comp_to_num_gradient, place=place),
             ],
         )
     end
@@ -32,7 +32,7 @@ function comp_to_num_scenarios_onearg(x::ComponentVector)
             scens,
             [
                 PushforwardScenario(
-                    comp_to_num; x=x, ref=comp_to_num_pushforward, operator=op
+                    comp_to_num; x=x, ref=comp_to_num_pushforward, place=place
                 ),
             ],
         )

--- a/DifferentiationInterfaceTest/src/scenarios/component.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/component.jl
@@ -27,7 +27,7 @@ function comp_to_num_scenarios_onearg(x::ComponentVector)
             ],
         )
     end
-    for op in (:outofplace,)
+    for place in (:outofplace,)
         append!(
             scens,
             [

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -21,15 +21,11 @@ num_to_num_pullback(x, dy) = num_to_num_derivative(x) * dy
 function num_to_num_scenarios_onearg(x::Number)
     # everyone out of place
     return [
-        PushforwardScenario(
-            num_to_num; x=x, ref=num_to_num_pushforward, operator=:outofplace
-        ),
-        PullbackScenario(num_to_num; x=x, ref=num_to_num_pullback, operator=:outofplace),
-        DerivativeScenario(
-            num_to_num; x=x, ref=num_to_num_derivative, operator=:outofplace
-        ),
+        PushforwardScenario(num_to_num; x=x, ref=num_to_num_pushforward, place=:outofplace),
+        PullbackScenario(num_to_num; x=x, ref=num_to_num_pullback, place=:outofplace),
+        DerivativeScenario(num_to_num; x=x, ref=num_to_num_derivative, place=:outofplace),
         SecondDerivativeScenario(
-            num_to_num; x=x, ref=num_to_num_second_derivative, operator=:outofplace
+            num_to_num; x=x, ref=num_to_num_second_derivative, place=:outofplace
         ),
     ]
 end
@@ -72,28 +68,28 @@ end
 function num_to_arr_scenarios_onearg(x::Number, a::AbstractArray)
     # pullback stays out of place
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
                 PushforwardScenario(
-                    _num_to_arr(a); x=x, ref=_num_to_arr_pushforward(a), operator=op
+                    _num_to_arr(a); x=x, ref=_num_to_arr_pushforward(a), place=place
                 ),
                 DerivativeScenario(
-                    _num_to_arr(a); x=x, ref=_num_to_arr_derivative(a), operator=op
+                    _num_to_arr(a); x=x, ref=_num_to_arr_derivative(a), place=place
                 ),
                 SecondDerivativeScenario(
-                    _num_to_arr(a); x=x, ref=_num_to_arr_second_derivative(a), operator=op
+                    _num_to_arr(a); x=x, ref=_num_to_arr_second_derivative(a), place=place
                 ),
             ],
         )
     end
-    for op in (:outofplace,)
+    for place in (:outofplace,)
         append!(
             scens,
             [
                 PullbackScenario(
-                    _num_to_arr(a); x=x, ref=_num_to_arr_pullback(a), operator=op
+                    _num_to_arr(a); x=x, ref=_num_to_arr_pullback(a), place=place
                 ),
             ],
         )
@@ -104,7 +100,7 @@ end
 function num_to_arr_scenarios_twoarg(x::Number, a::AbstractArray)
     # pullback stays out of place
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
@@ -113,19 +109,19 @@ function num_to_arr_scenarios_twoarg(x::Number, a::AbstractArray)
                     x=x,
                     y=similar(float.(a)),
                     ref=_num_to_arr_pushforward(a),
-                    operator=op,
+                    place=place,
                 ),
                 DerivativeScenario(
                     _num_to_arr!(a);
                     x=x,
                     y=similar(float.(a)),
                     ref=_num_to_arr_derivative(a),
-                    operator=op,
+                    place=place,
                 ),
             ],
         )
     end
-    for op in (:outofplace,)
+    for place in (:outofplace,)
         append!(
             scens,
             [
@@ -134,7 +130,7 @@ function num_to_arr_scenarios_twoarg(x::Number, a::AbstractArray)
                     x=x,
                     y=similar(float.(a)),
                     ref=_num_to_arr_pullback(a),
-                    operator=op,
+                    place=place,
                 ),
             ],
         )
@@ -155,22 +151,22 @@ arr_to_num_hessian(x) = Matrix(Diagonal(-sin.(vec(x))))
 function arr_to_num_scenarios_onearg(x::AbstractArray)
     # pushforward stays out of place
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
-                PullbackScenario(arr_to_num; x=x, ref=arr_to_num_pullback, operator=op),
-                GradientScenario(arr_to_num; x=x, ref=arr_to_num_gradient, operator=op),
-                GradientScenario(arr_to_num; x=x, ref=arr_to_num_gradient, operator=op),
-                HVPScenario(arr_to_num; x=x, ref=arr_to_num_hvp, operator=op),
-                HessianScenario(arr_to_num; x=x, ref=arr_to_num_hessian, operator=op),
+                PullbackScenario(arr_to_num; x=x, ref=arr_to_num_pullback, place=place),
+                GradientScenario(arr_to_num; x=x, ref=arr_to_num_gradient, place=place),
+                GradientScenario(arr_to_num; x=x, ref=arr_to_num_gradient, place=place),
+                HVPScenario(arr_to_num; x=x, ref=arr_to_num_hvp, place=place),
+                HessianScenario(arr_to_num; x=x, ref=arr_to_num_hessian, place=place),
             ],
         )
     end
-    for op in (:outofplace,)
+    for place in (:outofplace,)
         append!(
             scens,
-            [PushforwardScenario(arr_to_num; x=x, ref=arr_to_num_pushforward, operator=op)],
+            [PushforwardScenario(arr_to_num; x=x, ref=arr_to_num_pushforward, place=place)],
         )
     end
     return scens
@@ -192,15 +188,15 @@ vec_to_vec_jacobian(x) = vcat(Diagonal(cos.(x)), Diagonal(-sin.(x)))
 
 function vec_to_vec_scenarios_onearg(x::AbstractVector)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
                 PushforwardScenario(
-                    vec_to_vec; x=x, ref=vec_to_vec_pushforward, operator=op
+                    vec_to_vec; x=x, ref=vec_to_vec_pushforward, place=place
                 ),
-                PullbackScenario(vec_to_vec; x=x, ref=vec_to_vec_pullback, operator=op),
-                JacobianScenario(vec_to_vec; x=x, ref=vec_to_vec_jacobian, operator=op),
+                PullbackScenario(vec_to_vec; x=x, ref=vec_to_vec_pullback, place=place),
+                JacobianScenario(vec_to_vec; x=x, ref=vec_to_vec_jacobian, place=place),
             ],
         )
     end
@@ -210,7 +206,7 @@ end
 function vec_to_vec_scenarios_twoarg(x::AbstractVector)
     n = length(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
@@ -219,13 +215,13 @@ function vec_to_vec_scenarios_twoarg(x::AbstractVector)
                     x=x,
                     y=similar(x, 2n),
                     ref=vec_to_vec_pushforward,
-                    operator=op,
+                    place=place,
                 ),
                 PullbackScenario(
-                    vec_to_vec!; x=x, y=similar(x, 2n), ref=vec_to_vec_pullback, operator=op
+                    vec_to_vec!; x=x, y=similar(x, 2n), ref=vec_to_vec_pullback, place=place
                 ),
                 JacobianScenario(
-                    vec_to_vec!; x=x, y=similar(x, 2n), ref=vec_to_vec_jacobian, operator=op
+                    vec_to_vec!; x=x, y=similar(x, 2n), ref=vec_to_vec_jacobian, place=place
                 ),
             ],
         )
@@ -247,15 +243,15 @@ vec_to_mat_jacobian(x) = vcat(Diagonal(cos.(x)), Diagonal(-sin.(x)))
 
 function vec_to_mat_scenarios_onearg(x::AbstractVector)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
                 PushforwardScenario(
-                    vec_to_mat; x=x, ref=vec_to_mat_pushforward, operator=op
+                    vec_to_mat; x=x, ref=vec_to_mat_pushforward, place=place
                 ),
-                PullbackScenario(vec_to_mat; x=x, ref=vec_to_mat_pullback, operator=op),
-                JacobianScenario(vec_to_mat; x=x, ref=vec_to_mat_jacobian, operator=op),
+                PullbackScenario(vec_to_mat; x=x, ref=vec_to_mat_pullback, place=place),
+                JacobianScenario(vec_to_mat; x=x, ref=vec_to_mat_jacobian, place=place),
             ],
         )
     end
@@ -265,7 +261,7 @@ end
 function vec_to_mat_scenarios_twoarg(x::AbstractVector)
     n = length(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
@@ -274,21 +270,21 @@ function vec_to_mat_scenarios_twoarg(x::AbstractVector)
                     x=x,
                     y=similar(x, n, 2),
                     ref=vec_to_mat_pushforward,
-                    operator=op,
+                    place=place,
                 ),
                 PullbackScenario(
                     vec_to_mat!;
                     x=x,
                     y=similar(x, n, 2),
                     ref=vec_to_mat_pullback,
-                    operator=op,
+                    place=place,
                 ),
                 JacobianScenario(
                     vec_to_mat!;
                     x=x,
                     y=similar(x, n, 2),
                     ref=vec_to_mat_jacobian,
-                    operator=op,
+                    place=place,
                 ),
             ],
         )
@@ -319,18 +315,18 @@ mat_to_vec_jacobian(x) = vcat(Diagonal(vec(cos.(x))), Diagonal(vec(-sin.(x))))
 function mat_to_vec_scenarios_onearg(x::AbstractMatrix)
     m, n = size(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
                 PushforwardScenario(
-                    mat_to_vec; x=x, ref=mat_to_vec_pushforward, operator=op
+                    mat_to_vec; x=x, ref=mat_to_vec_pushforward, place=place
                 ),
                 PullbackScenario(
-                    mat_to_vec; x=randn(m, n), ref=mat_to_vec_pullback, operator=op
+                    mat_to_vec; x=randn(m, n), ref=mat_to_vec_pullback, place=place
                 ),
                 JacobianScenario(
-                    mat_to_vec; x=randn(m, n), ref=mat_to_vec_jacobian, operator=op
+                    mat_to_vec; x=randn(m, n), ref=mat_to_vec_jacobian, place=place
                 ),
             ],
         )
@@ -341,7 +337,7 @@ end
 function mat_to_vec_scenarios_twoarg(x::AbstractMatrix)
     m, n = size(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
@@ -350,21 +346,21 @@ function mat_to_vec_scenarios_twoarg(x::AbstractMatrix)
                     x=x,
                     y=similar(x, m * n * 2),
                     ref=mat_to_vec_pushforward,
-                    operator=op,
+                    place=place,
                 ),
                 PullbackScenario(
                     mat_to_vec!;
                     x=x,
                     y=similar(x, m * n * 2),
                     ref=mat_to_vec_pullback,
-                    operator=op,
+                    place=place,
                 ),
                 JacobianScenario(
                     mat_to_vec!;
                     x=x,
                     y=similar(x, m * n * 2),
                     ref=mat_to_vec_jacobian,
-                    operator=op,
+                    place=place,
                 ),
             ],
         )
@@ -393,15 +389,15 @@ mat_to_mat_jacobian(x) = vcat(Diagonal(vec(cos.(x))), Diagonal(vec(-sin.(x))))
 
 function mat_to_mat_scenarios_onearg(x::AbstractMatrix)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
                 PushforwardScenario(
-                    mat_to_mat; x=x, ref=mat_to_mat_pushforward, operator=op
+                    mat_to_mat; x=x, ref=mat_to_mat_pushforward, place=place
                 ),
-                PullbackScenario(mat_to_mat; x=x, ref=mat_to_mat_pullback, operator=op),
-                JacobianScenario(mat_to_mat; x=x, ref=mat_to_mat_jacobian, operator=op),
+                PullbackScenario(mat_to_mat; x=x, ref=mat_to_mat_pullback, place=place),
+                JacobianScenario(mat_to_mat; x=x, ref=mat_to_mat_jacobian, place=place),
             ],
         )
     end
@@ -411,7 +407,7 @@ end
 function mat_to_mat_scenarios_twoarg(x::AbstractMatrix)
     m, n = size(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
@@ -420,21 +416,21 @@ function mat_to_mat_scenarios_twoarg(x::AbstractMatrix)
                     x=x,
                     y=similar(x, m * n, 2),
                     ref=mat_to_mat_pushforward,
-                    operator=op,
+                    place=place,
                 ),
                 PullbackScenario(
                     mat_to_mat!;
                     x=x,
                     y=similar(x, m * n, 2),
                     ref=mat_to_mat_pullback,
-                    operator=op,
+                    place=place,
                 ),
                 JacobianScenario(
                     mat_to_mat!;
                     x=x,
                     y=similar(x, m * n, 2),
                     ref=mat_to_mat_jacobian,
-                    operator=op,
+                    place=place,
                 ),
             ],
         )

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -68,144 +68,109 @@ end
 ## Struct definitions
 
 """
-    PushforwardScenario(f; x, y, dx, ref, operator)
+    PushforwardScenario(f; x, y, dx, ref, place)
 
 See [`AbstractScenario`](@ref) for details.
 """
 struct PushforwardScenario{args,place,F,X,Y,DX,R} <:
        AbstractFirstOrderScenario{args,place,F,X,Y,R}
-    "function"
     f::F
-    "input"
     x::X
-    "output"
     y::Y
-    "pushforward seed"
     dx::DX
-    "reference pushforward operator or backend to compare against"
     ref::R
 end
 
 """
-    PullbackScenario(f; x, y, dy, ref, operator)
+    PullbackScenario(f; x, y, dy, ref, place)
 
 See [`AbstractScenario`](@ref) for details.
 """
 struct PullbackScenario{args,place,F,X,Y,DY,R} <:
        AbstractFirstOrderScenario{args,place,F,X,Y,R}
-    "function"
     f::F
-    "input"
     x::X
-    "output"
     y::Y
-    "pullback seed"
     dy::DY
-    "reference pullback operator or backend to compare against"
     ref::R
 end
 
 """
-    DerivativeScenario(f; x, y, ref, operator)
+    DerivativeScenario(f; x, y, ref, place)
 
 See [`AbstractScenario`](@ref) for details.
 """
 struct DerivativeScenario{args,place,F,X<:Number,Y,R} <:
        AbstractFirstOrderScenario{args,place,F,X,Y,R}
-    "function"
     f::F
-    "input"
     x::X
-    "output"
     y::Y
-    "reference derivative operator or backend to compare against"
     ref::R
 end
 
 """
-    GradientScenario(f; x, y, ref, operator)
+    GradientScenario(f; x, y, ref, place)
 
 See [`AbstractScenario`](@ref) for details.
 """
 struct GradientScenario{args,place,F,X,Y<:Number,R} <:
        AbstractFirstOrderScenario{args,place,F,X,Y,R}
-    "function"
     f::F
-    "input"
     x::X
-    "output"
     y::Y
-    "reference gradient operator or backend to compare against"
     ref::R
 end
 
 """
-    JacobianScenario(f; x, y, ref, operator)
+    JacobianScenario(f; x, y, ref, place)
 
 See [`AbstractScenario`](@ref) for details.
 """
 struct JacobianScenario{args,place,F,X<:AbstractArray,Y<:AbstractArray,R} <:
        AbstractFirstOrderScenario{args,place,F,X,Y,R}
-    "function"
     f::F
-    "input"
     x::X
-    "output"
     y::Y
-    "reference Jacobian operator or backend to compare against"
     ref::R
 end
 
 """
-    SecondDerivativeScenario(f; x, y, ref, operator)
+    SecondDerivativeScenario(f; x, y, ref, place)
 
 See [`AbstractScenario`](@ref) for details.
 """
 struct SecondDerivativeScenario{args,place,F,X<:Number,Y,R} <:
        AbstractSecondOrderScenario{args,place,F,X,Y,R}
-    "function"
     f::F
-    "input"
     x::X
-    "output"
     y::Y
-    "reference second derivative operator or backend to compare against"
     ref::R
 end
 
 """
-    HVPScenario(f; x, y, dx, ref, operator)
+    HVPScenario(f; x, y, dx, ref, place)
 
 See [`AbstractScenario`](@ref) for details.
 """
 struct HVPScenario{args,place,F,X,Y<:Number,DX,R} <:
        AbstractSecondOrderScenario{args,place,F,X,Y,R}
-    "function"
     f::F
-    "input"
     x::X
-    "output"
     y::Y
-    "Hessian-vector product seed"
     dx::DX
-    "reference Hessian-vector product operator or backend to compare against"
     ref::R
 end
 
 """
-    HessianScenario(f; x, y, ref, operator)
+    HessianScenario(f; x, y, ref, place)
 
 See [`AbstractScenario`](@ref) for details.
 """
 struct HessianScenario{args,place,F,X<:AbstractArray,Y<:Number,R} <:
        AbstractSecondOrderScenario{args,place,F,X,Y,R}
-    "function"
     f::F
-    "input"
     x::X
-    "output"
     y::Y
-    "reference Hessian operator or backend to compare against"
     ref::R
 end
 

--- a/DifferentiationInterfaceTest/src/scenarios/sparse.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/sparse.jl
@@ -32,17 +32,17 @@ end
 function sparse_vec_to_vec_scenarios(x::AbstractVector)
     n = length(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
-                JacobianScenario(diffsquare; x=x, ref=diffsquare_jacobian, operator=op),
+                JacobianScenario(diffsquare; x=x, ref=diffsquare_jacobian, place=place),
                 JacobianScenario(
                     diffsquare!;
                     x=x,
                     y=similar(x, n - 1),
                     ref=diffsquare_jacobian,
-                    operator=op,
+                    place=place,
                 ),
             ],
         )
@@ -70,7 +70,7 @@ end
 function sparse_mat_to_vec_scenarios(x::AbstractMatrix)
     m, n = size(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
@@ -78,14 +78,14 @@ function sparse_mat_to_vec_scenarios(x::AbstractMatrix)
                     diffsquarecube_matvec;
                     x=x,
                     ref=diffsquarecube_matvec_jacobian,
-                    operator=op,
+                    place=place,
                 ),
                 JacobianScenario(
                     diffsquarecube_matvec!;
                     x=x,
                     y=similar(x, 2(m * n) - 2),
                     ref=diffsquarecube_matvec_jacobian,
-                    operator=op,
+                    place=place,
                 ),
             ],
         )
@@ -110,7 +110,7 @@ end
 function sparse_vec_to_mat_scenarios(x::AbstractVector)
     n = length(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
@@ -118,14 +118,14 @@ function sparse_vec_to_mat_scenarios(x::AbstractVector)
                     diffsquarecube_vecmat;
                     x=x,
                     ref=diffsquarecube_vecmat_jacobian,
-                    operator=op,
+                    place=place,
                 ),
                 JacobianScenario(
                     diffsquarecube_vecmat!;
                     x=x,
                     y=similar(x, n - 1, 2),
                     ref=diffsquarecube_vecmat_jacobian,
-                    operator=op,
+                    place=place,
                 ),
             ],
         )
@@ -152,7 +152,7 @@ end
 function sparse_mat_to_mat_scenarios(x::AbstractMatrix)
     m, n = size(x)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
@@ -160,14 +160,14 @@ function sparse_mat_to_mat_scenarios(x::AbstractMatrix)
                     diffsquarecube_matmat;
                     x=x,
                     ref=diffsquarecube_matmat_jacobian,
-                    operator=op,
+                    place=place,
                 ),
                 JacobianScenario(
                     diffsquarecube_matmat!;
                     x=x,
                     y=similar(x, m * n - 1, 2),
                     ref=diffsquarecube_matmat_jacobian,
-                    operator=op,
+                    place=place,
                 ),
             ],
         )
@@ -187,9 +187,9 @@ end
 
 function sparse_vec_to_num_scenarios(x::AbstractVector)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
-            scens, [HessianScenario(sumdiffcube; x=x, ref=sumdiffcube_hessian, operator=op)]
+            scens, [HessianScenario(sumdiffcube; x=x, ref=sumdiffcube_hessian, place=place)]
         )
     end
     return scens
@@ -207,12 +207,12 @@ end
 
 function sparse_mat_to_num_scenarios(x::AbstractMatrix)
     scens = AbstractScenario[]
-    for op in (:outofplace, :inplace)
+    for place in (:outofplace, :inplace)
         append!(
             scens,
             [
                 HessianScenario(
-                    sumdiffcube_mat; x=x, ref=sumdiffcube_mat_hessian, operator=op
+                    sumdiffcube_mat; x=x, ref=sumdiffcube_mat_hessian, place=place
                 ),
             ],
         )

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -94,7 +94,7 @@ function test_differentiation(
                             (:scenario_type, "$st - $j/$(length(grouped_scenarios))"),
                             (:scenario, "$k/$(length(st_group))"),
                             (:arguments, nb_args(scen)),
-                            (:operator, operator_place(scen)),
+                            (:place, operator_place(scen)),
                             (:function, scen.f),
                             (:input_type, typeof(scen.x)),
                             (:input_size, size(scen.x)),
@@ -180,7 +180,7 @@ function benchmark_differentiation(
                         (:scenario_type, "$st - $j/$(length(grouped_scenarios))"),
                         (:scenario, "$k/$(length(st_group))"),
                         (:arguments, nb_args(scen)),
-                        (:operator, operator_place(scen)),
+                        (:place, operator_place(scen)),
                         (:function, scen.f),
                         (:input_type, typeof(scen.x)),
                         (:input_size, size(scen.x)),
@@ -188,7 +188,7 @@ function benchmark_differentiation(
                         (:output_size, size(scen.y)),
                     ],
                 )
-                run_benchmark!(benchmark_data, backend, scen)
+                run_benchmark!(benchmark_data, backend, scen; logging)
             end
         end
     end

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -19,10 +19,10 @@ Testing:
 
 Filtering:
 
-- `input_type=Any`: restrict scenario inputs to subtypes of this
-- `output_type=Any`: restrict scenario outputs to subtypes of this
-- `first_order=true`: include first order operators
-- `second_order=true`: include second order operators
+- `input_type=Any`, `output_type=Any`: restrict scenario inputs / outputs to subtypes of this
+- `first_order=true`, `second_order=true`: include first order / second order operators
+- `onearg=true`, `twoarg=true`: include one-argument / two-argument functions
+- `inplace=true`, `outofplace=true`: include in-place / out-of-place operators
 
 Options:
 
@@ -46,6 +46,10 @@ function test_differentiation(
     output_type::Type=Any,
     first_order=true,
     second_order=true,
+    onearg=true,
+    twoarg=true,
+    inplace=true,
+    outofplace=true,
     excluded=[],
     # options
     logging=false,
@@ -54,7 +58,16 @@ function test_differentiation(
     rtol=1e-3,
 )
     scenarios = filter_scenarios(
-        scenarios; first_order, second_order, input_type, output_type, excluded
+        scenarios;
+        first_order,
+        second_order,
+        input_type,
+        output_type,
+        onearg,
+        twoarg,
+        inplace,
+        outofplace,
+        excluded,
     )
 
     title_additions =
@@ -132,12 +145,25 @@ function benchmark_differentiation(
     output_type::Type=Any,
     first_order=true,
     second_order=true,
+    onearg=true,
+    twoarg=true,
+    inplace=true,
+    outofplace=true,
     excluded=[],
     # options
     logging=false,
 )
     scenarios = filter_scenarios(
-        scenarios; first_order, second_order, input_type, output_type, excluded
+        scenarios;
+        first_order,
+        second_order,
+        input_type,
+        output_type,
+        onearg,
+        twoarg,
+        inplace,
+        outofplace,
+        excluded,
     )
 
     benchmark_data = BenchmarkDataRow[]

--- a/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -129,7 +129,7 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_pushforward(f, ba, x, dx)
-        bench0 = @be prepare_pushforward(f, ba, x, dx) evals = 1 samples = 1
+        bench0 = @be prepare_pushforward(f, ba, x, dx) samples = 1 evals = 1
         bench1 = @be value_and_pushforward(f, ba, x, dx, extras)
         bench2 = @be pushforward(f, ba, x, dx, extras)
         # count
@@ -162,9 +162,10 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_pushforward(f, ba, x, dx)
-        bench0 = @be prepare_pushforward(f, ba, x, dx) evals = 1 samples = 1
-        bench1 = @be mysimilar(y) value_and_pushforward!(f, _, ba, x, dx, extras)
-        bench2 = @be mysimilar(y) pushforward!(f, _, ba, x, dx, extras)
+        bench0 = @be prepare_pushforward(f, ba, x, dx) samples = 1 evals = 1
+        bench1 = @be mysimilar(y) value_and_pushforward!(f, _, ba, x, dx, extras) evals =
+            1
+        bench2 = @be mysimilar(y) pushforward!(f, _, ba, x, dx, extras) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_pushforward(cc, ba, x, dx)
@@ -196,10 +197,11 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_pushforward(f!, mysimilar(y), ba, x, dx)
-        bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x, dx) evals = 1 samples =
+        bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x, dx) samples = 1 evals =
             1
-        bench1 = @be mysimilar(y) value_and_pushforward(f!, _, ba, x, dx, extras)
-        bench2 = @be mysimilar(y) pushforward(f!, _, ba, x, dx, extras)
+        bench1 = @be mysimilar(y) value_and_pushforward(f!, _, ba, x, dx, extras) evals =
+            1
+        bench2 = @be mysimilar(y) pushforward(f!, _, ba, x, dx, extras) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_pushforward(cc!, mysimilar(y), ba, x, dx)
@@ -235,10 +237,10 @@ function run_benchmark!(
             1
         bench1 = @be (mysimilar(y), mysimilar(y)) value_and_pushforward!(
             f!, _[1], _[2], ba, x, dx, extras
-        )
+        ) evals = 1
         bench2 = @be (mysimilar(y), mysimilar(y)) pushforward!(
             f!, _[1], _[2], ba, x, dx, extras
-        )
+        ) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_pushforward(cc!, mysimilar(y), ba, x, dx)
@@ -271,7 +273,7 @@ function run_benchmark!(
     (; bench0, bench1, bench2, bench3, bench4, calls0, calls1, calls2, calls3, calls4) = try
         # benchmark
         extras = prepare_pullback(f, ba, x, dy)
-        bench0 = @be prepare_pullback(f, ba, x, dy) evals = 1 samples = 1
+        bench0 = @be prepare_pullback(f, ba, x, dy) samples = 1 evals = 1
         bench1 = @be value_and_pullback(f, ba, x, dy, extras)
         bench2 = @be pullback(f, ba, x, dy, extras)
         bench3 = @be value_and_pullback_split(f, ba, x, extras)
@@ -310,13 +312,13 @@ function run_benchmark!(
     (; bench0, bench1, bench2, bench3, bench4, calls0, calls1, calls2, calls3, calls4) = try
         # benchmark
         extras = prepare_pullback(f, ba, x, dy)
-        bench0 = @be prepare_pullback(f, ba, x, dy) evals = 1 samples = 1
-        bench1 = @be mysimilar(x) value_and_pullback!(f, _, ba, x, dy, extras)
-        bench2 = @be mysimilar(x) pullback!(f, _, ba, x, dy, extras)
+        bench0 = @be prepare_pullback(f, ba, x, dy) samples = 1 evals = 1
+        bench1 = @be mysimilar(x) value_and_pullback!(f, _, ba, x, dy, extras) evals = 1
+        bench2 = @be mysimilar(x) pullback!(f, _, ba, x, dy, extras) evals = 1
         bench3 = @be value_and_pullback!_split(f, ba, x, extras)
         bench4 = @be (mysimilar(x), last(value_and_pullback!_split(f, ba, x, extras))) _[2](
             _[1], dy
-        )
+        ) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_pullback(cc, ba, x, dy)
@@ -354,12 +356,13 @@ function run_benchmark!(
     (; bench0, bench1, bench2, bench3, bench4, calls0, calls1, calls2, calls3, calls4) = try
         # benchmark
         extras = prepare_pullback(f!, mysimilar(y), ba, x, dy)
-        bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x, dy) evals = 1 samples =
+        bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x, dy) samples = 1 evals =
             1
-        bench1 = @be mysimilar(y) value_and_pullback(f!, _, ba, x, dy, extras)
-        bench2 = @be mysimilar(y) pullback(f!, _, ba, x, dy, extras)
+        bench1 = @be mysimilar(y) value_and_pullback(f!, _, ba, x, dy, extras) evals = 1
+        bench2 = @be mysimilar(y) pullback(f!, _, ba, x, dy, extras) evals = 1
         bench3 = @be value_and_pullback_split(f!, y, ba, x, extras)
-        bench4 = @be last(value_and_pullback_split(f!, y, ba, x, extras)) _(y, dy)
+        bench4 = @be last(value_and_pullback_split(f!, y, ba, x, extras)) _(y, dy) evals =
+            1
         # count
         cc! = CallCounter(f!)
         extras = prepare_pullback(cc!, mysimilar(y), ba, x, dy)
@@ -395,16 +398,16 @@ function run_benchmark!(
     (; bench0, bench1, bench2, bench3, bench4, calls0, calls1, calls2, calls3, calls4) = try
         # benchmark
         extras = prepare_pullback(f!, mysimilar(y), ba, x, dy)
-        bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x, dy) evals = 1 samples =
+        bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x, dy) samples = 1 evals =
             1
         bench1 = @be (mysimilar(y), mysimilar(x)) value_and_pullback!(
             f!, _[1], _[2], ba, x, dy, extras
-        )
+        ) evals = 1
         bench2 = @be (mysimilar(y), mysimilar(x)) pullback!(
             f!, _[1], _[2], ba, x, dy, extras
-        )
+        ) evals = 1
         bench3 = @be value_and_pullback!_split(f!, y, ba, x, extras)
-        bench4 = @be (mysimilar(x), last(value_and_pullback!_split(f!, y, ba, x, extras))) _[2](y, _[1], dy)
+        bench4 = @be (mysimilar(x), last(value_and_pullback!_split(f!, y, ba, x, extras))) _[2](y, _[1], dy) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_pullback(cc!, mysimilar(y), ba, x, dy)
@@ -443,7 +446,7 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_derivative(f, ba, x)
-        bench0 = @be prepare_derivative(f, ba, x) evals = 1 samples = 1
+        bench0 = @be prepare_derivative(f, ba, x) samples = 1 evals = 1
         bench1 = @be value_and_derivative(f, ba, x, extras)
         bench2 = @be derivative(f, ba, x, extras)
         # count
@@ -476,9 +479,9 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_derivative(f, ba, x)
-        bench0 = @be prepare_derivative(f, ba, x) evals = 1 samples = 1
-        bench1 = @be mysimilar(y) value_and_derivative!(f, _, ba, x, extras)
-        bench2 = @be mysimilar(y) derivative!(f, _, ba, x, extras)
+        bench0 = @be prepare_derivative(f, ba, x) samples = 1 evals = 1
+        bench1 = @be mysimilar(y) value_and_derivative!(f, _, ba, x, extras) evals = 1
+        bench2 = @be mysimilar(y) derivative!(f, _, ba, x, extras) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_derivative(cc, ba, x)
@@ -510,9 +513,9 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_derivative(f!, mysimilar(y), ba, x)
-        bench0 = @be mysimilar(y) prepare_derivative(f!, _, ba, x) evals = 1 samples = 1
-        bench1 = @be mysimilar(y) value_and_derivative(f!, _, ba, x, extras)
-        bench2 = @be mysimilar(y) derivative(f!, _, ba, x, extras)
+        bench0 = @be mysimilar(y) prepare_derivative(f!, _, ba, x) samples = 1 evals = 1
+        bench1 = @be mysimilar(y) value_and_derivative(f!, _, ba, x, extras) evals = 1
+        bench2 = @be mysimilar(y) derivative(f!, _, ba, x, extras) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_derivative(cc!, mysimilar(y), ba, x)
@@ -544,11 +547,11 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_derivative(f!, mysimilar(y), ba, x)
-        bench0 = @be mysimilar(y) prepare_derivative(f!, _, ba, x) evals = 1 samples = 1
+        bench0 = @be mysimilar(y) prepare_derivative(f!, _, ba, x) samples = 1 evals = 1
         bench1 = @be (mysimilar(y), mysimilar(y)) value_and_derivative!(
             f!, _[1], _[2], ba, x, extras
-        )
-        bench2 = @be (mysimilar(y), mysimilar(y)) derivative!(f!, _[1], _[2], ba, x, extras)
+        ) evals = 1
+        bench2 = @be (mysimilar(y), mysimilar(y)) derivative!(f!, _[1], _[2], ba, x, extras) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_derivative(cc!, mysimilar(y), ba, x)
@@ -581,7 +584,7 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_gradient(f, ba, x)
-        bench0 = @be prepare_gradient(f, ba, x) evals = 1 samples = 1
+        bench0 = @be prepare_gradient(f, ba, x) samples = 1 evals = 1
         bench1 = @be value_and_gradient(f, ba, x, extras)
         bench2 = @be gradient(f, ba, x, extras)
         # count
@@ -612,9 +615,9 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_gradient(f, ba, x)
-        bench0 = @be prepare_gradient(f, ba, x) evals = 1 samples = 1
-        bench1 = @be mysimilar(x) value_and_gradient!(f, _, ba, x, extras)
-        bench2 = @be mysimilar(x) gradient!(f, _, ba, x, extras)
+        bench0 = @be prepare_gradient(f, ba, x) samples = 1 evals = 1
+        bench1 = @be mysimilar(x) value_and_gradient!(f, _, ba, x, extras) evals = 1
+        bench2 = @be mysimilar(x) gradient!(f, _, ba, x, extras) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_gradient(cc, ba, x)
@@ -647,7 +650,7 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_jacobian(f, ba, x)
-        bench0 = @be prepare_jacobian(f, ba, x) evals = 1 samples = 1
+        bench0 = @be prepare_jacobian(f, ba, x) samples = 1 evals = 1
         bench1 = @be value_and_jacobian(f, ba, x, extras)
         bench2 = @be jacobian(f, ba, x, extras)
         # count
@@ -679,9 +682,10 @@ function run_benchmark!(
         jac_template = mysimilar(jacobian(f, ba, x))
         # benchmark
         extras = prepare_jacobian(f, ba, x)
-        bench0 = @be prepare_jacobian(f, ba, x) evals = 1 samples = 1
-        bench1 = @be mysimilar(jac_template) value_and_jacobian!(f, _, ba, x, extras)
-        bench2 = @be mysimilar(jac_template) jacobian!(f, _, ba, x, extras)
+        bench0 = @be prepare_jacobian(f, ba, x) samples = 1 evals = 1
+        bench1 = @be mysimilar(jac_template) value_and_jacobian!(f, _, ba, x, extras) evals =
+            1
+        bench2 = @be mysimilar(jac_template) jacobian!(f, _, ba, x, extras) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_jacobian(cc, ba, x)
@@ -713,9 +717,9 @@ function run_benchmark!(
     (; bench0, bench1, bench2, calls0, calls1, calls2) = try
         # benchmark
         extras = prepare_jacobian(f!, mysimilar(y), ba, x)
-        bench0 = @be mysimilar(y) prepare_jacobian(f!, _, ba, x) evals = 1 samples = 1
-        bench1 = @be mysimilar(y) value_and_jacobian(f!, _, ba, x, extras)
-        bench2 = @be mysimilar(y) jacobian(f!, _, ba, x, extras)
+        bench0 = @be mysimilar(y) prepare_jacobian(f!, _, ba, x) samples = 1 evals = 1
+        bench1 = @be mysimilar(y) value_and_jacobian(f!, _, ba, x, extras) evals = 1
+        bench2 = @be mysimilar(y) jacobian(f!, _, ba, x, extras) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_jacobian(cc!, mysimilar(y), ba, x)
@@ -746,13 +750,13 @@ function run_benchmark!(
         jac_template = mysimilar(jacobian(f!, mysimilar(y), ba, x))
         # benchmark
         extras = prepare_jacobian(f!, mysimilar(y), ba, x)
-        bench0 = @be mysimilar(y) prepare_jacobian(f!, _, ba, x) evals = 1 samples = 1
+        bench0 = @be mysimilar(y) prepare_jacobian(f!, _, ba, x) samples = 1 evals = 1
         bench1 = @be (mysimilar(y), mysimilar(jac_template)) value_and_jacobian!(
             f!, _[1], _[2], ba, x, extras
-        )
+        ) evals = 1
         bench2 = @be (mysimilar(y), mysimilar(jac_template)) jacobian!(
             f!, _[1], _[2], ba, x, extras
-        )
+        ) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_jacobian(cc!, y, ba, x)
@@ -785,7 +789,7 @@ function run_benchmark!(
     (; bench0, bench1, calls0, calls1) = try
         # benchmark
         extras = prepare_second_derivative(f, ba, x)
-        bench0 = @be prepare_second_derivative(f, ba, x) evals = 1 samples = 1
+        bench0 = @be prepare_second_derivative(f, ba, x) samples = 1 evals = 1
         bench1 = @be second_derivative(f, ba, x, extras)
         # count
         cc = CallCounter(f)
@@ -814,8 +818,8 @@ function run_benchmark!(
     (; bench0, bench1, calls0, calls1) = try
         # benchmark
         extras = prepare_second_derivative(f, ba, x)
-        bench0 = @be prepare_second_derivative(f, ba, x) evals = 1 samples = 1
-        bench1 = @be mysimilar(y) second_derivative!(f, _, ba, x, extras)
+        bench0 = @be prepare_second_derivative(f, ba, x) samples = 1 evals = 1
+        bench1 = @be mysimilar(y) second_derivative!(f, _, ba, x, extras) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_second_derivative(cc, ba, x)
@@ -843,7 +847,7 @@ function run_benchmark!(
     (; bench0, bench1, calls0, calls1) = try
         # benchmark
         extras = prepare_hvp(f, ba, x, dx)
-        bench0 = @be prepare_hvp(f, ba, x, dx) evals = 1 samples = 1
+        bench0 = @be prepare_hvp(f, ba, x, dx) samples = 1 evals = 1
         bench1 = @be hvp(f, ba, x, dx, extras)
         # count
         cc = CallCounter(f)
@@ -870,8 +874,8 @@ function run_benchmark!(
     (; bench0, bench1, calls0, calls1) = try
         # benchmark
         extras = prepare_hvp(f, ba, x, dx)
-        bench0 = @be prepare_hvp(f, ba, x, dx) evals = 1 samples = 1
-        bench1 = @be mysimilar(x) hvp!(f, _, ba, x, dx, extras)
+        bench0 = @be prepare_hvp(f, ba, x, dx) samples = 1 evals = 1
+        bench1 = @be mysimilar(x) hvp!(f, _, ba, x, dx, extras) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_hvp(cc, ba, x, dx)
@@ -899,7 +903,7 @@ function run_benchmark!(
     (; bench0, bench1, calls0, calls1) = try
         # benchmark
         extras = prepare_hessian(f, ba, x)
-        bench0 = @be prepare_hessian(f, ba, x) evals = 1 samples = 1
+        bench0 = @be prepare_hessian(f, ba, x) samples = 1 evals = 1
         bench1 = @be hessian(f, ba, x, extras)
         # count
         cc = CallCounter(f)
@@ -927,8 +931,8 @@ function run_benchmark!(
         hess_template = Matrix{typeof(y)}(undef, length(x), length(x))
         # benchmark
         extras = prepare_hessian(f, ba, x)
-        bench0 = @be prepare_hessian(f, ba, x) evals = 1 samples = 1
-        bench1 = @be mysimilar(hess_template) hessian!(f, _, ba, x, extras)
+        bench0 = @be prepare_hessian(f, ba, x) samples = 1 evals = 1
+        bench1 = @be mysimilar(hess_template) hessian!(f, _, ba, x, extras) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_hessian(cc, ba, x)

--- a/DifferentiationInterfaceTest/src/utils/filter.jl
+++ b/DifferentiationInterfaceTest/src/utils/filter.jl
@@ -4,6 +4,10 @@ function filter_scenarios(
     output_type::Type,
     first_order::Bool,
     second_order::Bool,
+    onearg::Bool,
+    twoarg::Bool,
+    inplace::Bool,
+    outofplace::Bool,
     excluded::Vector,
 )
     scenarios = filter(s -> (s.x isa input_type && s.y isa output_type), scenarios)
@@ -11,6 +15,10 @@ function filter_scenarios(
         (scenarios = filter(s -> isa(s, AbstractSecondOrderScenario), scenarios))
     !second_order &&
         (scenarios = filter(s -> isa(s, AbstractFirstOrderScenario), scenarios))
+    !onearg && (scenarios = filter(s -> nb_args(s) != 1, scenarios))
+    !twoarg && (scenarios = filter(s -> nb_args(s) != 2, scenarios))
+    !inplace && (scenarios = filter(s -> operator_place(s) != :inplace, scenarios))
+    !outofplace && (scenarios = filter(s -> operator_place(s) != :outofplace, scenarios))
     for T in excluded
         scenarios = filter(s -> !isa(s, T), scenarios)
     end

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -76,7 +76,7 @@ ADTypes.mode(::FakeBackend) = ADTypes.ForwardMode()
 
 data3 = benchmark_differentiation(
     [FakeBackend()]; logging=get(ENV, "CI", "false") == "false"
-);
+);  # this gives lots of warnings when logging is on, no worries
 
 df3 = DataFrames.DataFrame(data3)
 


### PR DESCRIPTION
**Extensions**

- Add `f::F` everywhere in ForwardDiffExt

**Tests**

- Add more options for filtering scenarios according to their number of arguments and their operator inplace
- Rename the `op` type parameter into `place = :inplace / :outofplace` for every scenario
- Add a `place` field to the benchmark row type
- Add `evals = 1` to benchmarks that mutate inputs, so that we get an integer number of allocations
- Deepcopy `extras` for every benchmark to remove spurious allocations
- Replace tuples with namedtuples in `@be` preparation to clarify what goes where