### PR TITLE
Add dual number–based second derivatives for `ForwardDiff`

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -10,6 +10,7 @@ using DifferentiationInterface:
     HessianExtras,
     JacobianExtras,
     NoDerivativeExtras,
+    NoSecondDerivativeExtras,
     PushforwardExtras
 using ForwardDiff.DiffResults: DiffResults, DiffResult, GradientResult, MutableDiffResult
 using ForwardDiff:

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -68,7 +68,7 @@ function DI.prepare_second_derivative(f::F, backend::AutoForwardDiff, x) where {
 end
 
 function DI.second_derivative(
-    f::F, ::AutoForwardDiff, x, dx, ::NoSecondDerivativeExtras
+    f::F, ::AutoForwardDiff, x, ::NoSecondDerivativeExtras
 ) where {F}
     T = tag_type(f, backend, x)
     xdual = make_dual(T, x, one(x))
@@ -78,7 +78,7 @@ function DI.second_derivative(
 end
 
 function DI.second_derivative!(
-    f::F, der2, ::AutoForwardDiff, x, dx, ::NoSecondDerivativeExtras
+    f::F, der2, ::AutoForwardDiff, x, ::NoSecondDerivativeExtras
 ) where {F}
     T = tag_type(f, backend, x)
     xdual = make_dual(T, x, one(x))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -67,14 +67,6 @@ function DI.prepare_derivative(f::F, backend::AutoForwardDiff, x) where {F}
     return NoDerivativeExtras()
 end
 
-function DI.derivative(f::F, ::AutoForwardDiff, x, ::NoDerivativeExtras) where {F}
-    return derivative(f, x)
-end
-
-function DI.derivative!(f::F, der, ::AutoForwardDiff, x, ::NoDerivativeExtras) where {F}
-    return derivative!(der, f, x)
-end
-
 function DI.value_and_derivative(
     f::F, backend::AutoForwardDiff, x, ::NoDerivativeExtras
 ) where {F}

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -71,12 +71,25 @@ function DI.derivative(f::F, ::AutoForwardDiff, x, ::NoDerivativeExtras) where {
     return derivative(f, x)
 end
 
+function DI.derivative!(f::F, der, ::AutoForwardDiff, x, ::NoDerivativeExtras) where {F}
+    return derivative!(der, f, x)
+end
+
 function DI.value_and_derivative(
     f::F, backend::AutoForwardDiff, x, ::NoDerivativeExtras
 ) where {F}
     T = tag_type(f, backend, x)
     ydual = f(make_dual(T, x, one(x)))
     return myvalue(T, ydual), myderivative(T, ydual)
+end
+
+function DI.value_and_derivative!(
+    f::F, der, ::AutoForwardDiff, x, ::NoDerivativeExtras
+) where {F}
+    T = tag_type(f, backend, x)
+    xdual = make_dual(T, x, one(x))
+    ydual = f(xdual)
+    return myvalue(T, ydual), myderivative!(T, der, ydual)
 end
 
 function DI.value_derivative_and_second_derivative(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -63,6 +63,10 @@ end
 
 ## Derivative
 
+function DI.prepare_derivative(f::F, backend::AutoForwardDiff, x) where {F}
+    return NoDerivativeExtras()
+end
+
 function DI.value_and_derivative(f::F, backend::AutoForwardDiff, x) where {F}
     T = tag_type(f, backend, x)
     ydual = f(make_dual(T, x, one(x)))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -184,19 +184,21 @@ function DI.value_gradient_and_hessian(
     )
 end
 
-function DI.value_and_derivative(f::F, ::AutoForwardDiff, x) where {F}
-    T = typeof(Tag(f, typeof(x)))
-    ydual = f(Dual{T}(x, one(x)))
-    return value(T, ydual), extract_derivative(T, ydual)
+function DI.value_and_derivative(f::F, backend::AutoForwardDiff, x) where {F}
+    T = tag_type(f, backend, x)
+    ydual = f(make_dual(T, x, one(x)))
+    return myvalue(T, ydual), myderivative(T, ydual)
 end
 
-function DI.value_derivative_and_second_derivative(f::F, ::AutoForwardDiff, x) where {F}
-    T = typeof(Tag(f, typeof(x)))
-    xdual = Dual{T}(x, one(x))
-    T2 = typeof(Tag(f, typeof(xdual)))
-    ydual = f(Dual{T2}(xdual, one(xdual)))
-    v = value(T, value(T2, ydual))
-    d = extract_derivative(T, value(T2, ydual))
-    d2 = extract_derivative(T, extract_derivative(T2, ydual))
+function DI.value_derivative_and_second_derivative(
+    f::F, backend::AutoForwardDiff, x
+) where {F}
+    T = tag_type(f, backend, x)
+    xdual = make_dual(T, x, one(x))
+    T2 = tag_type(f, backend, xdual)
+    ydual = f(make_dual(T2, xdual, one(xdual)))
+    v = myvalue(T, value(T2, ydual))
+    d = myderivative(T, value(T2, ydual))
+    d2 = myderivative(T, myderivative(T2, ydual))
     return v, d, d2
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -183,3 +183,20 @@ function DI.value_gradient_and_hessian(
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)
     )
 end
+
+function DI.value_and_derivative(f::F, ::AutoForwardDiff, x) where {F}
+    T = typeof(Tag(f, typeof(x)))
+    ydual = f(Dual{T}(x, one(x)))
+    return value(T, ydual), extract_derivative(T, ydual)
+end
+
+function DI.value_derivative_and_second_derivative(f::F, ::AutoForwardDiff, x) where {F}
+    T = typeof(Tag(f, typeof(x)))
+    xdual = Dual{T}(x, one(x))
+    T2 = typeof(Tag(f, typeof(xdual)))
+    ydual = f(Dual{T2}(xdual, one(xdual)))
+    v = value(T, value(T2, ydual))
+    d = extract_derivative(T, value(T2, ydual))
+    d2 = extract_derivative(T, extract_derivative(T2, ydual))
+    return v, d, d2
+end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -84,7 +84,7 @@ function DI.value_and_derivative(
 end
 
 function DI.value_and_derivative!(
-    f::F, der, ::AutoForwardDiff, x, ::NoDerivativeExtras
+    f::F, der, backend::AutoForwardDiff, x, ::NoDerivativeExtras
 ) where {F}
     T = tag_type(f, backend, x)
     xdual = make_dual(T, x, one(x))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -68,7 +68,7 @@ function DI.prepare_second_derivative(f::F, backend::AutoForwardDiff, x) where {
 end
 
 function DI.second_derivative(
-    f::F, ::AutoForwardDiff, x, ::NoSecondDerivativeExtras
+    f::F, backend::AutoForwardDiff, x, ::NoSecondDerivativeExtras
 ) where {F}
     T = tag_type(f, backend, x)
     xdual = make_dual(T, x, one(x))
@@ -78,7 +78,7 @@ function DI.second_derivative(
 end
 
 function DI.second_derivative!(
-    f::F, der2, ::AutoForwardDiff, x, ::NoSecondDerivativeExtras
+    f::F, der2, backend::AutoForwardDiff, x, ::NoSecondDerivativeExtras
 ) where {F}
     T = tag_type(f, backend, x)
     xdual = make_dual(T, x, one(x))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -84,17 +84,36 @@ function DI.value_and_derivative!(
     return myvalue(T, ydual), myderivative!(T, der, ydual)
 end
 
+## Second derivative
+
+function DI.prepare_second_derivative(f::F, backend::AutoForwardDiff, x) where {F}
+    return NoSecondDerivativeExtras()
+end
+
 function DI.value_derivative_and_second_derivative(
-    f::F, backend::AutoForwardDiff, x, ::NoDerivativeExtras
+    f::F, backend::AutoForwardDiff, x, ::NoSecondDerivativeExtras
 ) where {F}
     T = tag_type(f, backend, x)
     xdual = make_dual(T, x, one(x))
     T2 = tag_type(f, backend, xdual)
     ydual = f(make_dual(T2, xdual, one(xdual)))
-    v = myvalue(T, myvalue(T2, ydual))
-    d = myderivative(T, myvalue(T2, ydual))
-    d2 = myderivative(T, myderivative(T2, ydual))
-    return v, d, d2
+    y = myvalue(T, myvalue(T2, ydual))
+    der = myderivative(T, myvalue(T2, ydual))
+    der2 = myderivative(T, myderivative(T2, ydual))
+    return y, der, der2
+end
+
+function DI.value_derivative_and_second_derivative!(
+    f::F, der, der2, backend::AutoForwardDiff, x, ::NoSecondDerivativeExtras
+) where {F}
+    T = tag_type(f, backend, x)
+    xdual = make_dual(T, x, one(x))
+    T2 = tag_type(f, backend, xdual)
+    ydual = f(make_dual(T2, xdual, one(xdual)))
+    y = myvalue(T, myvalue(T2, ydual))
+    myderivative!(T, der, myvalue(T2, ydual))
+    myderivative!(T, der2, myderivative(T2, ydual))
+    return y, der, der2
 end
 
 ## Gradient

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -197,8 +197,8 @@ function DI.value_derivative_and_second_derivative(
     xdual = make_dual(T, x, one(x))
     T2 = tag_type(f, backend, xdual)
     ydual = f(make_dual(T2, xdual, one(xdual)))
-    v = myvalue(T, value(T2, ydual))
-    d = myderivative(T, value(T2, ydual))
+    v = myvalue(T, myvalue(T2, ydual))
+    d = myderivative(T, myvalue(T2, ydual))
     d2 = myderivative(T, myderivative(T2, ydual))
     return v, d, d2
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -67,14 +67,20 @@ function DI.prepare_derivative(f::F, backend::AutoForwardDiff, x) where {F}
     return NoDerivativeExtras()
 end
 
-function DI.value_and_derivative(f::F, backend::AutoForwardDiff, x) where {F}
+function DI.derivative(f::F, ::AutoForwardDiff, x, ::NoDerivativeExtras) where {F}
+    return derivative(f, x)
+end
+
+function DI.value_and_derivative(
+    f::F, backend::AutoForwardDiff, x, ::NoDerivativeExtras
+) where {F}
     T = tag_type(f, backend, x)
     ydual = f(make_dual(T, x, one(x)))
     return myvalue(T, ydual), myderivative(T, ydual)
 end
 
 function DI.value_derivative_and_second_derivative(
-    f::F, backend::AutoForwardDiff, x
+    f::F, backend::AutoForwardDiff, x, ::NoDerivativeExtras
 ) where {F}
     T = tag_type(f, backend, x)
     xdual = make_dual(T, x, one(x))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -67,6 +67,26 @@ function DI.prepare_second_derivative(f::F, backend::AutoForwardDiff, x) where {
     return NoSecondDerivativeExtras()
 end
 
+function DI.second_derivative(
+    f::F, ::AutoForwardDiff, x, dx, ::NoSecondDerivativeExtras
+) where {F}
+    T = tag_type(f, backend, x)
+    xdual = make_dual(T, x, one(x))
+    T2 = tag_type(f, backend, xdual)
+    ydual = f(make_dual(T2, xdual, one(xdual)))
+    return myderivative(T, myderivative(T2, ydual))
+end
+
+function DI.second_derivative!(
+    f::F, der2, ::AutoForwardDiff, x, dx, ::NoSecondDerivativeExtras
+) where {F}
+    T = tag_type(f, backend, x)
+    xdual = make_dual(T, x, one(x))
+    T2 = tag_type(f, backend, xdual)
+    ydual = f(make_dual(T2, xdual, one(xdual)))
+    return myderivative!(T, der2, myderivative(T2, ydual))
+end
+
 function DI.value_derivative_and_second_derivative(
     f::F, backend::AutoForwardDiff, x, ::NoSecondDerivativeExtras
 ) where {F}

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -61,29 +61,6 @@ function DI.pushforward!(
     return dy
 end
 
-## Derivative
-
-function DI.prepare_derivative(f::F, backend::AutoForwardDiff, x) where {F}
-    return NoDerivativeExtras()
-end
-
-function DI.value_and_derivative(
-    f::F, backend::AutoForwardDiff, x, ::NoDerivativeExtras
-) where {F}
-    T = tag_type(f, backend, x)
-    ydual = f(make_dual(T, x, one(x)))
-    return myvalue(T, ydual), myderivative(T, ydual)
-end
-
-function DI.value_and_derivative!(
-    f::F, der, backend::AutoForwardDiff, x, ::NoDerivativeExtras
-) where {F}
-    T = tag_type(f, backend, x)
-    xdual = make_dual(T, x, one(x))
-    ydual = f(xdual)
-    return myvalue(T, ydual), myderivative!(T, der, ydual)
-end
-
 ## Second derivative
 
 function DI.prepare_second_derivative(f::F, backend::AutoForwardDiff, x) where {F}


### PR DESCRIPTION
As discussed in #305, I'm starting by copying the implementations from https://github.com/JuliaDiff/AbstractDifferentiation.jl/pull/122 almost verbatim.