### PR TITLE
No mapreduce in default test scenarios

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -113,9 +113,9 @@ function DI.hvp(f, ::AutoZygote, x, v, extras::ZygoteHVPExtras)
     return DI.pushforward(∇f, AutoForwardDiff(), x, v, pushforward_extras)
 end
 
-function DI.hvp!(f, ::AutoZygote, x, v, extras::ZygoteHVPExtras)
+function DI.hvp!(f, p, ::AutoZygote, x, v, extras::ZygoteHVPExtras)
     @compat (; ∇f, pushforward_extras) = extras
-    return DI.pushforward!(∇f, v, AutoForwardDiff(), x, v, pushforward_extras)
+    return DI.pushforward!(∇f, p, AutoForwardDiff(), x, v, pushforward_extras)
 end
 
 ## Hessian

--- a/DifferentiationInterface/test/Single/Diffractor.jl
+++ b/DifferentiationInterface/test/Single/Diffractor.jl
@@ -8,4 +8,6 @@ for backend in [AutoDiffractor()]
     @test !check_hessian(backend; verbose=false)
 end
 
-test_differentiation(AutoDiffractor(); second_order=false, logging=LOGGING);
+test_differentiation(
+    AutoDiffractor(), default_scenarios(; linalg=false); second_order=false, logging=LOGGING
+);

--- a/DifferentiationInterface/test/Single/Zygote.jl
+++ b/DifferentiationInterface/test/Single/Zygote.jl
@@ -23,11 +23,13 @@ end
 ## Dense backends
 
 test_differentiation(
-    dense_backends,
-    default_scenarios();
+    AutoChainRules(Zygote.ZygoteRuleConfig());
     excluded=[SecondDerivativeScenario],
+    second_order=VERSION >= v"1.10",
     logging=LOGGING,
 );
