### PR TITLE
Batched ForwardDiff pushforward

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -5,6 +5,7 @@ using Base: Fix1
 using Compat
 import DifferentiationInterface as DI
 using DifferentiationInterface:
+    Batch,
     DerivativeExtras,
     GradientExtras,
     HessianExtras,
@@ -33,6 +34,8 @@ using ForwardDiff:
     hessian!,
     jacobian,
     jacobian!,
+    npartials,
+    partials,
     value
 using LinearAlgebra: dot, mul!
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -1,7 +1,7 @@
 module DifferentiationInterfaceForwardDiffExt
 
 using ADTypes: AbstractADType, AutoForwardDiff
-using Base: Fix1
+using Base: Fix1, Fix2
 using Compat
 import DifferentiationInterface as DI
 using DifferentiationInterface:

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -73,7 +73,7 @@ function DI.pushforward_batched(
     f::F, ::AutoForwardDiff, x, dx::Batch{B}, extras::ForwardDiffOneArgPushforwardExtras{T}
 ) where {F,T,B}
     ydual = compute_ydual_onearg(f, x, dx, extras)
-    new_dy = mypartials(T, ydual)
+    new_dy = mypartials(T, Val(B), ydual)
     return new_dy
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -86,7 +86,7 @@ function DI.pushforward_batched(
     extras::ForwardDiffTwoArgPushforwardExtras{T},
 ) where {F,T,B}
     ydual_tmp = compute_ydual_twoarg(f!, y, x, dx, extras)
-    dy = mypartials(T, ydual_tmp)
+    dy = mypartials(T, Val(B), ydual_tmp)
     return dy
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -78,8 +78,13 @@ function DI.pushforward!(
 end
 
 function DI.pushforward_batched(
-    f!::F, y, ::AutoForwardDiff, x, dx::Batch, extras::ForwardDiffTwoArgPushforwardExtras{T}
-) where {F,T}
+    f!::F,
+    y,
+    ::AutoForwardDiff,
+    x,
+    dx::Batch{B},
+    extras::ForwardDiffTwoArgPushforwardExtras{T},
+) where {F,T,B}
     ydual_tmp = compute_ydual_twoarg(f!, y, x, dx, extras)
     dy = mypartials(T, ydual_tmp)
     return dy
@@ -88,12 +93,12 @@ end
 function DI.pushforward_batched!(
     f!::F,
     y,
-    dy,
+    dy::Batch{B},
     ::AutoForwardDiff,
     x,
-    dx::Batch,
+    dx::Batch{B},
     extras::ForwardDiffTwoArgPushforwardExtras{T},
-) where {F,T}
+) where {F,T,B}
     ydual_tmp = compute_ydual_twoarg(f!, y, x, dx, extras)
     mypartials!(T, dy, ydual_tmp)
     return dy

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -1,23 +1,60 @@
 choose_chunk(::AutoForwardDiff{nothing}, x) = Chunk(x)
-choose_chunk(::AutoForwardDiff{C}, x) where {C} = Chunk{C}()
+choose_chunk(::AutoForwardDiff{C}, x) where {C} = Chunk{min(length(x), C)}()
 
 tag_type(f, ::AutoForwardDiff{C,T}, x) where {C,T} = T
 tag_type(f, ::AutoForwardDiff{C,Nothing}, x) where {C} = Tag{typeof(f),eltype(x)}
 
-make_dual_similar(::Type{T}, x::Number) where {T} = Dual{T}(x, x)
-make_dual_similar(::Type{T}, x) where {T} = similar(x, Dual{T,eltype(x),1})
+make_dual_similar(::Type{T}, x::Number, dx::Number) where {T} = Dual{T}(x, dx)
+make_dual_similar(::Type{T}, x, dx) where {T} = similar(x, Dual{T,eltype(x),1})
 
