### PR TITLE
Bump versions

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.5.4"
+version = "0.5.5"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/docs/src/backends.md
+++ b/DifferentiationInterface/docs/src/backends.md
@@ -64,15 +64,18 @@ backend_table = Markdown.parse(String(take!(io)))
 backend_table #hide
 ```
 
-!!! danger "Compatibility with Julia 1.6"
-    As of version 0.3.4, DifferentiationInterface.jl is compatible with Julia 1.6, the Long Term Support (LTS) version of the language.
-    However, we were only able to test the following backends on LTS:
-      - FiniteDifferences.jl
-      - ForwardDiff.jl
-      - ReverseDiff.jl
-      - Tracker.jl
-      - Zygote.jl
-    We strongly recommend that users upgrade to Julia 1.10, where all backends are tested.
+## Compatibility
+
+DifferentiationInterface.jl itself is compatible with Julia 1.6, the Long Term Support (LTS) version of the language.
+However, we were only able to test the following backends on Julia 1.6:
+
+- FiniteDifferences.jl
+- ForwardDiff.jl
+- ReverseDiff.jl
+- Tracker.jl
+- Zygote.jl
+
+We strongly recommend that users upgrade to Julia 1.10, where all backends are tested.
 
 ## Checks
 

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterfaceTest"
 uuid = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
**Versions**

- Bump DI to v0.5.5 and DIT to v0.4.4 following #313 

**DI docs**

- Move backend compatibility warning to its own paragraph