+
+test_differentiation(AutoZygote(); excluded=[SecondDerivativeScenario], logging=LOGGING);
 
 test_differentiation(
     AutoZygote(),

--- a/DifferentiationInterface/test/Single/Zygote.jl
+++ b/DifferentiationInterface/test/Single/Zygote.jl
@@ -22,11 +22,16 @@ end
 
 ## Dense backends
 
-test_differentiation(dense_backends; excluded=[SecondDerivativeScenario], logging=LOGGING);
+test_differentiation(
+    dense_backends,
+    default_scenarios(; linalg=VERSION >= v"1.10");
+    excluded=[SecondDerivativeScenario],
+    logging=LOGGING,
+);
 
 test_differentiation(
     AutoZygote(),
-    vcat(component_scenarios(), static_scenarios());
+    vcat(component_scenarios(), static_scenarios(; linalg=VERSION >= v"1.10"));
     second_order=false,
     logging=LOGGING,
 )

--- a/DifferentiationInterface/test/Single/Zygote.jl
+++ b/DifferentiationInterface/test/Single/Zygote.jl
@@ -24,14 +24,14 @@ end
 
 test_differentiation(
     dense_backends,
-    default_scenarios(; linalg=VERSION >= v"1.10");
+    default_scenarios();
     excluded=[SecondDerivativeScenario],
     logging=LOGGING,
 );
 
 test_differentiation(
     AutoZygote(),
-    vcat(component_scenarios(), static_scenarios(; linalg=VERSION >= v"1.10"));
+    vcat(component_scenarios(), static_scenarios());
     second_order=false,
     logging=LOGGING,
 )

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterfaceTest"
 uuid = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.4.1"
+version = "0.4.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterfaceTest/src/scenarios/component.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/component.jl
@@ -1,7 +1,7 @@
 ## Vector to scalar
 
 function comp_to_num(x::ComponentVector)::Number
-    return sum(sin, x.a) + sum(cos, x.b)
+    return sum(sin.(x.a)) + sum(cos.(x.b))
 end
 
 comp_to_num_gradient(x) = ComponentVector(; a=cos.(x.a), b=-sin.(x.b))

--- a/DifferentiationInterfaceTest/src/scenarios/component.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/component.jl
@@ -8,7 +8,7 @@ comp_to_num_gradient(x) = ComponentVector(; a=cos.(x.a), b=-sin.(x.b))
 
 function comp_to_num_pushforward(x, dx)
     g = comp_to_num_gradient(x)
-    return dot(g.a, dx.a) + dot(g.b, dx.b)
+    return sum(g.a .* dx.a) + sum(g.b .* dx.b)
 end
 
 function comp_to_num_pullback(x, dy)

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -480,21 +480,21 @@ Create a vector of [`AbstractScenario`](@ref)s with standard array types.
 function default_scenarios()
     return vcat(
         # one argument
-        num_to_num_scenarios_onearg(randn()),
-        num_to_arr_scenarios_onearg(randn(), IVEC),
-        num_to_arr_scenarios_onearg(randn(), IMAT),
-        arr_to_num_scenarios_onearg(randn(6)),
-        arr_to_num_scenarios_onearg(randn(2, 3)),
-        vec_to_vec_scenarios_onearg(randn(6)),
-        vec_to_mat_scenarios_onearg(randn(6)),
-        mat_to_vec_scenarios_onearg(randn(2, 3)),
-        mat_to_mat_scenarios_onearg(randn(2, 3)),
+        num_to_num_scenarios_onearg(rand()),
+        num_to_arr_scenarios_onearg(rand(), IVEC),
+        num_to_arr_scenarios_onearg(rand(), IMAT),
+        arr_to_num_scenarios_onearg(rand(6)),
+        arr_to_num_scenarios_onearg(rand(2, 3)),
+        vec_to_vec_scenarios_onearg(rand(6)),
+        vec_to_mat_scenarios_onearg(rand(6)),
+        mat_to_vec_scenarios_onearg(rand(2, 3)),
+        mat_to_mat_scenarios_onearg(rand(2, 3)),
         # two arguments
-        num_to_arr_scenarios_twoarg(randn(), IVEC),
-        num_to_arr_scenarios_twoarg(randn(), IMAT),
-        vec_to_vec_scenarios_twoarg(randn(6)),
-        vec_to_mat_scenarios_twoarg(randn(6)),
-        mat_to_vec_scenarios_twoarg(randn(2, 3)),
-        mat_to_mat_scenarios_twoarg(randn(2, 3)),
+        num_to_arr_scenarios_twoarg(rand(), IVEC),
+        num_to_arr_scenarios_twoarg(rand(), IMAT),
+        vec_to_vec_scenarios_twoarg(rand(6)),
+        vec_to_mat_scenarios_twoarg(rand(6)),
+        mat_to_vec_scenarios_twoarg(rand(2, 3)),
+        mat_to_mat_scenarios_twoarg(rand(2, 3)),
     )
 end

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -146,8 +146,9 @@ const DEFAULT_β = 6
 arr_to_num_aux_linalg(x; α, β) = sum(vec(x .^ α) .* transpose(vec(x .^ β)))
 
 function arr_to_num_aux_no_linalg(x; α, β)
+    n = length(x)
     s = zero(eltype(x))
-    for i in eachindex(x), j in eachindex(x)
+    for i in 1:n, j in 1:n
         s += x[i]^α * x[j]^β
     end
     return s

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -143,9 +143,18 @@ end
 const DEFAULT_α = 4
 const DEFAULT_β = 6
 
-arr_to_num_aux(x; α, β) = sum(vec(x .^ α) * transpose(vec(x .^ β)))
+arr_to_num_aux_linalg(x; α, β) = sum(vec(x .^ α) .* transpose(vec(x .^ β)))
+
+function arr_to_num_aux_no_linalg(x; α, β)
+    s = zero(eltype(x))
+    for i in eachindex(x), j in eachindex(x)
+        s += x[i]^α * x[j]^β
+    end
+    return s
+end
 
 function arr_to_num_aux_gradient(x; α, β)
+    x = Array(x)  # GPU arrays don't like indexing
     g = similar(x)
     for k in eachindex(g, x)
         g[k] = (
@@ -158,6 +167,7 @@ function arr_to_num_aux_gradient(x; α, β)
 end
 
 function arr_to_num_aux_hessian(x; α, β)
+    x = Array(x)  # GPU arrays don't like indexing
     H = similar(x, length(x), length(x))
     for k in axes(H, 1), l in axes(H, 2)
         if k == l
@@ -173,14 +183,19 @@ function arr_to_num_aux_hessian(x; α, β)
     return H
 end
 
-arr_to_num(x::AbstractArray)::Number = arr_to_num_aux(x; α=DEFAULT_α, β=DEFAULT_β)
+arr_to_num_linalg(x::AbstractArray)::Number =
+    arr_to_num_aux_linalg(x; α=DEFAULT_α, β=DEFAULT_β)
+arr_to_num_no_linalg(x::AbstractArray)::Number =
+    arr_to_num_aux_no_linalg(x; α=DEFAULT_α, β=DEFAULT_β)
+
 arr_to_num_gradient(x) = arr_to_num_aux_gradient(x; α=DEFAULT_α, β=DEFAULT_β)
 arr_to_num_hessian(x) = arr_to_num_aux_hessian(x; α=DEFAULT_α, β=DEFAULT_β)
 arr_to_num_pushforward(x, dx) = dot(arr_to_num_gradient(x), dx)
 arr_to_num_pullback(x, dy) = arr_to_num_gradient(x) .* dy
 arr_to_num_hvp(x, v) = reshape(arr_to_num_hessian(x) * vec(v), size(x))
 
-function arr_to_num_scenarios_onearg(x::AbstractArray)
+function arr_to_num_scenarios_onearg(x::AbstractArray; linalg=true)
+    arr_to_num = linalg ? arr_to_num_linalg : arr_to_num_no_linalg
     # pushforward stays out of place
     scens = AbstractScenario[]
     for place in (:outofplace, :inplace)
@@ -480,14 +495,14 @@ const IMAT = Matrix((1:2) .* transpose(1:3))
 
 Create a vector of [`AbstractScenario`](@ref)s with standard array types.
 """
-function default_scenarios()
+function default_scenarios(; linalg=true)
     return vcat(
         # one argument
         num_to_num_scenarios_onearg(rand()),
         num_to_arr_scenarios_onearg(rand(), IVEC),
         num_to_arr_scenarios_onearg(rand(), IMAT),
-        arr_to_num_scenarios_onearg(rand(6)),
-        arr_to_num_scenarios_onearg(rand(2, 3)),
+        arr_to_num_scenarios_onearg(rand(6); linalg),
+        arr_to_num_scenarios_onearg(rand(2, 3); linalg),
         vec_to_vec_scenarios_onearg(rand(6)),
         vec_to_mat_scenarios_onearg(rand(6)),
         mat_to_vec_scenarios_onearg(rand(2, 3)),

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -140,6 +140,9 @@ end
 
 ## Array to scalar
 
+const DEFAULT_α = 4
+const DEFAULT_β = 6
+
 arr_to_num_aux(x; α, β) = sum(vec(x .^ α) * transpose(vec(x .^ β)))
 
 function arr_to_num_aux_gradient(x; α, β)
@@ -170,9 +173,9 @@ function arr_to_num_aux_hessian(x; α, β)
     return H
 end
 
-arr_to_num(x::AbstractArray)::Number = arr_to_num_aux(x; α=2, β=3)
-arr_to_num_gradient(x) = arr_to_num_aux_gradient(x; α=2, β=3)
-arr_to_num_hessian(x) = arr_to_num_aux_hessian(x; α=2, β=3)
+arr_to_num(x::AbstractArray)::Number = arr_to_num_aux(x; α=DEFAULT_α, β=DEFAULT_β)
+arr_to_num_gradient(x) = arr_to_num_aux_gradient(x; α=DEFAULT_α, β=DEFAULT_β)
+arr_to_num_hessian(x) = arr_to_num_aux_hessian(x; α=DEFAULT_α, β=DEFAULT_β)
 arr_to_num_pushforward(x, dx) = dot(arr_to_num_gradient(x), dx)
 arr_to_num_pullback(x, dy) = arr_to_num_gradient(x) .* dy
 arr_to_num_hvp(x, v) = reshape(arr_to_num_hessian(x) * vec(v), size(x))

--- a/DifferentiationInterfaceTest/src/scenarios/gpu.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/gpu.jl
@@ -6,13 +6,13 @@ const JLMAT = jl(IMAT)
 
 Create a vector of [`AbstractScenario`](@ref)s with GPU array types from [JLArrays.jl](https://github.com/JuliaGPU/GPUArrays.jl/tree/master/lib/JLArrays).
 """
-function gpu_scenarios()
+function gpu_scenarios(; linalg=true)
     return vcat(
         # one argument
         num_to_arr_scenarios_onearg(rand(), JLVEC),
         num_to_arr_scenarios_onearg(rand(), JLMAT),
-        arr_to_num_scenarios_onearg(jl(rand(6))),
-        arr_to_num_scenarios_onearg(jl(rand(2, 3))),
+        arr_to_num_scenarios_onearg(jl(rand(6)); linalg),
+        arr_to_num_scenarios_onearg(jl(rand(2, 3)); linalg),
         vec_to_vec_scenarios_onearg(jl(rand(6))),
         vec_to_mat_scenarios_onearg(jl(rand(6))),
         mat_to_vec_scenarios_onearg(jl(rand(2, 3))),

--- a/DifferentiationInterfaceTest/src/scenarios/gpu.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/gpu.jl
@@ -9,20 +9,20 @@ Create a vector of [`AbstractScenario`](@ref)s with GPU array types from [JLArra
 function gpu_scenarios()
     return vcat(
         # one argument
-        num_to_arr_scenarios_onearg(randn(), JLVEC),
-        num_to_arr_scenarios_onearg(randn(), JLMAT),
-        arr_to_num_scenarios_onearg(jl(randn(6))),
-        arr_to_num_scenarios_onearg(jl(randn(2, 3))),
-        vec_to_vec_scenarios_onearg(jl(randn(6))),
-        vec_to_mat_scenarios_onearg(jl(randn(6))),
-        mat_to_vec_scenarios_onearg(jl(randn(2, 3))),
-        mat_to_mat_scenarios_onearg(jl(randn(2, 3))),
+        num_to_arr_scenarios_onearg(rand(), JLVEC),
+        num_to_arr_scenarios_onearg(rand(), JLMAT),
+        arr_to_num_scenarios_onearg(jl(rand(6))),
+        arr_to_num_scenarios_onearg(jl(rand(2, 3))),
+        vec_to_vec_scenarios_onearg(jl(rand(6))),
+        vec_to_mat_scenarios_onearg(jl(rand(6))),
+        mat_to_vec_scenarios_onearg(jl(rand(2, 3))),
+        mat_to_mat_scenarios_onearg(jl(rand(2, 3))),
         # two arguments
-        num_to_arr_scenarios_twoarg(randn(), JLVEC),
-        num_to_arr_scenarios_twoarg(randn(), JLMAT),
-        vec_to_vec_scenarios_twoarg(jl(randn(6))),
-        vec_to_mat_scenarios_twoarg(jl(randn(6))),
-        mat_to_vec_scenarios_twoarg(jl(randn(2, 3))),
-        mat_to_mat_scenarios_twoarg(jl(randn(2, 3))),
+        num_to_arr_scenarios_twoarg(rand(), JLVEC),
+        num_to_arr_scenarios_twoarg(rand(), JLMAT),
+        vec_to_vec_scenarios_twoarg(jl(rand(6))),
+        vec_to_mat_scenarios_twoarg(jl(rand(6))),
+        mat_to_vec_scenarios_twoarg(jl(rand(2, 3))),
+        mat_to_mat_scenarios_twoarg(jl(rand(2, 3))),
     )
 end

--- a/DifferentiationInterfaceTest/src/scenarios/sparse.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/sparse.jl
@@ -229,11 +229,11 @@ Create a vector of [`AbstractScenario`](@ref)s with sparse array types, focused 
 """
 function sparse_scenarios()
     return vcat(
-        sparse_vec_to_vec_scenarios(randn(6)),
-        sparse_vec_to_mat_scenarios(randn(6)),
-        sparse_mat_to_vec_scenarios(randn(2, 3)),
-        sparse_mat_to_mat_scenarios(randn(2, 3)),
-        sparse_vec_to_num_scenarios(randn(6)),
-        sparse_mat_to_num_scenarios(randn(2, 3)),
+        sparse_vec_to_vec_scenarios(rand(6)),
+        sparse_vec_to_mat_scenarios(rand(6)),
+        sparse_mat_to_vec_scenarios(rand(2, 3)),
+        sparse_mat_to_mat_scenarios(rand(2, 3)),
+        sparse_vec_to_num_scenarios(rand(6)),
+        sparse_mat_to_num_scenarios(rand(2, 3)),
     )
 end

--- a/DifferentiationInterfaceTest/src/scenarios/static.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/static.jl
@@ -6,13 +6,13 @@ const SMAT = SMatrix{size(IMAT, 1),size(IMAT, 2)}(IMAT)
 
 Create a vector of [`AbstractScenario`](@ref)s with static array types from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl).
 """
-function static_scenarios()
+function static_scenarios(; linalg=true)
     scens = vcat(
         # one argument
         num_to_arr_scenarios_onearg(rand(), SVEC),
         num_to_arr_scenarios_onearg(rand(), SMAT),
-        arr_to_num_scenarios_onearg(SVector{6}(rand(6))),
-        arr_to_num_scenarios_onearg(SMatrix{2,3}(rand(2, 3))),
+        arr_to_num_scenarios_onearg(SVector{6}(rand(6)); linalg),
+        arr_to_num_scenarios_onearg(SMatrix{2,3}(rand(2, 3)); linalg),
         vec_to_vec_scenarios_onearg(SVector{6}(rand(6))),
         vec_to_mat_scenarios_onearg(SVector{6}(rand(6))),
         mat_to_vec_scenarios_onearg(SMatrix{2,3}(rand(2, 3))),

--- a/DifferentiationInterfaceTest/src/scenarios/static.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/static.jl
@@ -9,21 +9,21 @@ Create a vector of [`AbstractScenario`](@ref)s with static array types from [Sta
 function static_scenarios()
     scens = vcat(
         # one argument
-        num_to_arr_scenarios_onearg(randn(), SVEC),
-        num_to_arr_scenarios_onearg(randn(), SMAT),
-        arr_to_num_scenarios_onearg(SVector{6}(randn(6))),
-        arr_to_num_scenarios_onearg(SMatrix{2,3}(randn(2, 3))),
-        vec_to_vec_scenarios_onearg(SVector{6}(randn(6))),
-        vec_to_mat_scenarios_onearg(SVector{6}(randn(6))),
-        mat_to_vec_scenarios_onearg(SMatrix{2,3}(randn(2, 3))),
-        mat_to_mat_scenarios_onearg(SMatrix{2,3}(randn(2, 3))),
+        num_to_arr_scenarios_onearg(rand(), SVEC),
+        num_to_arr_scenarios_onearg(rand(), SMAT),
+        arr_to_num_scenarios_onearg(SVector{6}(rand(6))),
+        arr_to_num_scenarios_onearg(SMatrix{2,3}(rand(2, 3))),
+        vec_to_vec_scenarios_onearg(SVector{6}(rand(6))),
+        vec_to_mat_scenarios_onearg(SVector{6}(rand(6))),
+        mat_to_vec_scenarios_onearg(SMatrix{2,3}(rand(2, 3))),
+        mat_to_mat_scenarios_onearg(SMatrix{2,3}(rand(2, 3))),
         # two arguments
-        num_to_arr_scenarios_twoarg(randn(), SVEC),
-        num_to_arr_scenarios_twoarg(randn(), SMAT),
-        vec_to_vec_scenarios_twoarg(MVector{6}(randn(6))),
-        vec_to_mat_scenarios_twoarg(MVector{6}(randn(6))),
-        mat_to_vec_scenarios_twoarg(MMatrix{2,3}(randn(2, 3))),
-        mat_to_mat_scenarios_twoarg(MMatrix{2,3}(randn(2, 3))),
+        num_to_arr_scenarios_twoarg(rand(), SVEC),
+        num_to_arr_scenarios_twoarg(rand(), SMAT),
+        vec_to_vec_scenarios_twoarg(MVector{6}(rand(6))),
+        vec_to_mat_scenarios_twoarg(MVector{6}(rand(6))),
+        mat_to_vec_scenarios_twoarg(MMatrix{2,3}(rand(2, 3))),
+        mat_to_mat_scenarios_twoarg(MMatrix{2,3}(rand(2, 3))),
     )
     scens = filter(scens) do s
         operator_place(s) == :outofplace || s.x isa Union{Number,MVector,MMatrix}


### PR DESCRIPTION
**Versions**

- ERRONEOUSLY bump DI to 0.5.2
- Bump DIT to 0.4.2

**DIT source**

- Change array-to-scalar scenario so that it has a full non-diagonal hessian with different coefficients everywhere: `f(x) = sum(x[i]^a * x[j]^b for i in 1:n, j in 1:n)`
- Remove every `mapreduce` in the scenarios (makes Enzyme angry)
- Create all scenarios with `rand()` instead of `randn()`
- Add a private `linalg` keyword disabling the use of linear algebra
- Adjust the reference functions so that they work on GPU arrays (conversion to `Array` before taking individual indices)

**DI source**

- Use ForwardDiff over Zygote for Zygote HVP (ForwardDiff is a dependency so it is loaded anyway). It is a bit cheating but it is used by the default `Zygote.hessian` too

**DI tests**

- Use custom scenarios for testing allocations with ForwardDiff, now that array-to-scalar scenarios allocate
- Appease Diffractor by avoiding linear algebra
- Avoid testing ChainRules with second order operators on 1.6 because of this error: https://discourse.julialang.org/t/zygote-error-in-backprop-through-nn/92920