### PR TITLE
Make Zygote extension depend on ForwardDiff too

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -41,7 +41,7 @@ DifferentiationInterfaceReverseDiffExt = "ReverseDiff"
 DifferentiationInterfaceSymbolicsExt = "Symbolics"
 DifferentiationInterfaceTapirExt = "Tapir"
 DifferentiationInterfaceTrackerExt = "Tracker"
-DifferentiationInterfaceZygoteExt = "Zygote"
+DifferentiationInterfaceZygoteExt = ["Zygote", "ForwardDiff"]
 
 [compat]
 ADTypes = "1.2.0"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -10,6 +10,7 @@ using DifferentiationInterface:
     NoPullbackExtras,
     PullbackExtras
 using DocStringExtensions
+using ForwardDiff: ForwardDiff
 using Zygote:
     ZygoteRuleConfig, gradient, hessian, jacobian, pullback, withgradient, withjacobian
 using Compat
@@ -93,9 +94,9 @@ function DI.jacobian!(f, jac, backend::AutoZygote, x, extras::NoJacobianExtras)
     return copyto!(jac, DI.jacobian(f, backend, x, extras))
 end
 
-## HVP (with ForwardDiff)
+## HVP
 
-# TODO: find a way to do this without cheating?
+# Beware, this uses ForwardDiff for the inner differentiation
 
 struct ZygoteHVPExtras{G,PE} <: HVPExtras
     ∇f::G


### PR DESCRIPTION
**DI extensions**

- Add ForwardDiff to the list of triggers for the Zygote extension, since it is needed by the HVP