### PR TITLE
Implement `value_gradient_and_hessian`

### DIFF
--- a/DifferentiationInterface/docs/src/api.md
+++ b/DifferentiationInterface/docs/src/api.md
@@ -93,6 +93,8 @@ hvp!
 prepare_hessian
 hessian
 hessian!
+value_gradient_and_hessian
+value_gradient_and_hessian!
 ```
 
 ## Utilities

--- a/DifferentiationInterface/docs/src/operators.md
+++ b/DifferentiationInterface/docs/src/operators.md
@@ -45,16 +45,16 @@ These operators are computed using the input `x` and a "seed" `v`, which lives e
 
 Several variants of each operator are defined.
 
-| out-of-place                | in-place                     | out-of-place + primal                            | in-place + primal                                |
-| :-------------------------- | :--------------------------- | :----------------------------------------------- | :----------------------------------------------- |
-| [`derivative`](@ref)        | [`derivative!`](@ref)        | [`value_and_derivative`](@ref)                   | [`value_and_derivative!`](@ref)                  |
+| out-of-place                | in-place                     | out-of-place + primal                            | in-place + primal                                 |
+| :-------------------------- | :--------------------------- | :----------------------------------------------- | :------------------------------------------------ |
+| [`derivative`](@ref)        | [`derivative!`](@ref)        | [`value_and_derivative`](@ref)                   | [`value_and_derivative!`](@ref)                   |
 | [`second_derivative`](@ref) | [`second_derivative!`](@ref) | [`value_derivative_and_second_derivative`](@ref) | [`value_derivative_and_second_derivative!`](@ref) |
-| [`gradient`](@ref)          | [`gradient!`](@ref)          | [`value_and_gradient`](@ref)                     | [`value_and_gradient!`](@ref)                    |
-| [`hessian`](@ref)           | [`hessian!`](@ref)           | NA                                               | NA                                               |
-| [`jacobian`](@ref)          | [`jacobian!`](@ref)          | [`value_and_jacobian`](@ref)                     | [`value_and_jacobian!`](@ref)                    |
-| [`pushforward`](@ref)       | [`pushforward!`](@ref)       | [`value_and_pushforward`](@ref)                  | [`value_and_pushforward!`](@ref)                 |
-| [`pullback`](@ref)          | [`pullback!`](@ref)          | [`value_and_pullback`](@ref)                     | [`value_and_pullback!`](@ref)                    |
-| [`hvp`](@ref)               | [`hvp!`](@ref)               | NA                                               | NA                                               |
+| [`gradient`](@ref)          | [`gradient!`](@ref)          | [`value_and_gradient`](@ref)                     | [`value_and_gradient!`](@ref)                     |
+| [`hessian`](@ref)           | [`hessian!`](@ref)           | [`value_gradient_and_hessian`](@ref)             | [`value_gradient_and_hessian!`](@ref) NA          |
+| [`jacobian`](@ref)          | [`jacobian!`](@ref)          | [`value_and_jacobian`](@ref)                     | [`value_and_jacobian!`](@ref)                     |
+| [`pushforward`](@ref)       | [`pushforward!`](@ref)       | [`value_and_pushforward`](@ref)                  | [`value_and_pushforward!`](@ref)                  |
+| [`pullback`](@ref)          | [`pullback!`](@ref)          | [`value_and_pullback`](@ref)                     | [`value_and_pullback!`](@ref)                     |
+| [`hvp`](@ref)               | [`hvp!`](@ref)               | NA                                               | NA                                                |
 
 ## Mutation and signatures
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/DifferentiationInterfaceFastDifferentiationExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/DifferentiationInterfaceFastDifferentiationExt.jl
@@ -1,6 +1,6 @@
 module DifferentiationInterfaceFastDifferentiationExt
 
-using ADTypes: ADTypes, AutoFastDifferentiation, AutoSparse
+using ADTypes: ADTypes, AutoFastDifferentiation, AutoSparse, dense_ad
 import DifferentiationInterface as DI
 using DifferentiationInterface:
     DerivativeExtras,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/DifferentiationInterfaceFastDifferentiationExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/DifferentiationInterfaceFastDifferentiationExt.jl
@@ -1,6 +1,6 @@
 module DifferentiationInterfaceFastDifferentiationExt
 
-using ADTypes: ADTypes, AutoFastDifferentiation, AutoSparse, dense_ad
+using ADTypes: ADTypes, AutoFastDifferentiation, AutoSparse
 import DifferentiationInterface as DI
 using DifferentiationInterface:
     DerivativeExtras,
@@ -10,7 +10,8 @@ using DifferentiationInterface:
     JacobianExtras,
     PullbackExtras,
     PushforwardExtras,
-    SecondDerivativeExtras
+    SecondDerivativeExtras,
+    maybe_dense_ad
 using FastDifferentiation:
     derivative,
     hessian,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
@@ -415,7 +415,7 @@ end
 ## Hessian
 
 struct FastDifferentiationHessianExtras{G,E2,E2!} <: HessianExtras
-    grad_extras::G
+    gradient_extras::G
     hess_exe::E2
     hess_exe!::E2!
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
@@ -424,7 +424,7 @@ function DI.prepare_hessian(
     f, backend::Union{AutoFastDifferentiation,AutoSparse{<:AutoFastDifferentiation}}, x
 )
     x_var = make_variables(:x, size(x)...)
-    y_var = f(x_vec_var)
+    y_var = f(x_var)
 
     x_vec_var = vec(x_var)
 
@@ -436,7 +436,7 @@ function DI.prepare_hessian(
     hess_exe = make_function(hess_var, x_vec_var; in_place=false)
     hess_exe! = make_function(hess_var, x_vec_var; in_place=true)
 
-    gradient_extras = DI.prepare_gradient(f, backend, x)
+    gradient_extras = DI.prepare_gradient(f, dense_ad(backend), x)
     return FastDifferentiationHessianExtras(gradient_extras, hess_exe, hess_exe!)
 end
 
@@ -466,7 +466,7 @@ function DI.value_gradient_and_hessian(
     x,
     extras::FastDifferentiationHessianExtras,
 )
-    y, grad = DI.value_and_gradient(f, backend, x, extras.gradient_extras)
+    y, grad = DI.value_and_gradient(f, dense_ad(backend), x, extras.gradient_extras)
     hess = DI.hessian(f, backend, x, extras)
     return y, grad, hess
 end
@@ -479,7 +479,7 @@ function DI.value_gradient_and_hessian!(
     x,
     extras::FastDifferentiationHessianExtras,
 )
-    y, _ = DI.value_and_gradient!(f, grad, backend, x, extras.gradient_extras)
+    y, _ = DI.value_and_gradient!(f, grad, dense_ad(backend), x, extras.gradient_extras)
     DI.hessian!(f, hess, backend, x, extras)
     return y, grad, hess
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
@@ -436,7 +436,7 @@ function DI.prepare_hessian(
     hess_exe = make_function(hess_var, x_vec_var; in_place=false)
     hess_exe! = make_function(hess_var, x_vec_var; in_place=true)
 
-    gradient_extras = DI.prepare_gradient(f, dense_ad(backend), x)
+    gradient_extras = DI.prepare_gradient(f, maybe_dense_ad(backend), x)
     return FastDifferentiationHessianExtras(gradient_extras, hess_exe, hess_exe!)
 end
 
@@ -466,7 +466,7 @@ function DI.value_gradient_and_hessian(
     x,
     extras::FastDifferentiationHessianExtras,
 )
-    y, grad = DI.value_and_gradient(f, dense_ad(backend), x, extras.gradient_extras)
+    y, grad = DI.value_and_gradient(f, maybe_dense_ad(backend), x, extras.gradient_extras)
     hess = DI.hessian(f, backend, x, extras)
     return y, grad, hess
 end
@@ -479,7 +479,9 @@ function DI.value_gradient_and_hessian!(
     x,
     extras::FastDifferentiationHessianExtras,
 )
-    y, _ = DI.value_and_gradient!(f, grad, dense_ad(backend), x, extras.gradient_extras)
+    y, _ = DI.value_and_gradient!(
+        f, grad, maybe_dense_ad(backend), x, extras.gradient_extras
+    )
     DI.hessian!(f, hess, backend, x, extras)
     return y, grad, hess
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/twoarg.jl
@@ -1,8 +1,8 @@
 ## Pushforward
 
-struct FastDifferentiationTwoArgPushforwardExtras{E1,E2} <: PushforwardExtras
+struct FastDifferentiationTwoArgPushforwardExtras{E1,E1!} <: PushforwardExtras
     jvp_exe::E1
-    jvp_exe!::E2
+    jvp_exe!::E1!
 end
 
 function DI.prepare_pushforward(f!, y, ::AutoFastDifferentiation, x, dx)
@@ -80,9 +80,9 @@ end
 
 ## Pullback
 
-struct FastDifferentiationTwoArgPullbackExtras{E1,E2} <: PullbackExtras
+struct FastDifferentiationTwoArgPullbackExtras{E1,E1!} <: PullbackExtras
     vjp_exe::E1
-    vjp_exe!::E2
+    vjp_exe!::E1!
 end
 
 function DI.prepare_pullback(f!, y, ::AutoFastDifferentiation, x, dy)
@@ -156,9 +156,9 @@ end
 
 ## Derivative
 
-struct FastDifferentiationTwoArgDerivativeExtras{E1,E2} <: DerivativeExtras
+struct FastDifferentiationTwoArgDerivativeExtras{E1,E1!} <: DerivativeExtras
     der_exe::E1
-    der_exe!::E2
+    der_exe!::E1!
 end
 
 function DI.prepare_derivative(f!, y, ::AutoFastDifferentiation, x)
@@ -216,9 +216,9 @@ end
 
 ## Jacobian
 
-struct FastDifferentiationTwoArgJacobianExtras{E1,E2} <: JacobianExtras
+struct FastDifferentiationTwoArgJacobianExtras{E1,E1!} <: JacobianExtras
     jac_exe::E1
-    jac_exe!::E2
+    jac_exe!::E1!
 end
 
 function DI.prepare_jacobian(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -166,7 +166,7 @@ function DI.value_gradient_and_hessian!(
     f::F, grad, hess, ::AutoForwardDiff, x, extras::ForwardDiffHessianExtras
 ) where {F}
     result = MutableDiffResult(one(eltype(x)), (grad, hess))
-    result = hessian!(result, f, x, extras.config)
+    result = hessian!(result, f, x, extras.result_config)
     return (
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)
     )
@@ -178,7 +178,7 @@ function DI.value_gradient_and_hessian(
     result = MutableDiffResult(
         one(eltype(x)), (similar(x), similar(x, length(x), length(x)))
     )
-    result = hessian!(result, f, x, extras.config)
+    result = hessian!(result, f, x, extras.result_config)
     return (
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)
     )

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -165,7 +165,7 @@ end
 function DI.value_gradient_and_hessian!(
     f::F, grad, hess, ::AutoForwardDiff, x, extras::ForwardDiffHessianExtras
 ) where {F}
-    result = MutableDiffResult(y, (grad, hess))
+    result = MutableDiffResult(one(eltype(x)), (grad, hess))
     result = hessian!(result, f, x, extras.config)
     return (
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)
@@ -175,7 +175,9 @@ end
 function DI.value_gradient_and_hessian(
     f::F, ::AutoForwardDiff, x, extras::ForwardDiffHessianExtras
 ) where {F}
-    result = MutableDiffResult(y, (similar(x), similar(x, length(x), length(x))))
+    result = MutableDiffResult(
+        one(eltype(x)), (similar(x), similar(x, length(x), length(x)))
+    )
     result = hessian!(result, f, x, extras.config)
     return (
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/onearg.jl
@@ -42,9 +42,9 @@ function DI.value_and_derivative(
 end
 
 function DI.value_and_derivative!(
-    f, dy, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
+    f, der, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
 )
-    return DI.value_and_derivative!(f, dy, single_threaded(backend), x, extras)
+    return DI.value_and_derivative!(f, der, single_threaded(backend), x, extras)
 end
 
 function DI.derivative(f, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras)
@@ -52,9 +52,9 @@ function DI.derivative(f, backend::AutoPolyesterForwardDiff, x, extras::Derivati
 end
 
 function DI.derivative!(
-    f, dy, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
+    f, der, backend::AutoPolyesterForwardDiff, x, extras::DerivativeExtras
 )
-    return DI.derivative!(f, dy, single_threaded(backend), x, extras)
+    return DI.derivative!(f, der, single_threaded(backend), x, extras)
 end
 
 ## Gradient
@@ -149,6 +149,20 @@ function DI.hessian(f, backend::AutoPolyesterForwardDiff, x, extras::HessianExtr
     return DI.hessian(f, single_threaded(backend), x, extras)
 end
 
-function DI.hessian!(f, dy, backend::AutoPolyesterForwardDiff, x, extras::HessianExtras)
-    return DI.hessian!(f, dy, single_threaded(backend), x, extras)
+function DI.hessian!(f, hess, backend::AutoPolyesterForwardDiff, x, extras::HessianExtras)
+    return DI.hessian!(f, hess, single_threaded(backend), x, extras)
+end
+
+function DI.value_gradient_and_hessian(
+    f, backend::AutoPolyesterForwardDiff, x, extras::HessianExtras
+)
+    return DI.value_gradient_and_hessian(f, single_threaded(backend), x, extras)
+end
+
+function DI.value_gradient_and_hessian!(
+    f, grad, hess, backend::AutoPolyesterForwardDiff, x, extras::HessianExtras
+)
+    return DI.value_gradient_and_hessian!(
+        f, grad, hess, single_threaded(backend), x, extras
+    )
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
@@ -166,7 +166,7 @@ end
 
 function DI.value_gradient_and_hessian!(
     _f,
-    grad::AbstractVector,
+    grad,
     hess::AbstractMatrix,
     ::AutoReverseDiff,
     x::AbstractArray,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
@@ -163,3 +163,28 @@ function DI.hessian(
 )
     return hessian!(extras.tape, x)
 end
+
+function DI.value_gradient_and_hessian!(
+    _f,
+    grad::AbstractVector,
+    hess::AbstractMatrix,
+    ::AutoReverseDiff,
+    x::AbstractArray,
+    extras::ReverseDiffHessianExtras,
+)
+    result = MutableDiffResult(y, (grad, hess))
+    result = hessian!(result, extras.tape, x)
+    return (
+        DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)
+    )
+end
+
+function DI.value_gradient_and_hessian(
+    _f, ::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffHessianExtras
+)
+    result = MutableDiffResult(y, (similar(x), similar(x, length(x), length(x))))
+    result = hessian!(result, extras.tape, x)
+    return (
+        DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)
+    )
+end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
@@ -172,7 +172,7 @@ function DI.value_gradient_and_hessian!(
     x::AbstractArray,
     extras::ReverseDiffHessianExtras,
 )
-    result = MutableDiffResult(y, (grad, hess))
+    result = MutableDiffResult(one(eltype(x)), (grad, hess))
     result = hessian!(result, extras.tape, x)
     return (
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)
@@ -182,7 +182,9 @@ end
 function DI.value_gradient_and_hessian(
     _f, ::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffHessianExtras
 )
-    result = MutableDiffResult(y, (similar(x), similar(x, length(x), length(x))))
+    result = MutableDiffResult(
+        one(eltype(x)), (similar(x), similar(x, length(x), length(x)))
+    )
     result = hessian!(result, extras.tape, x)
     return (
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/DifferentiationInterfaceSymbolicsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/DifferentiationInterfaceSymbolicsExt.jl
@@ -1,6 +1,6 @@
 module DifferentiationInterfaceSymbolicsExt
 
-using ADTypes: ADTypes, AutoSymbolics, AutoSparse
+using ADTypes: ADTypes, AutoSymbolics, AutoSparse, dense_ad
 import DifferentiationInterface as DI
 using DifferentiationInterface:
     DerivativeExtras,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/DifferentiationInterfaceSymbolicsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/DifferentiationInterfaceSymbolicsExt.jl
@@ -1,6 +1,6 @@
 module DifferentiationInterfaceSymbolicsExt
 
-using ADTypes: ADTypes, AutoSymbolics, AutoSparse, dense_ad
+using ADTypes: ADTypes, AutoSymbolics, AutoSparse
 import DifferentiationInterface as DI
 using DifferentiationInterface:
     DerivativeExtras,
@@ -10,7 +10,8 @@ using DifferentiationInterface:
     JacobianExtras,
     PullbackExtras,
     PushforwardExtras,
-    SecondDerivativeExtras
+    SecondDerivativeExtras,
+    maybe_dense_ad
 using FillArrays: Fill
 using LinearAlgebra: dot
 using Symbolics:

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/onearg.jl
@@ -215,7 +215,7 @@ function DI.prepare_hessian(f, backend::Union{AutoSymbolics,AutoSparse{<:AutoSym
     res = build_function(hess_var, vec(x_var); expression=Val(false))
     (hess_exe, hess_exe!) = res
 
-    gradient_extras = DI.prepare_gradient(f, dense_ad(backend), x)
+    gradient_extras = DI.prepare_gradient(f, maybe_dense_ad(backend), x)
     return SymbolicsOneArgHessianExtras(gradient_extras, hess_exe, hess_exe!)
 end
 
@@ -245,7 +245,7 @@ function DI.value_gradient_and_hessian(
     x,
     extras::SymbolicsOneArgHessianExtras,
 )
-    y, grad = DI.value_and_gradient(f, dense_ad(backend), x, extras.gradient_extras)
+    y, grad = DI.value_and_gradient(f, maybe_dense_ad(backend), x, extras.gradient_extras)
     hess = DI.hessian(f, backend, x, extras)
     return y, grad, hess
 end
@@ -258,7 +258,9 @@ function DI.value_gradient_and_hessian!(
     x,
     extras::SymbolicsOneArgHessianExtras,
 )
-    y, _ = DI.value_and_gradient!(f, grad, dense_ad(backend), x, extras.gradient_extras)
+    y, _ = DI.value_and_gradient!(
+        f, grad, maybe_dense_ad(backend), x, extras.gradient_extras
+    )
     DI.hessian!(f, hess, backend, x, extras)
     return y, grad, hess
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/onearg.jl
@@ -215,7 +215,7 @@ function DI.prepare_hessian(f, backend::Union{AutoSymbolics,AutoSparse{<:AutoSym
     res = build_function(hess_var, vec(x_var); expression=Val(false))
     (hess_exe, hess_exe!) = res
 
-    gradient_extras = DI.prepare_gradient(f, backend, x)
+    gradient_extras = DI.prepare_gradient(f, dense_ad(backend), x)
     return SymbolicsOneArgHessianExtras(gradient_extras, hess_exe, hess_exe!)
 end
 
@@ -245,7 +245,7 @@ function DI.value_gradient_and_hessian(
     x,
     extras::SymbolicsOneArgHessianExtras,
 )
-    y, grad = DI.value_and_gradient(f, backend, x, extras.gradient_extras)
+    y, grad = DI.value_and_gradient(f, dense_ad(backend), x, extras.gradient_extras)
     hess = DI.hessian(f, backend, x, extras)
     return y, grad, hess
 end
@@ -258,7 +258,7 @@ function DI.value_gradient_and_hessian!(
     x,
     extras::SymbolicsOneArgHessianExtras,
 )
-    y, _ = DI.value_and_gradient!(f, grad, backend, x, extras.gradient_extras)
+    y, _ = DI.value_and_gradient!(f, grad, dense_ad(backend), x, extras.gradient_extras)
     DI.hessian!(f, hess, backend, x, extras)
     return y, grad, hess
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/twoarg.jl
@@ -1,8 +1,8 @@
 ## Pushforward
 
-struct SymbolicsTwoArgPushforwardExtras{E1,E2} <: PushforwardExtras
+struct SymbolicsTwoArgPushforwardExtras{E1,E1!} <: PushforwardExtras
     pushforward_exe::E1
-    pushforward_exe!::E2
+    pushforward_exe!::E1!
 end
 
 function DI.prepare_pushforward(f!, y, ::AutoSymbolics, x, dx)
@@ -61,9 +61,9 @@ end
 
 ## Derivative
 
-struct SymbolicsTwoArgDerivativeExtras{E1,E2} <: DerivativeExtras
+struct SymbolicsTwoArgDerivativeExtras{E1,E1!} <: DerivativeExtras
     der_exe::E1
-    der_exe!::E2
+    der_exe!::E1!
 end
 
 function DI.prepare_derivative(f!, y, ::AutoSymbolics, x)
@@ -106,9 +106,9 @@ end
 
 ## Jacobian
 
-struct SymbolicsTwoArgJacobianExtras{E1,E2} <: JacobianExtras
+struct SymbolicsTwoArgJacobianExtras{E1,E1!} <: JacobianExtras
     jac_exe::E1
-    jac_exe!::E2
+    jac_exe!::E1!
 end
 
 function DI.prepare_jacobian(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -131,4 +131,18 @@ function DI.hessian!(f, hess, backend::AutoZygote, x, extras::NoHessianExtras)
     return copyto!(hess, DI.hessian(f, backend, x, extras))
 end
 
+function DI.value_gradient_and_hessian(f, ::AutoZygote, x, ::NoHessianExtras)
+    y, grad = DI.value_and_gradient(f, backend, x, NoGradientExtras())
+    hess = DI.hessian(f, backend, x, extras)
+    return y, grad, hess
+end
+
+function DI.value_gradient_and_hessian!(
+    f, grad, hess, backend::AutoZygote, x, extras::NoHessianExtras
+)
+    y, _ = DI.value_and_gradient!(f, backend, x, NoGradientExtras())
+    DI.hessian!(f, hess, backend, x, extras)
+    return y, grad, hess
+end
+
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -140,7 +140,7 @@ end
 function DI.value_gradient_and_hessian!(
     f, grad, hess, backend::AutoZygote, x, extras::NoHessianExtras
 )
-    y, _ = DI.value_and_gradient!(f, backend, x, NoGradientExtras())
+    y, _ = DI.value_and_gradient!(f, grad, backend, x, NoGradientExtras())
     DI.hessian!(f, hess, backend, x, extras)
     return y, grad, hess
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -131,7 +131,7 @@ function DI.hessian!(f, hess, backend::AutoZygote, x, extras::NoHessianExtras)
     return copyto!(hess, DI.hessian(f, backend, x, extras))
 end
 
-function DI.value_gradient_and_hessian(f, ::AutoZygote, x, ::NoHessianExtras)
+function DI.value_gradient_and_hessian(f, backend::AutoZygote, x, ::NoHessianExtras)
     y, grad = DI.value_and_gradient(f, backend, x, NoGradientExtras())
     hess = DI.hessian(f, backend, x, extras)
     return y, grad, hess

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -131,7 +131,7 @@ function DI.hessian!(f, hess, backend::AutoZygote, x, extras::NoHessianExtras)
     return copyto!(hess, DI.hessian(f, backend, x, extras))
 end
 
-function DI.value_gradient_and_hessian(f, backend::AutoZygote, x, ::NoHessianExtras)
+function DI.value_gradient_and_hessian(f, backend::AutoZygote, x, extras::NoHessianExtras)
     y, grad = DI.value_and_gradient(f, backend, x, NoGradientExtras())
     hess = DI.hessian(f, backend, x, extras)
     return y, grad, hess

--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -54,6 +54,7 @@ include("utils/printing.jl")
 include("utils/chunk.jl")
 include("utils/check.jl")
 include("utils/exceptions.jl")
+include("utils/maybe.jl")
 
 include("first_order/pushforward.jl")
 include("first_order/pullback.jl")

--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -99,6 +99,7 @@ export second_derivative!, second_derivative
 export value_derivative_and_second_derivative, value_derivative_and_second_derivative!
 export hvp!, hvp
 export hessian!, hessian
+export value_gradient_and_hessian, value_gradient_and_hessian!
 
 export prepare_pushforward, prepare_pushforward_same_point
 export prepare_pullback, prepare_pullback_same_point

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -50,8 +50,8 @@ abstract type HessianExtras <: Extras end
 struct NoHessianExtras <: HessianExtras end
 
 struct HVPGradientHessianExtras{E2<:HVPExtras,E1<:GradientExtras} <: HessianExtras
-    hvp_extras::E1
-    gradient_extras::E2
+    hvp_extras::E2
+    gradient_extras::E1
 end
 
 function prepare_hessian(f::F, backend::AbstractADType, x) where {F}

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -49,8 +49,9 @@ abstract type HessianExtras <: Extras end
 
 struct NoHessianExtras <: HessianExtras end
 
-struct HVPGradientHessianExtras{E<:HVPExtras} <: HessianExtras
-    hvp_extras::E
+struct HVPGradientHessianExtras{E1<:HVPExtras,E2<:GradientExtras} <: HessianExtras
+    hvp_extras::E1
+    gradient_extras::E2
 end
 
 function prepare_hessian(f::F, backend::AbstractADType, x) where {F}

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -110,6 +110,6 @@ function value_gradient_and_hessian!(
     extras::HessianExtras=prepare_hessian(f, backend, x),
 ) where {F}
     y, _ = value_and_gradient!(f, grad, maybe_inner(backend), x, extras.gradient_extras)
-    hessian!(f, hess, backend, extras)
+    hessian!(f, hess, backend, x, extras)
     return y, grad, hess
 end

--- a/DifferentiationInterface/src/second_order/second_order.jl
+++ b/DifferentiationInterface/src/second_order/second_order.jl
@@ -54,8 +54,3 @@ Return a possibly modified `backend` that can work while nested inside another d
 At the moment, this is only useful for Enzyme, which needs `autodiff_deferred` to be compatible with higher-order differentiation.
 """
 nested(backend::AbstractADType) = backend
-
-maybe_inner(backend::SecondOrder) = inner(backend)
-maybe_outer(backend::SecondOrder) = outer(backend)
-maybe_inner(backend::AbstractADType) = backend
-maybe_outer(backend::AbstractADType) = backend

--- a/DifferentiationInterface/src/second_order/second_order.jl
+++ b/DifferentiationInterface/src/second_order/second_order.jl
@@ -54,3 +54,8 @@ Return a possibly modified `backend` that can work while nested inside another d
 At the moment, this is only useful for Enzyme, which needs `autodiff_deferred` to be compatible with higher-order differentiation.
 """
 nested(backend::AbstractADType) = backend
+
+maybe_inner(backend::SecondOrder) = inner(backend)
+maybe_outer(backend::SecondOrder) = outer(backend)
+maybe_inner(backend::AbstractADType) = backend
+maybe_outer(backend::AbstractADType) = backend

--- a/DifferentiationInterface/src/sparse/hessian.jl
+++ b/DifferentiationInterface/src/sparse/hessian.jl
@@ -78,6 +78,6 @@ function value_gradient_and_hessian(
     y, grad = value_and_gradient(
         f, maybe_inner(dense_ad(backend)), x, extras.gradient_extras
     )
-    hess = hessian(f, hess, backend, x, extras)
+    hess = hessian(f, backend, x, extras)
     return y, grad, hess
 end

--- a/DifferentiationInterface/src/sparse/hessian.jl
+++ b/DifferentiationInterface/src/sparse/hessian.jl
@@ -4,14 +4,16 @@ Base.@kwdef struct SparseHessianExtras{
     K<:AbstractVector{<:Integer},
     D<:AbstractVector,
     P<:AbstractVector,
-    E<:Extras,
+    E2<:HVPExtras,
+    E1<:GradientExtras,
 } <: HessianExtras
     sparsity::S
     compressed::C
     colors::K
     seeds::D
     products::P
-    hvp_extras::E
+    hvp_extras::E2
+    gradient_extras::E1
 end
 
 ## Hessian, one argument
@@ -32,7 +34,10 @@ function prepare_hessian(f::F, backend::AutoSparse, x) where {F}
         similar(x)
     end
     compressed = stack(vec, products; dims=2)
-    return SparseHessianExtras(; sparsity, compressed, colors, seeds, products, hvp_extras)
+    gradient_extras = prepare_gradient(f, maybe_inner(dense_backend), x)
+    return SparseHessianExtras(;
+        sparsity, compressed, colors, seeds, products, hvp_extras, gradient_extras
+    )
 end
 
 function hessian!(f::F, hess, backend::AutoSparse, x, extras::SparseHessianExtras) where {F}
@@ -55,4 +60,24 @@ function hessian(f::F, backend::AutoSparse, x, extras::SparseHessianExtras) wher
         vec(hvp(f, dense_backend, x, seeds[k], hvp_extras_same))
     end
     return decompress_symmetric(sparsity, compressed, colors)
+end
+
+function value_gradient_and_hessian!(
+    f::F, grad, hess, backend::AutoSparse, x, extras::SparseHessianExtras
+) where {F}
+    y, _ = value_and_gradient!(
+        f, grad, maybe_inner(dense_ad(backend)), x, extras.gradient_extras
+    )
+    hessian!(f, hess, backend, x, extras)
+    return y, grad, hess
+end
+
+function value_gradient_and_hessian(
+    f::F, backend::AutoSparse, x, extras::SparseHessianExtras
+) where {F}
+    y, grad = value_and_gradient(
+        f, maybe_inner(dense_ad(backend)), x, extras.gradient_extras
+    )
+    hess = hessian(f, hess, backend, x, extras)
+    return y, grad, hess
 end

--- a/DifferentiationInterface/src/utils/maybe.jl
+++ b/DifferentiationInterface/src/utils/maybe.jl
@@ -1,0 +1,7 @@
+maybe_inner(backend::SecondOrder) = inner(backend)
+maybe_outer(backend::SecondOrder) = outer(backend)
+maybe_inner(backend::AbstractADType) = backend
+maybe_outer(backend::AbstractADType) = backend
+
+maybe_dense_ad(backend::AutoSparse) = dense_ad(backend)
+maybe_dense_ad(backend::AbstractADType) = backend

--- a/DifferentiationInterface/test/runtests.jl
+++ b/DifferentiationInterface/test/runtests.jl
@@ -33,7 +33,7 @@ ALL_BACKENDS = [
 @testset verbose = true "DifferentiationInterface.jl" begin
     if GROUP == "Formalities" || GROUP == "All"
         @testset "Formalities/$file" for file in readdir(joinpath(@__DIR__, "Formalities"))
-            @info "Testing Formalities/$file)"
+            @info "Testing Formalities/$file"
             include(joinpath(@__DIR__, "Formalities", file))
         end
     end

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -24,6 +24,8 @@ using DifferentiationInterface
 using DifferentiationInterface:
     backend_str,
     inner,
+    maybe_inner,
+    maybe_dense_ad,
     mode,
     outer,
     twoarg_support,

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -971,7 +971,7 @@ function test_correctness(
     grad_true = if ref_backend isa AbstractADType
         gradient(f, maybe_dense_ad(maybe_inner(ref_backend)), x)
     else
-        new_scen.ref(x)
+        new_scen.first_order_ref(x)
     end
     hess_true = if ref_backend isa AbstractADType
         hessian(f, ref_backend, x)
@@ -1014,7 +1014,7 @@ function test_correctness(
     grad_true = if ref_backend isa AbstractADType
         gradient(f, maybe_dense_ad(maybe_inner(ref_backend)), x)
     else
-        new_scen.ref(x)
+        new_scen.first_order_ref(x)
     end
     hess_true = if ref_backend isa AbstractADType
         hessian(f, ref_backend, x)

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -1040,7 +1040,7 @@ function test_correctness(
             @test extras isa HessianExtras
         end
         @testset "Primal value" begin
-            @test y2 ≈ y_true
+            @test y2 ≈ y
         end
         @testset "Gradient value" begin
             @test grad2_in ≈ grad_true

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -794,10 +794,8 @@ function test_correctness(
 )
     @compat (; f, x, y) = new_scen = deepcopy(scen)
     extras = prepare_second_derivative(f, ba, mycopy_random(x))
-    der1_true = if ref_backend isa SecondOrder
-        derivative(f, inner(ref_backend), x)
-    elseif ref_backend isa AbstractADType
-        derivative(f, ref_backend, x)
+    der1_true = if ref_backend isa AbstractADType
+        derivative(f, maybe_inner(ref_backend), x)
     else
         new_scen.first_order_ref(x)
     end
@@ -839,10 +837,8 @@ function test_correctness(
 )
     @compat (; f, x, y) = new_scen = deepcopy(scen)
     extras = prepare_second_derivative(f, ba, mycopy_random(x))
-    der1_true = if ref_backend isa SecondOrder
-        derivative(f, inner(ref_backend), x)
-    elseif ref_backend isa AbstractADType
-        derivative(f, ref_backend, x)
+    der1_true = if ref_backend isa AbstractADType
+        derivative(f, maybe_inner(ref_backend), x)
     else
         new_scen.first_order_ref(x)
     end
@@ -972,10 +968,8 @@ function test_correctness(
 )
     @compat (; f, x, y) = new_scen = deepcopy(scen)
     extras = prepare_hessian(f, ba, mycopy_random(x))
-    grad_true = if ref_backend isa SecondOrder
-        gradient(f, inner(ref_backend), x)
-    elseif ref_backend isa AbstractADType
-        gradient(f, ref_backend, x)
+    grad_true = if ref_backend isa AbstractADType
+        gradient(f, maybe_dense_ad(maybe_inner(ref_backend)), x)
     else
         new_scen.ref(x)
     end
@@ -1017,10 +1011,8 @@ function test_correctness(
 )
     @compat (; f, x, y) = new_scen = deepcopy(scen)
     extras = prepare_hessian(f, ba, mycopy_random(x))
-    grad_true = if ref_backend isa SecondOrder
-        gradient(f, inner(ref_backend), x)
-    elseif ref_backend isa AbstractADType
-        gradient(f, ref_backend, x)
+    grad_true = if ref_backend isa AbstractADType
+        gradient(f, maybe_dense_ad(maybe_inner(ref_backend)), x)
     else
         new_scen.ref(x)
     end

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -993,7 +993,7 @@ function test_correctness(
             @test extras isa HessianExtras
         end
         @testset "Primal value" begin
-            @test y2 ≈ y_true
+            @test y2 ≈ y
         end
         @testset "Gradient value" begin
             @test grad2 ≈ grad_true

--- a/DifferentiationInterfaceTest/src/tests/sparsity.jl
+++ b/DifferentiationInterfaceTest/src/tests/sparsity.jl
@@ -99,9 +99,11 @@ function test_sparsity(
     end
 
     hess1 = hessian(f, ba, x, extras)
+    _, _, hess2 = value_gradient_and_hessian(f, ba, x, extras)
 
     @testset "Sparsity pattern" begin
         @test mynnz(hess1) == mynnz(hess_true)
+        @test mynnz(hess2) == mynnz(hess_true)
     end
     return nothing
 end
@@ -116,9 +118,13 @@ function test_sparsity(ba::AbstractADType, scen::HessianScenario{1,:inplace}; re
     end
 
     hess1 = hessian!(f, mysimilar(hess_true), ba, x, extras)
+    _, _, hess2 = value_gradient_and_hessian!(
+        f, mysimilar(x), mysimilar(hess_true), ba, x, extras
+    )
 
     @testset "Sparsity pattern" begin
         @test mynnz(hess1) == mynnz(hess_true)
+        @test mynnz(hess2) == mynnz(hess_true)
     end
     return nothing
 end

--- a/DifferentiationInterfaceTest/src/tests/type_stability.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability.jl
@@ -283,14 +283,19 @@ function test_jet(ba::AbstractADType, scen::HessianScenario{1,:outofplace}; ref_
     extras = prepare_hessian(f, ba, x)
 
     JET.@test_opt function_filter = filt hessian(f, ba, x, extras)
+    JET.@test_opt function_filter = filt value_gradient_and_hessian(f, ba, x, extras)
     return nothing
 end
 
 function test_jet(ba::AbstractADType, scen::HessianScenario{1,:inplace}; ref_backend)
     @compat (; f, x, y) = deepcopy(scen)
     extras = prepare_hessian(f, ba, x)
+    grad_in = mysimilar(x)
     hess_in = Matrix{typeof(y)}(undef, length(x), length(x))
 
     JET.@test_opt function_filter = filt hessian!(f, hess_in, ba, x, extras)
+    JET.@test_opt function_filter = filt value_gradient_and_hessian!(
+        f, grad_in, hess_in, ba, x, extras
+    )
     return nothing
 end


### PR DESCRIPTION
**DI source**

- [x] Add `value_gradient_and_hessian` for dense and sparse backends
- [x] Adjust `extras` accordingly to prepare the gradient too
- [x] Add `maybe_inner`, `maybe_outer` and `maybe_dense_ad` logic to accommodate first-order backends

**DI extensions**

Add operator for:

- [x] FastDifferentiation
- [x] FiniteDiff
- [x] ForwardDiff
- [x] PolyesterForwardDiff
- [x] ReverseDiff
- [x] Symbolics
- [x] Zygote

**DI docs**

- [x] Document `value_gradient_and_hessian`

**DIT source**

- [x] Add correctness, benchmark and type stability tests for `value_gradient_and_hessian`