-make_dual(::Type{T}, x::Number, dx) where {T} = Dual{T}(x, dx)
+function make_dual_similar(::Type{T}, x::Number, dx::Batch{B,<:Number}) where {T,B}
+    return Dual{T}(x, dx.elements...)
+end
+
+function make_dual_similar(::Type{T}, x, dx::Batch{B}) where {T,B}
+    return similar(x, Dual{T,eltype(x),B})
+end
+
+make_dual(::Type{T}, x::Number, dx::Number) where {T} = Dual{T}(x, dx)
 make_dual!(::Type{T}, xdual, x, dx) where {T} = map!(Dual{T}, xdual, x, dx)
 
-myvalue(::Type{T}, ydual::Number) where {T} = value(T, ydual)
-myvalue(::Type{T}, ydual) where {T} = map(Fix1(value, T), ydual)
+function make_dual(::Type{T}, x::Number, dx::Batch{B,<:Number}) where {T,B}
+    return Dual{T}(x, dx.elements...)
+end
 
-myvalue!(::Type{T}, y, ydual) where {T} = map!(Fix1(value, T), y, ydual)
+function make_dual!(::Type{T}, xdual, x, dx::Batch{B}) where {T,B}
+    return map!(Dual{T}, xdual, x, dx.elements...)
+end
 
-myderivative(::Type{T}, ydual::Number) where {T} = extract_derivative(T, ydual)
-myderivative(::Type{T}, ydual) where {T} = map(Fix1(extract_derivative, T), ydual)
+myvalue(::Type{T}, ydual::Dual{T}) where {T} = value(T, ydual)
+myvalue(::Type{T}, ydual) where {T} = map(Fix1(myvalue, T), ydual)
+
+function myvalue!(::Type{T}, y, ydual) where {T}
+    return map!(Fix1(myvalue, T), y, ydual)
+end
+
+myderivative(::Type{T}, ydual::Dual{T}) where {T} = extract_derivative(T, ydual)
+myderivative(::Type{T}, ydual) where {T} = map(Fix1(myderivative, T), ydual)
 
 function myderivative!(::Type{T}, dy, ydual) where {T}
-    return map!(Fix1(extract_derivative, T), dy, ydual)
+    return map!(Fix1(myderivative, T), dy, ydual)
+end
+
+mypartials(::Type{T}, ydual::Dual{T}) where {T} = Batch(partials(ydual).values)
+
+function mypartials(::Type{T}, ydual) where {T}
+    B = npartials(eltype(ydual))
+    elements = ntuple(Val(B)) do b
+        map(Fix2(partials, b), ydual)
+    end
+    return Batch(elements)
+end
+
+function mypartials!(::Type{T}, dy::Batch{B}, ydual) where {T,B}
+    for b in eachindex(dy.elements)
+        for i in eachindex(dy.elements[b], ydual)
+            dy.elements[b][i] = partials(ydual[i], b)
+        end
+    end
+    return dy
 end

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -11,6 +11,8 @@ end
 
 ADTypes.mode(::AutoForwardFromPrimitive) = ADTypes.ForwardMode()
 
+### Standard
+
 function prepare_pushforward(f, fromprim::AutoForwardFromPrimitive, x, dx)
     return prepare_pushforward(f, fromprim.backend, x, dx)
 end
