### PR TITLE
Color by decreasing vertex degree

### DIFF
--- a/DifferentiationInterface/src/sparse/coloring.jl
+++ b/DifferentiationInterface/src/sparse/coloring.jl
@@ -164,15 +164,18 @@ end
 """
     GreedyColoringAlgorithm <: ADTypes.AbstractColoringAlgorithm
 
-Matrix coloring algorithm for sparse Jacobians and Hessians.
+Matrix coloring algorithm for sparse Jacobians and Hessians, in which vertices are colored sequentially by order of decreasing degree.
 
 Compatible with the [ADTypes.jl coloring framework](https://sciml.github.io/ADTypes.jl/stable/#Coloring-algorithm).
 
-# See also
+# Implements
 
-- `ADTypes.column_coloring`
-- `ADTypes.row_coloring`
-- `ADTypes.symmetric_coloring`
+- [`ADTypes.column_coloring`](@extref ADTypes) with a partial distance-2 coloring of the bipartite graph
+- [`ADTypes.row_coloring`](@extref ADTypes) with a partial distance-2 coloring of the bipartite graph
+- [`ADTypes.symmetric_coloring`](@extref ADTypes) with a star coloring of the adjacency graph
+
+!!! warning
+    Symmetric coloring is not used by DifferentiationInterface.jl at the moment: Hessians are colored by columns just like Jacobians.
 
 # Reference
 
@@ -180,17 +183,17 @@ Compatible with the [ADTypes.jl coloring framework](https://sciml.github.io/ADTy
 """
 struct GreedyColoringAlgorithm <: ADTypes.AbstractColoringAlgorithm end
 
-function ADTypes.column_coloring(A, ::GreedyColoringAlgorithm)
+function ADTypes.column_coloring(A::AbstractMatrix, ::GreedyColoringAlgorithm)
     g = BipartiteGraph(A)
     return distance2_column_coloring(g)
 end
 
-function ADTypes.row_coloring(A, ::GreedyColoringAlgorithm)
+function ADTypes.row_coloring(A::AbstractMatrix, ::GreedyColoringAlgorithm)
     g = BipartiteGraph(A)
     return distance2_row_coloring(g)
 end
 
-function ADTypes.symmetric_coloring(A, ::GreedyColoringAlgorithm)
+function ADTypes.symmetric_coloring(A::AbstractMatrix, ::GreedyColoringAlgorithm)
     g = AdjacencyGraph(A)
     return star_coloring(g)
 end

--- a/DifferentiationInterface/src/sparse/coloring.jl
+++ b/DifferentiationInterface/src/sparse/coloring.jl
@@ -2,10 +2,21 @@
 Everything in this file is taken from "What color is your Jacobian?"
 =#
 
-function get_groups(colors::AbstractVector{<:Integer})
-    return map(unique(colors)) do c
-        filter(j -> colors[j] == c, eachindex(colors))
+"""
+    color_groups(colors)
+
+Return `groups::Vector{Vector{Int}}` such that `i ∈ groups[c]` iff `colors[i] == c`.
+
+Assumes the colors are contiguously numbered from `1` to some `cmax`.
+"""
+function color_groups(colors::AbstractVector{<:Integer})
+    cmin, cmax = extrema(colors)
+    @assert cmin == 1
+    groups = [Int[] for c in 1:cmax]
+    for (k, c) in enumerate(colors)
+        push!(groups[c], k)
     end
+    return groups
 end
 
 abstract type AbstractMatrixGraph end
@@ -57,7 +68,7 @@ function distance2_column_coloring(g::BipartiteGraph)
                 end
             end
         end
-        for c in columns(g)
+        for c in eachindex(forbidden_colors)
             if forbidden_colors[c] != v
                 colors[v] = c
                 break
@@ -79,7 +90,7 @@ function distance2_row_coloring(g::BipartiteGraph)
                 end
             end
         end
-        for c in rows(g)
+        for c in eachindex(forbidden_colors)
             if forbidden_colors[c] != v
                 colors[v] = c
                 break
