### PR TITLE
Update fallback for mutating second-order operators

### DIFF
--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -77,9 +77,7 @@ function hessian!(
     x,
     extras::HessianExtras=prepare_hessian(f, backend, x),
 ) where {F}
-    new_backend = SecondOrder(backend, backend)
-    new_extras = prepare_hessian(f, new_backend, x)
-    return hessian!(f, hess, new_backend, x, new_extras)
+    return hessian!(f, hess, SecondOrder(backend, backend), x, extras)
 end
 
 function hessian!(

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -182,9 +182,7 @@ end
 function hvp!(
     f::F, p, backend::AbstractADType, x, v, extras::HVPExtras=prepare_hvp(f, backend, x, v)
 ) where {F}
-    new_backend = SecondOrder(backend, backend)
-    new_extras = prepare_hvp(f, new_backend, x, v)
-    return hvp!(f, p, new_backend, x, v, new_extras)
+    return hvp!(f, p, SecondOrder(backend, backend), x, v, extras)
 end
 
 function hvp!(

--- a/DifferentiationInterface/src/second_order/second_derivative.jl
+++ b/DifferentiationInterface/src/second_order/second_derivative.jl
@@ -81,9 +81,7 @@ function second_derivative!(
     x,
     extras::SecondDerivativeExtras=prepare_second_derivative(f, backend, x),
 ) where {F}
-    new_backend = SecondOrder(backend, backend)
-    new_extras = prepare_second_derivative(f, new_backend, x)
-    return second_derivative!(f, der2, new_backend, x, new_extras)
+    return second_derivative!(f, der2, SecondOrder(backend, backend), x, extras)
 end
 
 function second_derivative!(


### PR DESCRIPTION
**DI source**

- Add missing fallbacks for `backend -> SecondOrder(backend, backend)` without regenerating extras