@@ -43,6 +45,55 @@ function value_and_pushforward!(
     return value_and_pushforward!(f!, y, dy, fromprim.backend, x, dx, extras)
 end
 
+### Batched
+
+function prepare_pushforward_batched(
+    f, fromprim::AutoForwardFromPrimitive, x, dx::Batch{B}
+) where {B}
+    return prepare_pushforward_batched(f, fromprim.backend, x, dx)
+end
+
+function prepare_pushforward_batched(
+    f!, y, fromprim::AutoForwardFromPrimitive, x, dx::Batch{B}
+) where {B}
+    return prepare_pushforward_batched(f!, y, fromprim.backend, x, dx)
+end
+
+function pushforward_batched(
+    f, fromprim::AutoForwardFromPrimitive, x, dx::Batch{B}, extras::PushforwardExtras
+) where {B}
+    return pushforward_batched(f, fromprim.backend, x, dx, extras)
+end
+
+function pushforward_batched(
+    f!, y, fromprim::AutoForwardFromPrimitive, x, dx::Batch{B}, extras::PushforwardExtras
+) where {B}
+    return pushforward_batched(f!, y, fromprim.backend, x, dx, extras)
+end
+
+function pushforward_batched!(
+    f,
+    dy::Batch{B},
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    dx::Batch{B},
+    extras::PushforwardExtras,
+) where {B}
+    return pushforward_batched!(f, dy, fromprim.backend, x, dx, extras)
+end
+
+function pushforward_batched!(
+    f!,
+    y,
+    dy::Batch{B},
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    dx::Batch{B},
+    extras::PushforwardExtras,
+) where {B}
+    return pushforward_batched!(f!, y, dy, fromprim.backend, x, dx, extras)
+end
+
 ## Reverse
 
 struct AutoReverseFromPrimitive{B} <: FromPrimitive
@@ -50,6 +101,8 @@ struct AutoReverseFromPrimitive{B} <: FromPrimitive
 end
 
 ADTypes.mode(::AutoReverseFromPrimitive) = ADTypes.ReverseMode()
+
+### Standard
 
 function prepare_pullback(f, fromprim::AutoReverseFromPrimitive, x, dy)
     return prepare_pullback(f, fromprim.backend, x, dy)
@@ -81,4 +134,53 @@ function value_and_pullback!(
     f!, y, dx, fromprim::AutoReverseFromPrimitive, x, dy, extras::PullbackExtras
 )
     return value_and_pullback!(f!, y, dx, fromprim.backend, x, dy, extras)
+end
+
+### Batched
+
+function prepare_pullback_batched(
+    f, fromprim::AutoReverseFromPrimitive, x, dy::Batch{B}
+) where {B}
+    return prepare_pullback_batched(f, fromprim.backend, x, dy)
+end
+
+function prepare_pullback_batched(
+    f!, y, fromprim::AutoReverseFromPrimitive, x, dy::Batch{B}
+) where {B}
+    return prepare_pullback_batched(f!, y, fromprim.backend, x, dy)
+end
+
+function pullback_batched(
+    f, fromprim::AutoReverseFromPrimitive, x, dy::Batch{B}, extras::PullbackExtras
+) where {B}
+    return pullback_batched(f, fromprim.backend, x, dy, extras)
+end
+
+function pullback_batched(
+    f!, y, fromprim::AutoReverseFromPrimitive, x, dy::Batch{B}, extras::PullbackExtras
+) where {B}
+    return pullback_batched(f!, y, fromprim.backend, x, dy, extras)
+end
+
+function pullback_batched!(
+    f,
+    dx::Batch{B},
+    fromprim::AutoReverseFromPrimitive,
+    x,
+    dy::Batch{B},
+    extras::PullbackExtras,
+) where {B}
+    return pullback_batched!(f, dx, fromprim.backend, x, dy, extras)
+end
+
+function pullback_batched!(
+    f!,
+    y,
+    dx::Batch{B},
+    fromprim::AutoReverseFromPrimitive,
+    x,
+    dy::Batch{B},
+    extras::PullbackExtras,
+) where {B}
+    return pullback_batched!(f!, y, dx, fromprim.backend, x, dy, extras)
 end

--- a/DifferentiationInterface/test/Internals/batch.jl
+++ b/DifferentiationInterface/test/Internals/batch.jl
@@ -1,2 +1,0 @@
-import DifferentiationInterface as DI
-using Test

--- a/DifferentiationInterface/test/Single/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/test.jl
@@ -31,7 +31,7 @@ end
 test_differentiation(vcat(dense_backends, fromprimitive_backends); logging=LOGGING);
 
 test_differentiation(
-    vcat(dense_backends, fromprimitive_backends);
+    dense_backends;  # TODO: add fromprimitive
     correctness=false,
     type_stability=true,
     second_order=false,

--- a/DifferentiationInterface/test/Single/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/test.jl
@@ -4,7 +4,11 @@ using ForwardDiff: ForwardDiff
 using SparseConnectivityTracer, SparseMatrixColorings
 using Test
 
-dense_backends = [AutoForwardDiff(), AutoForwardDiff(; chunksize=2, tag=:hello)]
+dense_backends = [
+    AutoForwardDiff(),
+    AutoForwardDiff(; chunksize=2),
+    AutoForwardDiff(; chunksize=100, tag=:hello),
+]
 
 fromprimitive_backends = [AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5))]
 