@@ -149,7 +160,7 @@ function star_coloring(g::AdjacencyGraph)
                 end
             end
         end
-        for c in columns(g)
+        for c in eachindex(forbidden_colors)
             if forbidden_colors[c] != v
                 colors[v] = c
                 break

--- a/DifferentiationInterface/src/sparse/coloring.jl
+++ b/DifferentiationInterface/src/sparse/coloring.jl
@@ -49,7 +49,7 @@ function distance2_column_coloring(g::BipartiteGraph)
     n = length(columns(g))
     colors = zeros(Int, n)
     forbidden_colors = zeros(Int, n)
-    for v in columns(g)  # default ordering
+    for v in sort(columns(g); by=j -> length(neighbors_of_column(g, j)), rev=true)
         for w in neighbors_of_column(g, v)
             for x in neighbors_of_row(g, w)
                 if !iszero(colors[x])
@@ -71,7 +71,7 @@ function distance2_row_coloring(g::BipartiteGraph)
     m = length(rows(g))
     colors = zeros(Int, m)
     forbidden_colors = zeros(Int, m)
-    for v in 1:m  # default ordering
+    for v in sort(rows(g); by=i -> length(neighbors_of_row(g, i)), rev=true)
         for w in neighbors_of_row(g, v)
             for x in neighbors_of_column(g, w)
                 if !iszero(colors[x])
@@ -129,7 +129,7 @@ function star_coloring(g::AdjacencyGraph)
     n = length(columns(g))
     colors = zeros(Int, n)
     forbidden_colors = zeros(Int, n)
-    for v in columns(g)  # default ordering
+    for v in sort(columns(g); by=j -> length(neighbors(g, j)), rev=true)
         for w in neighbors(g, v)
             if !iszero(colors[w])  # w is colored
                 forbidden_colors[colors[w]] = v

