### PR TITLE
Measure code coverage for test folder too

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -86,7 +86,7 @@ jobs:
           JULIA_DI_TEST_GROUP: ${{ matrix.group }}
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: ./DifferentiationInterface/src,./DifferentiationInterface/ext
+          directories: ./DifferentiationInterface/src,./DifferentiationInterface/ext,./DifferentiationInterface/test
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
@@ -135,7 +135,7 @@ jobs:
           JULIA_DI_TEST_GROUP: ${{ matrix.group }}
       - uses: julia-actions/julia-processcoverage@v1
         with:
-          directories: ./DifferentiationInterfaceTest/src,./DifferentiationInterfaceTest/ext
+          directories: ./DifferentiationInterfaceTest/src,./DifferentiationInterfaceTest/ext,./DifferentiationInterfaceTest/test
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info


### PR DESCRIPTION
**CI**

- Add `test` to the folders `src` and `ext` that are tracked for code coverage