--- a/DifferentiationInterface/test/Single/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/test.jl
@@ -4,11 +4,7 @@ using ForwardDiff: ForwardDiff
 using SparseConnectivityTracer, SparseMatrixColorings
 using Test
 
-dense_backends = [
-    AutoForwardDiff(),
-    AutoForwardDiff(; chunksize=2),
-    AutoForwardDiff(; chunksize=100, tag=:hello),
-]
+dense_backends = [AutoForwardDiff(), AutoForwardDiff(; chunksize=2, tag=:hello)]
 
 fromprimitive_backends = [AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5))]
 
@@ -31,7 +27,7 @@ end
 test_differentiation(vcat(dense_backends, fromprimitive_backends); logging=LOGGING);
 
 test_differentiation(
-    dense_backends;  # TODO: add fromprimitive
+    vcat(dense_backends, fromprimitive_backends);
     correctness=false,
     type_stability=true,
     second_order=false,

--- a/DifferentiationInterfaceTest/src/tests/type_stability.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability.jl
@@ -1,7 +1,3 @@
-function filt(@nospecialize f)
-    return f !== Base.print
-end
-
 ## Pushforward
 
 function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,1,:outofplace})
@@ -9,8 +5,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,1,:outofplace}
     extras = prepare_pushforward(f, ba, x, seed)
 
     if Bool(pushforward_performance(ba))
-        JET.@test_opt function_filter = filt value_and_pushforward(f, ba, x, seed, extras)
-        JET.@test_opt function_filter = filt pushforward(f, ba, x, seed, extras)
+        JET.@test_opt value_and_pushforward(f, ba, x, seed, extras)
+        JET.@test_opt pushforward(f, ba, x, seed, extras)
     end
     return nothing
 end
@@ -21,10 +17,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,1,:inplace})
     dy_in = mysimilar(y)
 
     if Bool(pushforward_performance(ba))
-        JET.@test_opt function_filter = filt value_and_pushforward!(
-            f, dy_in, ba, x, seed, extras
-        )
-        JET.@test_opt function_filter = filt pushforward!(f, dy_in, ba, x, seed, extras)
+        JET.@test_opt value_and_pushforward!(f, dy_in, ba, x, seed, extras)
+        JET.@test_opt pushforward!(f, dy_in, ba, x, seed, extras)
     end
     return nothing
 end
@@ -36,10 +30,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,2,:outofplace}
     y_in = mysimilar(y)
 
     if Bool(pushforward_performance(ba))
-        JET.@test_opt function_filter = filt value_and_pushforward(
-            f!, y_in, ba, x, seed, extras
-        )
-        JET.@test_opt function_filter = filt pushforward(f!, y_in, ba, x, seed, extras)
+        JET.@test_opt value_and_pushforward(f!, y_in, ba, x, seed, extras)
+        JET.@test_opt pushforward(f!, y_in, ba, x, seed, extras)
     end
     return nothing
 end
@@ -51,12 +43,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,2,:inplace})
     y_in, dy_in = mysimilar(y), mysimilar(y)
 
     if Bool(pushforward_performance(ba))
-        JET.@test_opt function_filter = filt value_and_pushforward!(
-            f!, y_in, dy_in, ba, x, seed, extras
-        )
-        JET.@test_opt function_filter = filt pushforward!(
-            f!, y_in, dy_in, ba, x, seed, extras
-        )
+        JET.@test_opt value_and_pushforward!(f!, y_in, dy_in, ba, x, seed, extras)
+        JET.@test_opt pushforward!(f!, y_in, dy_in, ba, x, seed, extras)
     end
     return nothing
 end