--- a/DifferentiationInterface/src/sparse/detector.jl
+++ b/DifferentiationInterface/src/sparse/detector.jl
@@ -6,12 +6,12 @@ Sparsity detection algorithm based on the [Symbolics.jl tracing system](https://
 Compatible with the [ADTypes.jl sparsity detection framework](https://sciml.github.io/ADTypes.jl/stable/#Sparsity-detector).
 
 !!! danger
-    This functionality is implemented in an extension, and requires [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl) to be loaded.
+    This functionality is in a package extension, and requires [Symbolics.jl](https://github.com/JuliaSymbolics/Symbolics.jl) to be loaded.
 
-# See also
+# Implements
 
-- `ADTypes.jacobian_sparsity`
-- `ADTypes.hessian_sparsity`
+- [`ADTypes.jacobian_sparsity`](@extref ADTypes)
+- [`ADTypes.hessian_sparsity`](@extref ADTypes)
 
 # Reference
 

--- a/DifferentiationInterface/src/sparse/hessian.jl
+++ b/DifferentiationInterface/src/sparse/hessian.jl
@@ -13,7 +13,7 @@ function prepare_hessian(f::F, backend::AutoSparse, x) where {F}
     initial_sparsity = hessian_sparsity(f, x, sparsity_detector(backend))
     sparsity = col_major(initial_sparsity)
     colors = column_coloring(sparsity, coloring_algorithm(backend))  # no star coloring
-    groups = get_groups(colors)
+    groups = color_groups(colors)
     seeds = map(groups) do group
         seed = zero(x)
         seed[group] .= one(eltype(x))

--- a/DifferentiationInterface/src/sparse/hessian.jl
+++ b/DifferentiationInterface/src/sparse/hessian.jl
@@ -12,7 +12,7 @@ end
 function prepare_hessian(f::F, backend::AutoSparse, x) where {F}
     initial_sparsity = hessian_sparsity(f, x, sparsity_detector(backend))
     sparsity = col_major(initial_sparsity)
-    colors = column_coloring(sparsity, coloring_algorithm(backend))
+    colors = column_coloring(sparsity, coloring_algorithm(backend))  # no star coloring
     groups = get_groups(colors)
     seeds = map(groups) do group
         seed = zero(x)

--- a/DifferentiationInterface/src/sparse/jacobian.jl
+++ b/DifferentiationInterface/src/sparse/jacobian.jl
@@ -27,7 +27,7 @@ function prepare_jacobian(f::F, backend::AutoSparse, x) where {F}
     if Bool(pushforward_performance(backend))
         sparsity = col_major(initial_sparsity)
         colors = column_coloring(sparsity, coloring_algorithm(backend))
-        groups = get_groups(colors)
+        groups = color_groups(colors)
         seeds = map(groups) do group
             seed = zero(x)
             seed[group] .= one(eltype(x))
@@ -42,7 +42,7 @@ function prepare_jacobian(f::F, backend::AutoSparse, x) where {F}
     else
         sparsity = row_major(initial_sparsity)
         colors = row_coloring(sparsity, coloring_algorithm(backend))
-        groups = get_groups(colors)
+        groups = color_groups(colors)
         seeds = map(groups) do group
             seed = zero(y)
             seed[group] .= one(eltype(y))
@@ -110,7 +110,7 @@ function prepare_jacobian(f!::F, y, backend::AutoSparse, x) where {F}
     if Bool(pushforward_performance(backend))
         sparsity = col_major(initial_sparsity)
         colors = column_coloring(sparsity, coloring_algorithm(backend))
-        groups = get_groups(colors)
+        groups = color_groups(colors)
         seeds = map(groups) do group
             seed = zero(x)
             seed[group] .= one(eltype(x))
@@ -125,7 +125,7 @@ function prepare_jacobian(f!::F, y, backend::AutoSparse, x) where {F}
     else
         sparsity = row_major(initial_sparsity)
         colors = row_coloring(sparsity, coloring_algorithm(backend))
-        groups = get_groups(colors)
+        groups = color_groups(colors)
         seeds = map(groups) do group
             seed = zero(y)
             seed[group] .= one(eltype(y))

--- a/DifferentiationInterfaceTest/test/coloring.jl
+++ b/DifferentiationInterfaceTest/test/coloring.jl
@@ -7,6 +7,15 @@ using Test
 
 alg = DI.GreedyColoringAlgorithm()
 
+@testset "Grouping" begin
+    colors = [1, 3, 1, 3, 1, 2]
+    @test DI.color_groups(colors) == [[1, 3, 5], [6], [2, 4]]
+    colors = [2, 3, 2, 3, 2, 1]
+    @test DI.color_groups(colors) == [[6], [1, 3, 5], [2, 4]]
+    colors = [2, 3, 2, 3, 2]
+    @test_throws AssertionError DI.color_groups(colors)
+end
+
 @testset "Column coloring" begin
     for A in (sprand(Bool, 100, 200, 0.05), sprand(Bool, 200, 100, 0.05))
         column_colors = ADTypes.column_coloring(A, alg)

--- a/DifferentiationInterfaceTest/test/coloring.jl
+++ b/DifferentiationInterfaceTest/test/coloring.jl
@@ -3,20 +3,32 @@ import DifferentiationInterface as DI
 import DifferentiationInterfaceTest as DIT
 using LinearAlgebra: I, Symmetric
 using SparseArrays: sprand
+using Test
 
 alg = DI.GreedyColoringAlgorithm()
 
-A = sprand(Bool, 100, 200, 0.05)
+@testset "Column coloring" begin
+    for A in (sprand(Bool, 100, 200, 0.05), sprand(Bool, 200, 100, 0.05))
+        column_colors = ADTypes.column_coloring(A, alg)
+        @test DIT.check_structurally_orthogonal_columns(A, column_colors)
+        @test minimum(column_colors) == 1
+        @test maximum(column_colors) < size(A, 2) ÷ 2
+    end
+end
 
-column_colors = ADTypes.column_coloring(A, alg)
-@test DIT.check_structurally_orthogonal_columns(A, column_colors)
-@test maximum(column_colors) < size(A, 2) ÷ 2
+@testset "Row coloring" begin
+    for A in (sprand(Bool, 100, 200, 0.05), sprand(Bool, 200, 100, 0.05))
+        row_colors = ADTypes.row_coloring(A, alg)
+        @test DIT.check_structurally_orthogonal_rows(A, row_colors)
+        @test minimum(row_colors) == 1
+        @test maximum(row_colors) < size(A, 1) ÷ 2
+    end
+end
 
-row_colors = ADTypes.row_coloring(A, alg)
-@test DIT.check_structurally_orthogonal_rows(A, row_colors)
-@test maximum(row_colors) < size(A, 1) ÷ 2
-
-S = Symmetric(sprand(Bool, 100, 100, 0.05)) + I
-symmetric_colors = ADTypes.symmetric_coloring(S, alg)
-@test DIT.check_symmetrically_structurally_orthogonal(S, symmetric_colors)
-@test maximum(symmetric_colors) < size(A, 2) ÷ 2
+@testset "Symmetric coloring" begin
+    S = Symmetric(sprand(Bool, 100, 100, 0.05)) + I
+    symmetric_colors = ADTypes.symmetric_coloring(S, alg)
+    @test DIT.check_symmetrically_structurally_orthogonal(S, symmetric_colors)
+    @test minimum(symmetric_colors) == 1
+    @test maximum(symmetric_colors) < size(S, 2) ÷ 2
+end

--- a/DifferentiationInterfaceTest/test/forwarddiff.jl
+++ b/DifferentiationInterfaceTest/test/forwarddiff.jl
@@ -25,11 +25,3 @@ test_differentiation(
     excluded=[HessianScenario],
     logging=get(ENV, "CI", "false") == "false",
 )
-
-b = MyAutoSparse(AutoForwardDiff())
-
-jacobian(diff, b, rand(5))
-sparse(ForwardDiff.jacobian(diff, rand(5)))
-
-hessian(x -> sum(abs2, diff(x)), b, rand(5))
-ForwardDiff.hessian(x -> sum(abs2, diff(x)), rand(5))

--- a/DifferentiationInterfaceTest/test/forwarddiff.jl
+++ b/DifferentiationInterfaceTest/test/forwarddiff.jl
@@ -1,6 +1,14 @@
+using ADTypes
 using DifferentiationInterface
 using DifferentiationInterfaceTest
 using ForwardDiff: ForwardDiff
+using SparseConnectivityTracer
+
+function MyAutoSparse(backend::AbstractADType)
+    coloring_algorithm = GreedyColoringAlgorithm()
+    sparsity_detector = TracerSparsityDetector()
+    return AutoSparse(backend; sparsity_detector, coloring_algorithm)
+end
 
 test_differentiation(AutoForwardDiff(); logging=get(ENV, "CI", "false") == "false")
 
@@ -17,3 +25,11 @@ test_differentiation(
     excluded=[HessianScenario],
     logging=get(ENV, "CI", "false") == "false",
 )
+
+b = MyAutoSparse(AutoForwardDiff())
+
+jacobian(diff, b, rand(5))
+sparse(ForwardDiff.jacobian(diff, rand(5)))
+
+hessian(x -> sum(abs2, diff(x)), b, rand(5))
+ForwardDiff.hessian(x -> sum(abs2, diff(x)), rand(5))

--- a/DifferentiationInterfaceTest/test/runtests.jl
+++ b/DifferentiationInterfaceTest/test/runtests.jl
@@ -10,12 +10,6 @@ if isdir(DI_PATH)
     Pkg.develop(; path=DI_PATH)
 end
 
-function MyAutoSparse(backend::AbstractADType)
-    coloring_algorithm = GreedyColoringAlgorithm()
-    sparsity_detector = TracerSparsityDetector()
-    return AutoSparse(backend; sparsity_detector, coloring_algorithm)
-end
-
 ## Main tests
 
 @testset verbose = true "DifferentiationInterfaceTest.jl" begin


### PR DESCRIPTION
**Core**

- Replace default col/row order by decreasing degree order for coloring
- Fix `color_groups` so that it returns groups in the same order as the color numbers (which it didn't before because of `unique`)
- Clarify docstrings in the sparse implementation
- Add more tests