### PR TITLE
Non-constant f in Enzyme

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -12,7 +12,7 @@ function DI.value_and_pushforward(
     y, new_dy = if backend isa AutoDeferredEnzyme
         autodiff_deferred(forward_mode(backend), f, Duplicated, x_and_dx)
     else
-        autodiff(forward_mode(backend), Const(f), Duplicated, x_and_dx)
+        autodiff(forward_mode(backend), f, Duplicated, x_and_dx)
     end
     return y, new_dy
 end
@@ -25,7 +25,7 @@ function DI.pushforward(
     new_dy = if backend isa AutoDeferredEnzyme
         only(autodiff_deferred(forward_mode(backend), f, DuplicatedNoNeed, x_and_dx))
     else
-        only(autodiff(forward_mode(backend), Const(f), DuplicatedNoNeed, x_and_dx))
+        only(autodiff(forward_mode(backend), f, DuplicatedNoNeed, x_and_dx))
     end
     return new_dy
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -19,7 +19,7 @@ function DI.value_and_pushforward(
     if backend isa AutoDeferredEnzyme
         autodiff_deferred(forward_mode(backend), f!, Const, y_and_dy, x_and_dx)
     else
-        autodiff(forward_mode(backend), Const(f!), Const, y_and_dy, x_and_dx)
+        autodiff(forward_mode(backend), f!, Const, y_and_dy, x_and_dx)
     end
     return y, dy_sametype
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -16,7 +16,7 @@ function DI.value_and_pullback(
     der, y = if backend isa AutoDeferredEnzyme
         autodiff_deferred(ReverseWithPrimal, f, Active, Active(x))
     else
-        autodiff(ReverseWithPrimal, Const(f), Active, Active(x))
+        autodiff(ReverseWithPrimal, f, Active, Active(x))
     end
     new_dx = dy * only(der)
     return y, new_dx
@@ -31,9 +31,9 @@ function DI.value_and_pullback(
 )
     tf, tx = typeof(f), typeof(x)
     forw, rev = autodiff_thunk(ReverseSplitWithPrimal, Const{tf}, Duplicated, Active{tx})
-    tape, y, new_dy = forw(Const(f), Active(x))
+    tape, y, new_dy = forw(f, Active(x))
     copyto!(new_dy, dy)
-    new_dx = only(only(rev(Const(f), Active(x), tape)))
+    new_dx = only(only(rev(f, Active(x), tape)))
     return y, new_dx
 end
 
@@ -68,9 +68,9 @@ function DI.value_and_pullback!(
     dx_sametype .= zero(eltype(x))
     x_and_dx = Duplicated(x, dx_sametype)
     _, y = if backend isa AutoDeferredEnzyme
-        autodiff_deferred(ReverseWithPrimal, Const(f), Active, x_and_dx)
+        autodiff_deferred(ReverseWithPrimal, f, Active, x_and_dx)
     else
-        autodiff(ReverseWithPrimal, Const(f), Active, x_and_dx)
+        autodiff(ReverseWithPrimal, f, Active, x_and_dx)
     end
     dx_sametype .*= dy
     return y, copyto!(dx, dx_sametype)
@@ -90,9 +90,9 @@ function DI.value_and_pullback!(
     )
     dx_sametype = convert(typeof(x), dx)
     dx_sametype .= zero(eltype(x))
-    tape, y, new_dy = forw(Const(f), Duplicated(x, dx_sametype))
+    tape, y, new_dy = forw(f, Duplicated(x, dx_sametype))
     copyto!(new_dy, dy)
-    rev(Const(f), Duplicated(x, dx_sametype), tape)
+    rev(f, Duplicated(x, dx_sametype), tape)
     return y, copyto!(dx, dx_sametype)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -17,7 +17,7 @@ function DI.value_and_pullback(
     _, new_dx = if backend isa AutoDeferredEnzyme
         only(autodiff_deferred(reverse_mode(backend), f!, Const, y_and_dy, Active(x)))
     else
-        only(autodiff(reverse_mode(backend), Const(f!), Const, y_and_dy, Active(x)))
+        only(autodiff(reverse_mode(backend), f!, Const, y_and_dy, Active(x)))
     end
     return y, new_dx
 end
@@ -37,7 +37,7 @@ function DI.value_and_pullback(
     if backend isa AutoDeferredEnzyme
         autodiff_deferred(reverse_mode(backend), f!, Const, y_and_dy, x_and_dx)
     else
-        autodiff(reverse_mode(backend), Const(f!), Const, y_and_dy, x_and_dx)
+        autodiff(reverse_mode(backend), f!, Const, y_and_dy, x_and_dx)
     end
     return y, dx_sametype
 end


### PR DESCRIPTION
**DI extensions**

- [x] Remove `Const` annotation on `f`.
  - Downside: performance loss in most cases
  - Upside: allows closures and thus second order

**DI tests**

- [ ] Test this