@@ -68,8 +56,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pullback,1,:outofplace})
     extras = prepare_pullback(f, ba, x, seed)
 
     if Bool(pullback_performance(ba))
-        JET.@test_opt function_filter = filt value_and_pullback(f, ba, x, seed, extras)
-        JET.@test_opt function_filter = filt pullback(f, ba, x, seed, extras)
+        JET.@test_opt value_and_pullback(f, ba, x, seed, extras)
+        JET.@test_opt pullback(f, ba, x, seed, extras)
     end
     return nothing
 end
@@ -80,10 +68,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pullback,1,:inplace})
     dx_in = mysimilar(x)
 
     if Bool(pullback_performance(ba))
-        JET.@test_opt function_filter = filt value_and_pullback!(
-            f, dx_in, ba, x, seed, extras
-        )
-        JET.@test_opt function_filter = filt pullback!(f, dx_in, ba, x, seed, extras)
+        JET.@test_opt value_and_pullback!(f, dx_in, ba, x, seed, extras)
+        JET.@test_opt pullback!(f, dx_in, ba, x, seed, extras)
     end
     return nothing
 end
@@ -95,10 +81,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pullback,2,:outofplace})
     y_in = mysimilar(y)
 
     if Bool(pullback_performance(ba))
-        JET.@test_opt function_filter = filt value_and_pullback(
-            f!, y_in, ba, x, seed, extras
-        )
-        JET.@test_opt function_filter = filt pullback(f!, y_in, ba, x, seed, extras)
+        JET.@test_opt value_and_pullback(f!, y_in, ba, x, seed, extras)
+        JET.@test_opt pullback(f!, y_in, ba, x, seed, extras)
     end
     return nothing
 end
@@ -110,10 +94,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pullback,2,:inplace})
     y_in, dx_in = mysimilar(y), mysimilar(x)
 
     if Bool(pullback_performance(ba))
-        JET.@test_opt function_filter = filt value_and_pullback!(
-            f!, y_in, dx_in, ba, x, seed, extras
-        )
-        JET.@test_opt function_filter = filt pullback!(f!, y_in, dx_in, ba, x, seed, extras)
+        JET.@test_opt value_and_pullback!(f!, y_in, dx_in, ba, x, seed, extras)
+        JET.@test_opt pullback!(f!, y_in, dx_in, ba, x, seed, extras)
     end
     return nothing
 end
@@ -124,8 +106,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:derivative,1,:outofplace})
     @compat (; f, x, y) = deepcopy(scen)
     extras = prepare_derivative(f, ba, x)
 
-    JET.@test_opt function_filter = filt value_and_derivative(f, ba, x, extras)
-    JET.@test_opt function_filter = filt derivative(f, ba, x, extras)
+    JET.@test_opt value_and_derivative(f, ba, x, extras)
+    JET.@test_opt derivative(f, ba, x, extras)
     return nothing
 end
 
@@ -134,8 +116,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:derivative,1,:inplace})
     extras = prepare_derivative(f, ba, x)
     der_in = mysimilar(y)
 
-    JET.@test_opt function_filter = filt value_and_derivative!(f, der_in, ba, x, extras)
-    JET.@test_opt function_filter = filt derivative!(f, der_in, ba, x, extras)
+    JET.@test_opt value_and_derivative!(f, der_in, ba, x, extras)
+    JET.@test_opt derivative!(f, der_in, ba, x, extras)
     return nothing
 end
 
@@ -145,8 +127,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:derivative,2,:outofplace})
     extras = prepare_derivative(f!, mysimilar(y), ba, x)
     y_in = mysimilar(y)
 
-    JET.@test_opt function_filter = filt value_and_derivative(f!, y_in, ba, x, extras)
-    JET.@test_opt function_filter = filt derivative(f!, y_in, ba, x, extras)
+    JET.@test_opt value_and_derivative(f!, y_in, ba, x, extras)
+    JET.@test_opt derivative(f!, y_in, ba, x, extras)
     return nothing
 end
 
@@ -156,10 +138,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:derivative,2,:inplace})
     extras = prepare_derivative(f!, mysimilar(y), ba, x)
     y_in, der_in = mysimilar(y), mysimilar(y)
 
-    JET.@test_opt function_filter = filt value_and_derivative!(
-        f!, y_in, der_in, ba, x, extras
-    )
-    JET.@test_opt function_filter = filt derivative!(f!, y_in, der_in, ba, x, extras)
+    JET.@test_opt value_and_derivative!(f!, y_in, der_in, ba, x, extras)
+    JET.@test_opt derivative!(f!, y_in, der_in, ba, x, extras)
     return nothing
 end
 
@@ -169,8 +149,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:gradient,1,:outofplace})
     @compat (; f, x) = deepcopy(scen)
     extras = prepare_gradient(f, ba, x)
 
-    JET.@test_opt function_filter = filt value_and_gradient(f, ba, x, extras)
-    JET.@test_opt function_filter = filt gradient(f, ba, x, extras)
+    JET.@test_opt value_and_gradient(f, ba, x, extras)
+    JET.@test_opt gradient(f, ba, x, extras)
     return nothing
 end
 
@@ -179,8 +159,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:gradient,1,:inplace})
     extras = prepare_gradient(f, ba, x)
     grad_in = mysimilar(x)
 
-    JET.@test_opt function_filter = filt value_and_gradient!(f, grad_in, ba, x, extras)
-    JET.@test_opt function_filter = filt gradient!(f, grad_in, ba, x, extras)
+    JET.@test_opt value_and_gradient!(f, grad_in, ba, x, extras)
+    JET.@test_opt gradient!(f, grad_in, ba, x, extras)
     return nothing
 end
 
@@ -190,8 +170,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:jacobian,1,:outofplace})
     @compat (; f, x, y) = deepcopy(scen)
     extras = prepare_jacobian(f, ba, x)
 
-    JET.@test_opt function_filter = filt value_and_jacobian(f, ba, x, extras)
-    JET.@test_opt function_filter = filt jacobian(f, ba, x, extras)
+    JET.@test_opt value_and_jacobian(f, ba, x, extras)
+    JET.@test_opt jacobian(f, ba, x, extras)
     return nothing
 end
 
@@ -200,8 +180,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:jacobian,1,:inplace})
     extras = prepare_jacobian(f, ba, x)
     jac_in = mysimilar(jacobian(f, ba, x))
 
-    JET.@test_opt function_filter = filt value_and_jacobian!(f, jac_in, ba, x, extras)
-    JET.@test_opt function_filter = filt jacobian!(f, jac_in, ba, x, extras)
+    JET.@test_opt value_and_jacobian!(f, jac_in, ba, x, extras)
+    JET.@test_opt jacobian!(f, jac_in, ba, x, extras)
     return nothing
 end
 
@@ -211,8 +191,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:jacobian,2,:outofplace})
     extras = prepare_jacobian(f!, mysimilar(y), ba, x)
     y_in = mysimilar(y)
 
-    JET.@test_opt function_filter = filt value_and_jacobian(f!, y_in, ba, x, extras)
-    JET.@test_opt function_filter = filt jacobian(f!, y_in, ba, x, extras)
+    JET.@test_opt value_and_jacobian(f!, y_in, ba, x, extras)
+    JET.@test_opt jacobian(f!, y_in, ba, x, extras)
     return nothing
 end
 
@@ -222,10 +202,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:jacobian,2,:inplace})
     extras = prepare_jacobian(f!, mysimilar(y), ba, x)
     y_in, jac_in = mysimilar(y), mysimilar(jacobian(f!, mysimilar(y), ba, x))
 
-    JET.@test_opt function_filter = filt value_and_jacobian!(
-        f!, y_in, jac_in, ba, x, extras
-    )
-    JET.@test_opt function_filter = filt jacobian!(f!, y_in, jac_in, ba, x, extras)
+    JET.@test_opt value_and_jacobian!(f!, y_in, jac_in, ba, x, extras)
+    JET.@test_opt jacobian!(f!, y_in, jac_in, ba, x, extras)
     return nothing
 end
 
@@ -235,10 +213,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:second_derivative,1,:outof
     @compat (; f, x, y) = deepcopy(scen)
     extras = prepare_second_derivative(f, ba, x)
 
-    JET.@test_opt function_filter = filt second_derivative(f, ba, x, extras)
-    JET.@test_opt function_filter = filt value_derivative_and_second_derivative(
-        f, ba, x, extras
-    )
+    JET.@test_opt second_derivative(f, ba, x, extras)
+    JET.@test_opt value_derivative_and_second_derivative(f, ba, x, extras)
     return nothing
 end
 
@@ -248,8 +224,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:second_derivative,1,:inpla
     der1_in = mysimilar(y)
     der2_in = mysimilar(y)
 
-    JET.@test_opt function_filter = filt second_derivative!(f, der2_in, ba, x, extras)
-    JET.@test_opt function_filter = filt value_derivative_and_second_derivative!(
+    JET.@test_opt second_derivative!(f, der2_in, ba, x, extras)
+    JET.@test_opt value_derivative_and_second_derivative!(
         f, der1_in, der2_in, ba, x, extras
     )
     return nothing
@@ -261,7 +237,7 @@ function test_jet(ba::AbstractADType, scen::Scenario{:hvp,1,:outofplace})
     @compat (; f, x, seed) = deepcopy(scen)
     extras = prepare_hvp(f, ba, x, seed)
 
-    JET.@test_opt function_filter = filt hvp(f, ba, x, seed, extras)
+    JET.@test_opt hvp(f, ba, x, seed, extras)
     return nothing
 end
 
@@ -270,7 +246,7 @@ function test_jet(ba::AbstractADType, scen::Scenario{:hvp,1,:inplace})
     extras = prepare_hvp(f, ba, x, seed)
     p_in = mysimilar(x)
 
-    JET.@test_opt function_filter = filt hvp!(f, p_in, ba, x, seed, extras)
+    JET.@test_opt hvp!(f, p_in, ba, x, seed, extras)
     return nothing
 end
 
@@ -280,8 +256,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:hessian,1,:outofplace})
     @compat (; f, x, y) = deepcopy(scen)
     extras = prepare_hessian(f, ba, x)
 
-    JET.@test_opt function_filter = filt hessian(f, ba, x, extras)
-    JET.@test_opt function_filter = filt value_gradient_and_hessian(f, ba, x, extras)
+    JET.@test_opt hessian(f, ba, x, extras)
+    JET.@test_opt value_gradient_and_hessian(f, ba, x, extras)
     return nothing
 end
 
@@ -291,9 +267,7 @@ function test_jet(ba::AbstractADType, scen::Scenario{:hessian,1,:inplace})
     grad_in = mysimilar(x)
     hess_in = mysimilar(hessian(f, ba, x))
 
-    JET.@test_opt function_filter = filt hessian!(f, hess_in, ba, x, extras)
-    JET.@test_opt function_filter = filt value_gradient_and_hessian!(
-        f, grad_in, hess_in, ba, x, extras
-    )
+    JET.@test_opt hessian!(f, hess_in, ba, x, extras)
+    JET.@test_opt value_gradient_and_hessian!(f, grad_in, hess_in, ba, x, extras)
     return nothing
 end


### PR DESCRIPTION
**DI extensions**

- Implement batched pushforward in ForwardDiff by extracting all the partials from a `Dual` number, and converting an array-of-tuples into a tuple-of-arrays
- Fix ForwardDiff chunk choice so that it never exceeds `length(x)`

**DI source**

- Add batched operators to `FromPrimitive` so that they better reflect the underlying backend

**DIT source**

- Remove function filter in type stability check