### PR TITLE
Test batched operators

### DIFF
--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -56,13 +56,16 @@ include("utils/exceptions.jl")
 include("utils/maybe.jl")
 
 include("first_order/pushforward.jl")
+include("first_order/pushforward_batched.jl")
 include("first_order/pullback.jl")
+include("first_order/pullback_batched.jl")
 include("first_order/derivative.jl")
 include("first_order/gradient.jl")
 include("first_order/jacobian.jl")
 
 include("second_order/second_derivative.jl")
 include("second_order/hvp.jl")
+include("second_order/hvp_batched.jl")
 include("second_order/hessian.jl")
 
 include("sparse/fallbacks.jl")

--- a/DifferentiationInterface/src/first_order/derivative.jl
+++ b/DifferentiationInterface/src/first_order/derivative.jl
@@ -72,6 +72,8 @@ end
 
 ## One argument
 
+### Without extras
+
 function value_and_derivative(f::F, backend::AbstractADType, x) where {F}
     return value_and_derivative(f, backend, x, prepare_derivative(f, backend, x))
 end
@@ -87,6 +89,8 @@ end
 function derivative!(f::F, der, backend::AbstractADType, x) where {F}
     return derivative!(f, der, backend, x, prepare_derivative(f, backend, x))
 end
+
+### With extras
 
 function value_and_derivative(
     f::F, backend::AbstractADType, x, extras::PushforwardDerivativeExtras
@@ -114,6 +118,8 @@ end
 
 ## Two arguments
 
+### Without extras
+
 function value_and_derivative(f!::F, y, backend::AbstractADType, x) where {F}
     return value_and_derivative(f!, y, backend, x, prepare_derivative(f!, y, backend, x))
 end
@@ -131,6 +137,8 @@ end
 function derivative!(f!::F, y, der, backend::AbstractADType, x) where {F}
     return derivative!(f!, y, der, backend, x, prepare_derivative(f!, y, backend, x))
 end
+
+### With extras
 
 function value_and_derivative(
     f!::F, y, backend::AbstractADType, x, extras::PushforwardDerivativeExtras

--- a/DifferentiationInterface/src/first_order/gradient.jl
+++ b/DifferentiationInterface/src/first_order/gradient.jl
@@ -62,6 +62,8 @@ end
 
 ## One argument
 
+### Without extras
+
 function value_and_gradient(f::F, backend::AbstractADType, x) where {F}
     return value_and_gradient(f, backend, x, prepare_gradient(f, backend, x))
 end
@@ -77,6 +79,8 @@ end
 function gradient!(f::F, der, backend::AbstractADType, x) where {F}
     return gradient!(f, der, backend, x, prepare_gradient(f, backend, x))
 end
+
+### With extras
 
 function value_and_gradient(
     f::F, backend::AbstractADType, x, extras::PullbackGradientExtras

--- a/DifferentiationInterface/src/first_order/jacobian.jl
+++ b/DifferentiationInterface/src/first_order/jacobian.jl
@@ -104,6 +104,8 @@ end
 
 ## One argument
 
+### Without extras
+
 function jacobian(f::F, backend::AbstractADType, x) where {F}
     return jacobian(f, backend, x, prepare_jacobian(f, backend, x))
 end
@@ -119,6 +121,8 @@ end
 function value_and_jacobian!(f::F, jac, backend::AbstractADType, x) where {F}
     return value_and_jacobian!(f, jac, backend, x, prepare_jacobian(f, backend, x))
 end
+
+### With extras
 
 function jacobian(f::F, backend::AbstractADType, x, extras::JacobianExtras) where {F}
     return jacobian_aux((f,), backend, x, extras)
@@ -142,6 +146,8 @@ end
 
 ## Two arguments
 
+### Without extras
+
 function jacobian(f!::F, y, backend::AbstractADType, x) where {F}
     return jacobian(f!, y, backend, x, prepare_jacobian(f!, y, backend, x))
 end
@@ -157,6 +163,8 @@ end
 function value_and_jacobian!(f!::F, y, jac, backend::AbstractADType, x) where {F}
     return value_and_jacobian!(f!, y, jac, backend, x, prepare_jacobian(f!, y, backend, x))
 end
+
+### With extras
 
 function jacobian(f!::F, y, backend::AbstractADType, x, extras::JacobianExtras) where {F}
     return jacobian_aux((f!, y), backend, x, extras)

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -12,8 +12,6 @@ Create an `extras` object that can be given to [`pullback`](@ref) and its varian
 """
 function prepare_pullback end
 
-function prepare_pullback_batched end
-
 """
     prepare_pullback_same_point(f,     backend, x, dy) -> extras_same
     prepare_pullback_same_point(f!, y, backend, x, dy) -> extras_same
@@ -25,8 +23,6 @@ Create an `extras_same` object that can be given to [`pullback`](@ref) and its v
     In the two-argument case, `y` is mutated by `f!` during preparation.
 """
 function prepare_pullback_same_point end
-
-function prepare_pullback_batched_same_point end
 
 """
     value_and_pullback(f,     backend, x, dy, [extras]) -> (y, dx)
@@ -55,8 +51,6 @@ Compute the pullback of the function `f` at point `x` with seed `dy`.
 """
 function pullback end
 
-function pullback_batched end
-
 """
     pullback!(f,     dx, backend, x, dy, [extras]) -> dx
     pullback!(f!, y, dx, backend, x, dy, [extras]) -> dx
@@ -64,8 +58,6 @@ function pullback_batched end
 Compute the pullback of the function `f` at point `x` with seed `dy`, overwriting `dx`.
 """
 function pullback! end
-
-function pullback_batched! end
 
 ## Preparation
 
@@ -84,7 +76,7 @@ struct PushforwardPullbackExtras{E} <: PullbackExtras
     pushforward_extras::E
 end
 
-## Standard
+## Different point
 
 function prepare_pullback(f::F, backend::AbstractADType, x, dy) where {F}
     return prepare_pullback_aux(f, backend, x, dy, pullback_performance(backend))
@@ -114,7 +106,7 @@ function prepare_pullback_aux(f!, y, backend, x, dy, ::PullbackFast)
     throw(MissingBackendError(backend))
 end
 
-### Standard, same point
+### Same point
 
 function prepare_pullback_same_point(
     f::F, backend::AbstractADType, x, dy, extras::PullbackExtras
@@ -138,47 +130,9 @@ function prepare_pullback_same_point(f!::F, y, backend::AbstractADType, x, dy) w
     return prepare_pullback_same_point(f!, y, backend, x, dy, extras)
 end
 
-### Batched
-
-function prepare_pullback_batched(f::F, backend::AbstractADType, x, dy::Batch) where {F}
-    return prepare_pullback(f, backend, x, first(dy.elements))
-end
-
-function prepare_pullback_batched(f!::F, y, backend::AbstractADType, x, dy::Batch) where {F}
-    return prepare_pullback(f!, y, backend, x, first(dy.elements))
-end
-
-### Batched, same point
-
-function prepare_pullback_batched_same_point(
-    f::F, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
-) where {F}
-    return prepare_pullback_same_point(f, backend, x, first(dy.elements), extras)
-end
-
-function prepare_pullback_batched_same_point(
-    f!::F, y, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
-) where {F}
-    return prepare_pullback_same_point(f!, y, backend, x, first(dy.elements), extras)
-end
-
-function prepare_pullback_batched_same_point(
-    f::F, backend::AbstractADType, x, dy::Batch
-) where {F}
-    extras = prepare_pullback_batched(f, backend, x, dy)
-    return prepare_pullback_batched_same_point(f, backend, x, dy, extras)
-end
-
-function prepare_pullback_batched_same_point(
-    f!::F, y, backend::AbstractADType, x, dy::Batch
-) where {F}
-    extras = prepare_pullback_batched(f!, y, backend, x, dy)
-    return prepare_pullback_batched_same_point(f!, y, backend, x, dy, extras)
-end
-
 ## One argument
 
-### Standard
+### Without extras
 
 function value_and_pullback(f::F, backend::AbstractADType, x, dy) where {F}
     return value_and_pullback(f, backend, x, dy, prepare_pullback(f, backend, x, dy))
@@ -195,6 +149,8 @@ end
 function pullback!(f::F, dx, backend::AbstractADType, x, dy) where {F}
     return pullback!(f, dx, backend, x, dy, prepare_pullback(f, backend, x, dy))
 end
+
+### With extras
 
 function value_and_pullback(
     f::F, backend, x, dy, extras::PushforwardPullbackExtras
@@ -234,29 +190,9 @@ function pullback!(
     return value_and_pullback!(f, dx, backend, x, dy, extras)[2]
 end
 
-### Batched
-
-function pullback_batched(
-    f::F, backend::AbstractADType, x, dy::Batch{B}, extras::PullbackExtras
-) where {F,B}
-    dx_elements = ntuple(Val(B)) do b
-        pullback(f, backend, x, dy.elements[b], extras)
-    end
-    return Batch(dx_elements)
-end
-
-function pullback_batched!(
-    f::F, dx::Batch, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
-) where {F}
-    for b in eachindex(dx.elements, dy.elements)
-        pullback!(f, dx.elements[b], backend, x, dy.elements[b], extras)
-    end
-    return dx
-end
-
 ## Two arguments
 
-### Standard
+### Without extras
 
 function value_and_pullback(f!::F, y, backend::AbstractADType, x, dy) where {F}
     return value_and_pullback(
@@ -277,6 +213,8 @@ end
 function pullback!(f!::F, y, dx, backend::AbstractADType, x, dy) where {F}
     return pullback!(f!, y, dx, backend, x, dy, prepare_pullback(f!, y, backend, x, dy))
 end
+
+### With extras
 
 function value_and_pullback(
     f!::F, y, backend, x, dy, extras::PushforwardPullbackExtras
@@ -310,24 +248,4 @@ function pullback!(
     f!::F, y, dx, backend::AbstractADType, x, dy, extras::PullbackExtras
 ) where {F}
     return value_and_pullback!(f!, y, dx, backend, x, dy, extras)[2]
-end
-
-### Batched
-
-function pullback_batched(
-    f!::F, y, backend::AbstractADType, x, dy::Batch{B}, extras::PullbackExtras
-) where {F,B}
-    dx_elements = ntuple(Val(B)) do b
-        pullback(f!, y, backend, x, dy.elements[b], extras)
-    end
-    return Batch(dx_elements)
-end
-
-function pullback_batched!(
-    f!::F, y, dx::Batch, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
-) where {F}
-    for b in eachindex(dx.elements, dy.elements)
-        pullback!(f!, y, dx.elements[b], backend, x, dy.elements[b], extras)
-    end
-    return dx
 end

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -162,6 +162,20 @@ function prepare_pullback_batched_same_point(
     return prepare_pullback_same_point(f!, y, backend, x, first(dy.elements), extras)
 end
 
+function prepare_pullback_batched_same_point(
+    f::F, backend::AbstractADType, x, dy::Batch
+) where {F}
+    extras = prepare_pullback_batched(f, backend, x, dy)
+    return prepare_pullback_batched_same_point(f, backend, x, dy, extras)
+end
+
+function prepare_pullback_batched_same_point(
+    f!::F, y, backend::AbstractADType, x, dy::Batch
+) where {F}
+    extras = prepare_pullback_batched(f!, y, backend, x, dy)
+    return prepare_pullback_batched_same_point(f!, y, backend, x, dy, extras)
+end
+
 ## One argument
 
 ### Standard

--- a/DifferentiationInterface/src/first_order/pullback_batched.jl
+++ b/DifferentiationInterface/src/first_order/pullback_batched.jl
@@ -145,9 +145,7 @@ end
 function pullback_batched(
     f!::F, y, backend::AbstractADType, x, dy::Batch{B}, extras::PullbackExtras
 ) where {F,B}
-    dx_elements = ntuple(Val(B)) do b
-        pullback(f!, y, backend, x, dy.elements[b], extras)
-    end
+    dx_elements = pullback.(Ref(f!), Ref(y), Ref(backend), Ref(x), dy.elements, Ref(extras))
     return Batch(dx_elements)
 end
 

--- a/DifferentiationInterface/src/first_order/pullback_batched.jl
+++ b/DifferentiationInterface/src/first_order/pullback_batched.jl
@@ -1,0 +1,177 @@
+## Docstrings
+
+function prepare_pullback_batched end
+function prepare_pullback_batched_same_point end
+
+function value_and_pullback_batched end
+function value_and_pullback_batched! end
+function pullback_batched end
+function pullback_batched! end
+
+## Preparation
+
+### Different point
+
+function prepare_pullback_batched(f::F, backend::AbstractADType, x, dy::Batch) where {F}
+    return prepare_pullback(f, backend, x, first(dy.elements))
+end
+
+function prepare_pullback_batched(f!::F, y, backend::AbstractADType, x, dy::Batch) where {F}
+    return prepare_pullback(f!, y, backend, x, first(dy.elements))
+end
+
+### Same point
+
+function prepare_pullback_batched_same_point(
+    f::F, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
+) where {F}
+    return prepare_pullback_same_point(f, backend, x, first(dy.elements), extras)
+end
+
+function prepare_pullback_batched_same_point(
+    f!::F, y, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
+) where {F}
+    return prepare_pullback_same_point(f!, y, backend, x, first(dy.elements), extras)
+end
+
+function prepare_pullback_batched_same_point(
+    f::F, backend::AbstractADType, x, dy::Batch
+) where {F}
+    extras = prepare_pullback_batched(f, backend, x, dy)
+    return prepare_pullback_batched_same_point(f, backend, x, dy, extras)
+end
+
+function prepare_pullback_batched_same_point(
+    f!::F, y, backend::AbstractADType, x, dy::Batch
+) where {F}
+    extras = prepare_pullback_batched(f!, y, backend, x, dy)
+    return prepare_pullback_batched_same_point(f!, y, backend, x, dy, extras)
+end
+
+## One argument
+
+### Without extras
+
+function value_and_pullback_batched(f::F, backend::AbstractADType, x, dy::Batch) where {F}
+    return value_and_pullback_batched(
+        f, backend, x, dy, prepare_pullback_batched(f, backend, x, dy)
+    )
+end
+
+function value_and_pullback_batched!(
+    f::F, dx, backend::AbstractADType, x, dy::Batch
+) where {F}
+    return value_and_pullback_batched!(
+        f, dx, backend, x, dy, prepare_pullback_batched(f, backend, x, dy)
+    )
+end
+
+function pullback_batched(f::F, backend::AbstractADType, x, dy::Batch) where {F}
+    return pullback_batched(f, backend, x, dy, prepare_pullback_batched(f, backend, x, dy))
+end
+
+function pullback_batched!(f::F, dx, backend::AbstractADType, x, dy::Batch) where {F}
+    return pullback_batched!(
+        f, dx, backend, x, dy, prepare_pullback_batched(f, backend, x, dy)
+    )
+end
+
+### With extras
+
+function pullback_batched(
+    f::F, backend::AbstractADType, x, dy::Batch{B}, extras::PullbackExtras
+) where {F,B}
+    dx_elements = ntuple(Val(B)) do b
+        pullback(f, backend, x, dy.elements[b], extras)
+    end
+    return Batch(dx_elements)
+end
+
+function pullback_batched!(
+    f::F, dx::Batch, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
+) where {F}
+    for b in eachindex(dx.elements, dy.elements)
+        pullback!(f, dx.elements[b], backend, x, dy.elements[b], extras)
+    end
+    return dx
+end
+
+function value_and_pullback_batched(
+    f::F, backend::AbstractADType, x, dy::Batch{B}, extras::PullbackExtras
+) where {F,B}
+    return f(x), pullback_batched(f, backend, x, dy, extras)
+end
+
+function value_and_pullback_batched!(
+    f::F, dx::Batch, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
+) where {F}
+    return f(x), pullback_batched!(f, dx, backend, x, dy, extras)
+end
+
+## Two arguments
+
+### Without extras
+
+function value_and_pullback_batched(
+    f!::F, y, backend::AbstractADType, x, dy::Batch
+) where {F}
+    return value_and_pullback_batched(
+        f!, y, backend, x, dy, prepare_pullback_batched(f!, y, backend, x, dy)
+    )
+end
+
+function value_and_pullback_batched!(
+    f!::F, y, dx, backend::AbstractADType, x, dy::Batch
+) where {F}
+    return value_and_pullback_batched!(
+        f!, y, dx, backend, x, dy, prepare_pullback_batched(f!, y, backend, x, dy)
+    )
+end
+
+function pullback_batched(f!::F, y, backend::AbstractADType, x, dy::Batch) where {F}
+    return pullback_batched(
+        f!, y, backend, x, dy, prepare_pullback_batched(f!, y, backend, x, dy)
+    )
+end
+
+function pullback_batched!(f!::F, y, dx, backend::AbstractADType, x, dy::Batch) where {F}
+    return pullback_batched!(
+        f!, y, dx, backend, x, dy, prepare_pullback_batched(f!, y, backend, x, dy)
+    )
+end
+
+### With extras
+
+function pullback_batched(
+    f!::F, y, backend::AbstractADType, x, dy::Batch{B}, extras::PullbackExtras
+) where {F,B}
+    dx_elements = ntuple(Val(B)) do b
+        pullback(f!, y, backend, x, dy.elements[b], extras)
+    end
+    return Batch(dx_elements)
+end
+
+function pullback_batched!(
+    f!::F, y, dx::Batch, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
+) where {F}
+    for b in eachindex(dx.elements, dy.elements)
+        pullback!(f!, y, dx.elements[b], backend, x, dy.elements[b], extras)
+    end
+    return dx
+end
+
+function value_and_pullback_batched(
+    f!::F, y, backend::AbstractADType, x, dy::Batch{B}, extras::PullbackExtras
+) where {F,B}
+    dx = pullback_batched(f!, y, backend, x, dy, extras)
+    f!(y, x)
+    return y, dx
+end
+
+function value_and_pullback_batched!(
+    f!::F, y, dx::Batch, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
+) where {F}
+    pullback_batched!(f!, y, dx, backend, x, dy, extras)
+    f!(y, x)
+    return y, dx
+end

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -26,7 +26,7 @@ Create an `extras_same` object that can be given to [`pushforward`](@ref) and it
 """
 function prepare_pushforward_same_point end
 
-function prepare_pushforward_same_point_batched end
+function prepare_pushforward_batched_same_point end
 
 """
     value_and_pushforward(f,     backend, x, dx, [extras]) -> (y, dy)
@@ -149,6 +149,20 @@ function prepare_pushforward_batched(
     f!::F, y, backend::AbstractADType, x, dx::Batch
 ) where {F}
     return prepare_pushforward(f!, y, backend, x, first(dx.elements))
+end
+
+function prepare_pushforward_batched_same_point(
+    f::F, backend::AbstractADType, x, dx::Batch
+) where {F}
+    extras = prepare_pushforward_batched(f, backend, x, dx)
+    return prepare_pushforward_batched_same_point(f, backend, x, dx, extras)
+end
+
+function prepare_pushforward_batched_same_point(
+    f!::F, y, backend::AbstractADType, x, dx::Batch
+) where {F}
+    extras = prepare_pushforward_batched(f!, y, backend, x, dx)
+    return prepare_pushforward_batched_same_point(f!, y, backend, x, dx, extras)
 end
 
 ### Batched, same point

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -12,8 +12,6 @@ Create an `extras` object that can be given to [`pushforward`](@ref) and its var
 """
 function prepare_pushforward end
 
-function prepare_pushforward_batched end
-
 """
     prepare_pushforward_same_point(f,     backend, x, dx) -> extras_same
     prepare_pushforward_same_point(f!, y, backend, x, dx) -> extras_same
@@ -25,8 +23,6 @@ Create an `extras_same` object that can be given to [`pushforward`](@ref) and it
     In the two-argument case, `y` is mutated by `f!` during preparation.
 """
 function prepare_pushforward_same_point end
-
-function prepare_pushforward_batched_same_point end
 
 """
     value_and_pushforward(f,     backend, x, dx, [extras]) -> (y, dy)
@@ -55,8 +51,6 @@ Compute the pushforward of the function `f` at point `x` with seed `dx`.
 """
 function pushforward end
 
-function pushforward_batched end
-
 """
     pushforward!(f,     dy, backend, x, dx, [extras]) -> dy
     pushforward!(f!, y, dy, backend, x, dx, [extras]) -> dy
@@ -64,8 +58,6 @@ function pushforward_batched end
 Compute the pushforward of the function `f` at point `x` with seed `dx`, overwriting `dy`.
 """
 function pushforward! end
-
-function pushforward_batched! end
 
 ## Preparation
 
@@ -84,7 +76,7 @@ struct PullbackPushforwardExtras{E} <: PushforwardExtras
     pullback_extras::E
 end
 
-### Standard
+### Different point
 
 function prepare_pushforward(f::F, backend::AbstractADType, x, dx) where {F}
     return prepare_pushforward_aux(f, backend, x, dx, pushforward_performance(backend))
@@ -115,7 +107,7 @@ function prepare_pushforward_aux(f!, y, backend, x, dy, ::PushforwardFast)
     throw(MissingBackendError(backend))
 end
 
-### Standard, same point
+### Same point
 
 function prepare_pushforward_same_point(
     f::F, backend::AbstractADType, x, dx, extras::PushforwardExtras
@@ -139,49 +131,9 @@ function prepare_pushforward_same_point(f!::F, y, backend::AbstractADType, x, dx
     return prepare_pushforward_same_point(f!, y, backend, x, dx, extras)
 end
 
-### Batched
-
-function prepare_pushforward_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
-    return prepare_pushforward(f, backend, x, first(dx.elements))
-end
-
-function prepare_pushforward_batched(
-    f!::F, y, backend::AbstractADType, x, dx::Batch
-) where {F}
-    return prepare_pushforward(f!, y, backend, x, first(dx.elements))
-end
-
-function prepare_pushforward_batched_same_point(
-    f::F, backend::AbstractADType, x, dx::Batch
-) where {F}
-    extras = prepare_pushforward_batched(f, backend, x, dx)
-    return prepare_pushforward_batched_same_point(f, backend, x, dx, extras)
-end
-
-function prepare_pushforward_batched_same_point(
-    f!::F, y, backend::AbstractADType, x, dx::Batch
-) where {F}
-    extras = prepare_pushforward_batched(f!, y, backend, x, dx)
-    return prepare_pushforward_batched_same_point(f!, y, backend, x, dx, extras)
-end
-
-### Batched, same point
-
-function prepare_pushforward_batched_same_point(
-    f::F, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
-) where {F}
-    return prepare_pushforward_same_point(f, backend, x, first(dx.elements), extras)
-end
-
-function prepare_pushforward_batched_same_point(
-    f!::F, y, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
-) where {F}
-    return prepare_pushforward_same_point(f!, y, backend, x, first(dx.elements), extras)
-end
-
 ## One argument
 
-### Standard
+### Without extras
 
 function value_and_pushforward(f::F, backend::AbstractADType, x, dx) where {F}
     return value_and_pushforward(f, backend, x, dx, prepare_pushforward(f, backend, x, dx))
@@ -200,6 +152,8 @@ end
 function pushforward!(f::F, dy, backend::AbstractADType, x, dx) where {F}
     return pushforward!(f, dy, backend, x, dx, prepare_pushforward(f, backend, x, dx))
 end
+
+### With extras
 
 function value_and_pushforward(
     f::F, backend, x, dx, extras::PullbackPushforwardExtras
@@ -241,29 +195,9 @@ function pushforward!(
     return value_and_pushforward!(f, dy, backend, x, dx, extras)[2]
 end
 
-### Batched
-
-function pushforward_batched(
-    f::F, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
-) where {F,B}
-    dy_elements = ntuple(Val(B)) do b
-        pushforward(f, backend, x, dx.elements[b], extras)
-    end
-    return Batch(dy_elements)
-end
-
-function pushforward_batched!(
-    f::F, dy::Batch, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
-) where {F}
-    for b in eachindex(dy.elements, dx.elements)
-        pushforward!(f, dy.elements[b], backend, x, dx.elements[b], extras)
-    end
-    return dy
-end
-
 ## Two arguments
 
-### Standard
+### Without extras
 
 function value_and_pushforward(f!::F, y, backend::AbstractADType, x, dx) where {F}
     return value_and_pushforward(
@@ -286,6 +220,8 @@ function pushforward!(f!::F, y, dy, backend::AbstractADType, x, dx) where {F}
         f!, y, dy, backend, x, dx, prepare_pushforward(f!, y, backend, x, dx)
     )
 end
+
+### With extras
 
 function value_and_pushforward(
     f!::F, y, backend, x, dx, extras::PullbackPushforwardExtras
@@ -321,24 +257,4 @@ function pushforward!(
     f!::F, y, dy, backend::AbstractADType, x, dx, extras::PushforwardExtras
 ) where {F}
     return value_and_pushforward!(f!, y, dy, backend, x, dx, extras)[2]
-end
-
-### Batched
-
-function pushforward_batched(
-    f!::F, y, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
-) where {F,B}
-    dy_elements = ntuple(Val(B)) do b
-        pushforward(f!, y, backend, x, dx.elements[b], extras)
-    end
-    return Batch(dy_elements)
-end
-
-function pushforward_batched!(
-    f!::F, y, dy::Batch, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
-) where {F}
-    for b in eachindex(dy.elements, dx.elements)
-        pushforward!(f!, y, dy.elements[b], backend, x, dx.elements[b], extras)
-    end
-    return dy
 end

--- a/DifferentiationInterface/src/first_order/pushforward_batched.jl
+++ b/DifferentiationInterface/src/first_order/pushforward_batched.jl
@@ -1,0 +1,180 @@
+## Docstrings
+
+function prepare_pushforward_batched end
+function prepare_pushforward_batched_same_point end
+
+function value_and_pushforward_batched end
+function value_and_pushforward_batched! end
+function pushforward_batched end
+function pushforward_batched! end
+
+## Preparation
+
+### Different point
+
+function prepare_pushforward_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
+    return prepare_pushforward(f, backend, x, first(dx.elements))
+end
+
+function prepare_pushforward_batched(
+    f!::F, y, backend::AbstractADType, x, dx::Batch
+) where {F}
+    return prepare_pushforward(f!, y, backend, x, first(dx.elements))
+end
+
+### Same point
+
+function prepare_pushforward_batched_same_point(
+    f::F, backend::AbstractADType, x, dx::Batch
+) where {F}
+    extras = prepare_pushforward_batched(f, backend, x, dx)
+    return prepare_pushforward_batched_same_point(f, backend, x, dx, extras)
+end
+
+function prepare_pushforward_batched_same_point(
+    f!::F, y, backend::AbstractADType, x, dx::Batch
+) where {F}
+    extras = prepare_pushforward_batched(f!, y, backend, x, dx)
+    return prepare_pushforward_batched_same_point(f!, y, backend, x, dx, extras)
+end
+
+function prepare_pushforward_batched_same_point(
+    f::F, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
+    return prepare_pushforward_same_point(f, backend, x, first(dx.elements), extras)
+end
+
+function prepare_pushforward_batched_same_point(
+    f!::F, y, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
+    return prepare_pushforward_same_point(f!, y, backend, x, first(dx.elements), extras)
+end
+
+## One argument
+
+### Without extras
+
+function value_and_pushforward_batched(
+    f::F, backend::AbstractADType, x, dx::Batch
+) where {F}
+    return value_and_pushforward_batched(
+        f, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
+    )
+end
+
+function value_and_pushforward_batched!(
+    f::F, dy, backend::AbstractADType, x, dx::Batch
+) where {F}
+    return value_and_pushforward_batched!(
+        f, dy, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
+    )
+end
+
+function pushforward_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
+    return pushforward_batched(
+        f, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
+    )
+end
+
+function pushforward_batched!(f::F, dy, backend::AbstractADType, x, dx::Batch) where {F}
+    return pushforward_batched!(
+        f, dy, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
+    )
+end
+
+### With extras
+
+function pushforward_batched(
+    f::F, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
+) where {F,B}
+    dy_elements = pushforward.(Ref(f), Ref(backend), Ref(x), dx.elements, Ref(extras))
+    return Batch(dy_elements)
+end
+
+function pushforward_batched!(
+    f::F, dy::Batch, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
+    for b in eachindex(dy.elements, dx.elements)
+        pushforward!(f, dy.elements[b], backend, x, dx.elements[b], extras)
+    end
+    return dy
+end
+
+function value_and_pushforward_batched(
+    f::F, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
+) where {F,B}
+    return f(x), pushforward_batched(f, backend, x, dx, extras)
+end
+
+function value_and_pushforward_batched!(
+    f::F, dy::Batch, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
+    return f(x), pushforward_batched!(f, dy, backend, x, dx, extras)
+end
+
+## Two arguments
+
+### Without extras
+
+function value_and_pushforward_batched(
+    f!::F, y, backend::AbstractADType, x, dx::Batch
+) where {F}
+    return value_and_pushforward_batched(
+        f!, y, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
+    )
+end
+
+function value_and_pushforward_batched!(
+    f!::F, y, dy, backend::AbstractADType, x, dx::Batch
+) where {F}
+    return value_and_pushforward_batched!(
+        f!, y, dy, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
+    )
+end
+
+function pushforward_batched(f!::F, y, backend::AbstractADType, x, dx::Batch) where {F}
+    return pushforward_batched(
+        f!, y, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
+    )
+end
+
+function pushforward_batched!(f!::F, y, dy, backend::AbstractADType, x, dx::Batch) where {F}
+    return pushforward_batched!(
+        f!, y, dy, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
+    )
+end
+
+### With extras
+
+function pushforward_batched(
+    f!::F, y, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
+) where {F,B}
+    dy_elements =
+        pushforward.(Ref(f!), Ref(y), Ref(backend), Ref(x), dx.elements, Ref(extras))
+    return Batch(dy_elements)
+end
+
+function pushforward_batched!(
+    f!::F, y, dy::Batch, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
+    for b in eachindex(dy.elements, dx.elements)
+        pushforward!(f!, y, dy.elements[b], backend, x, dx.elements[b], extras)
+    end
+    return dy
+end
+
+function value_and_pushforward_batched(
+    f!::F, y, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
+) where {F,B}
+    dy = pushforward_batched(f!, y, backend, x, dx, extras)
+    f!(y, x)
+    return y, dy
+end
+
+function value_and_pushforward_batched!(
+    f!::F, y, dy::Batch, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
+    pushforward_batched!(f!, y, dy, backend, x, dx, extras)
+    f!(y, x)
+    return y, dy
+end

--- a/DifferentiationInterface/src/first_order/pushforward_batched.jl
+++ b/DifferentiationInterface/src/first_order/pushforward_batched.jl
@@ -63,7 +63,7 @@ function value_and_pushforward_batched(
 end
 
 function value_and_pushforward_batched!(
-    f::F, dy, backend::AbstractADType, x, dx::Batch
+    f::F, dy::Batch, backend::AbstractADType, x, dx::Batch
 ) where {F}
     return value_and_pushforward_batched!(
         f, dy, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
@@ -76,7 +76,9 @@ function pushforward_batched(f::F, backend::AbstractADType, x, dx::Batch) where 
     )
 end
 
-function pushforward_batched!(f::F, dy, backend::AbstractADType, x, dx::Batch) where {F}
+function pushforward_batched!(
+    f::F, dy::Batch, backend::AbstractADType, x, dx::Batch
+) where {F}
     return pushforward_batched!(
         f, dy, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
     )
@@ -85,8 +87,8 @@ end
 ### With extras
 
 function pushforward_batched(
-    f::F, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
-) where {F,B}
+    f::F, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
     dy_elements = pushforward.(Ref(f), Ref(backend), Ref(x), dx.elements, Ref(extras))
     return Batch(dy_elements)
 end
@@ -101,8 +103,8 @@ function pushforward_batched!(
 end
 
 function value_and_pushforward_batched(
-    f::F, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
-) where {F,B}
+    f::F, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
     return f(x), pushforward_batched(f, backend, x, dx, extras)
 end
 
@@ -125,7 +127,7 @@ function value_and_pushforward_batched(
 end
 
 function value_and_pushforward_batched!(
-    f!::F, y, dy, backend::AbstractADType, x, dx::Batch
+    f!::F, y, dy::Batch, backend::AbstractADType, x, dx::Batch
 ) where {F}
     return value_and_pushforward_batched!(
         f!, y, dy, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
@@ -138,7 +140,9 @@ function pushforward_batched(f!::F, y, backend::AbstractADType, x, dx::Batch) wh
     )
 end
 
-function pushforward_batched!(f!::F, y, dy, backend::AbstractADType, x, dx::Batch) where {F}
+function pushforward_batched!(
+    f!::F, y, dy::Batch, backend::AbstractADType, x, dx::Batch
+) where {F}
     return pushforward_batched!(
         f!, y, dy, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
     )
@@ -147,8 +151,8 @@ end
 ### With extras
 
 function pushforward_batched(
-    f!::F, y, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
-) where {F,B}
+    f!::F, y, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
     dy_elements =
         pushforward.(Ref(f!), Ref(y), Ref(backend), Ref(x), dx.elements, Ref(extras))
     return Batch(dy_elements)
@@ -164,8 +168,8 @@ function pushforward_batched!(
 end
 
 function value_and_pushforward_batched(
-    f!::F, y, backend::AbstractADType, x, dx::Batch{B}, extras::PushforwardExtras
-) where {F,B}
+    f!::F, y, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
+) where {F}
     dy = pushforward_batched(f!, y, backend, x, dx, extras)
     f!(y, x)
     return y, dy

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -70,6 +70,8 @@ end
 
 ## One argument
 
+### Without extras
+
 function value_gradient_and_hessian(f::F, backend::AbstractADType, x) where {F}
     return value_gradient_and_hessian(f, backend, x, prepare_hessian(f, backend, x))
 end
@@ -87,6 +89,8 @@ end
 function hessian!(f::F, hess, backend::AbstractADType, x) where {F}
     return hessian!(f, hess, backend, x, prepare_hessian(f, backend, x))
 end
+
+### With extras
 
 function hessian(
     f::F, backend::AbstractADType, x, extras::HVPGradientHessianExtras{B}

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -203,6 +203,13 @@ function prepare_hvp_batched_same_point(
     return extras
 end
 
+function prepare_hvp_batched_same_point(
+    f::F, backend::AbstractADType, x, dx::Batch
+) where {F}
+    extras = prepare_hvp_batched(f, backend, x, dx)
+    return prepare_hvp_batched_same_point(f, backend, x, dx, extras)
+end
+
 ## One argument
 
 ### Standard

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -10,8 +10,6 @@ Create an `extras` object that can be given to [`hvp`](@ref) and its variants.
 """
 function prepare_hvp end
 
-function prepare_hvp_batched end
-
 """
     prepare_hvp_same_point(f, backend, x, dx) -> extras_same
 
@@ -22,8 +20,6 @@ Create an `extras_same` object that can be given to [`hvp`](@ref) and its varian
 """
 function prepare_hvp_same_point end
 
-function prepare_hvp_batched_same_point end
-
 """
     hvp(f, backend, x, dx, [extras]) -> dg
 
@@ -31,16 +27,12 @@ Compute the Hessian-vector product of `f` at point `x` with seed `dx`.
 """
 function hvp end
 
-function hvp_batched end
-
 """
     hvp!(f, dg, backend, x, dx, [extras]) -> dg
 
 Compute the Hessian-vector product of `f` at point `x` with seed `dx`, overwriting `dg`.
 """
 function hvp! end
-
-function hvp_batched! end
 
 ## Preparation
 
@@ -95,7 +87,7 @@ struct ReverseOverReverseHVPExtras{IG<:InnerGradient,E<:PullbackExtras} <: HVPEx
     outer_pullback_extras::E
 end
 
-### Standard
+### Different point
 
 function prepare_hvp(f::F, backend::AbstractADType, x, dx) where {F}
     return prepare_hvp(f, SecondOrder(backend, backend), x, dx)
@@ -134,7 +126,7 @@ function prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ReverseOverReverse
     return ReverseOverReverseHVPExtras(inner_gradient, outer_pullback_extras)
 end
 
-### Standard, same point
+### Same point
 
 function prepare_hvp_same_point(
     f::F, backend::AbstractADType, x, dx, extras::HVPExtras
@@ -147,76 +139,19 @@ function prepare_hvp_same_point(f::F, backend::AbstractADType, x, dx) where {F}
     return prepare_hvp_same_point(f, backend, x, dx, extras)
 end
 
-### Batched
-
-function prepare_hvp_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
-    return prepare_hvp_batched(f, SecondOrder(backend, backend), x, dx)
-end
-
-function prepare_hvp_batched(f::F, backend::SecondOrder, x, dx::Batch) where {F}
-    return prepare_hvp_batched_aux(f, backend, x, dx, hvp_mode(backend))
-end
-
-function prepare_hvp_batched_aux(
-    f::F, backend::SecondOrder, x, dx::Batch, ::ForwardOverForward
-) where {F}
-    # batched pushforward of gradient
-    inner_gradient = InnerGradient(f, nested(inner(backend)))
-    outer_pushforward_extras = prepare_pushforward_batched(
-        inner_gradient, outer(backend), x, dx
-    )
-    return ForwardOverForwardHVPExtras(inner_gradient, outer_pushforward_extras)
-end
-
-function prepare_hvp_batched_aux(
-    f::F, backend::SecondOrder, x, dx::Batch, ::ForwardOverReverse
-) where {F}
-    # batched pushforward of gradient
-    inner_gradient = InnerGradient(f, nested(inner(backend)))
-    outer_pushforward_extras = prepare_pushforward_batched(
-        inner_gradient, outer(backend), x, dx
-    )
-    return ForwardOverReverseHVPExtras(inner_gradient, outer_pushforward_extras)
-end
-
-function prepare_hvp_batched_aux(
-    f::F, backend::SecondOrder, x, dx::Batch, ::ReverseOverForward
-) where {F}
-    # TODO: batched version replacing the outer gradient with a pullback
-    return prepare_hvp_aux(f, backend, x, first(dx.elements), ReverseOverForward())
-end
-
-function prepare_hvp_batched_aux(
-    f::F, backend::SecondOrder, x, dx::Batch, ::ReverseOverReverse
-) where {F}
-    # batched pullback of gradient
-    inner_gradient = InnerGradient(f, nested(inner(backend)))
-    outer_pullback_extras = prepare_pullback_batched(inner_gradient, outer(backend), x, dx)
-    return ReverseOverReverseHVPExtras(inner_gradient, outer_pullback_extras)
-end
-
-### Batched, same point
-
-function prepare_hvp_batched_same_point(
-    f::F, backend::AbstractADType, x, dx::Batch, extras::HVPExtras
-) where {F}
-    return extras
-end
-
-function prepare_hvp_batched_same_point(
-    f::F, backend::AbstractADType, x, dx::Batch
-) where {F}
-    extras = prepare_hvp_batched(f, backend, x, dx)
-    return prepare_hvp_batched_same_point(f, backend, x, dx, extras)
-end
-
 ## One argument
 
-### Standard
+### Without extras
 
 function hvp(f::F, backend::AbstractADType, x, dx) where {F}
     return hvp(f, backend, x, dx, prepare_hvp(f, backend, x, dx))
 end
+
+function hvp!(f::F, dg, backend::AbstractADType, x, dx) where {F}
+    return hvp!(f, dg, backend, x, dx, prepare_hvp(f, backend, x, dx))
+end
+
+### With extras
 
 function hvp(f::F, backend::AbstractADType, x, dx, extras::HVPExtras) where {F}
     return hvp(f, SecondOrder(backend, backend), x, dx, extras)
@@ -251,10 +186,6 @@ function hvp(
     return pullback(inner_gradient, outer(backend), x, dx, outer_pullback_extras)
 end
 
-function hvp!(f::F, dg, backend::AbstractADType, x, dx) where {F}
-    return hvp!(f, dg, backend, x, dx, prepare_hvp(f, backend, x, dx))
-end
-
 function hvp!(f::F, dg, backend::AbstractADType, x, dx, extras::HVPExtras) where {F}
     return hvp!(f, dg, SecondOrder(backend, backend), x, dx, extras)
 end
@@ -286,93 +217,4 @@ function hvp!(
 ) where {F}
     @compat (; inner_gradient, outer_pullback_extras) = extras
     return pullback!(inner_gradient, dg, outer(backend), x, dx, outer_pullback_extras)
-end
-
-### Batched
-
-function hvp_batched(
-    f::F, backend::AbstractADType, x, dx::Batch, extras::HVPExtras
-) where {F}
-    return hvp_batched(f, SecondOrder(backend, backend), x, dx, extras)
-end
-
-function hvp_batched(
-    f::F, backend::SecondOrder, x, dx::Batch, extras::ForwardOverForwardHVPExtras
-) where {F}
-    @compat (; inner_gradient, outer_pushforward_extras) = extras
-    return pushforward_batched(
-        inner_gradient, outer(backend), x, dx, outer_pushforward_extras
-    )
-end
-
-function hvp_batched(
-    f::F, backend::SecondOrder, x, dx::Batch, extras::ForwardOverReverseHVPExtras
-) where {F}
-    @compat (; inner_gradient, outer_pushforward_extras) = extras
-    return pushforward_batched(
-        inner_gradient, outer(backend), x, dx, outer_pushforward_extras
-    )
-end
-
-function hvp_batched(
-    f::F, backend::SecondOrder, x, dx::Batch{B}, extras::ReverseOverForwardHVPExtras
-) where {F,B}
-    dg_elements = ntuple(Val(B)) do b
-        hvp(f, backend, x, dx.elements[b], extras)
-    end
-    return Batch(dg_elements)
-end
-
-function hvp_batched(
-    f::F, backend::SecondOrder, x, dx::Batch, extras::ReverseOverReverseHVPExtras
-) where {F}
-    @compat (; inner_gradient, outer_pullback_extras) = extras
-    return pullback_batched(inner_gradient, outer(backend), x, dx, outer_pullback_extras)
-end
-
-function hvp_batched!(
-    f::F, dg::Batch, backend::AbstractADType, x, dx::Batch, extras::HVPExtras
-) where {F}
-    return hvp_batched!(f, dg, SecondOrder(backend, backend), x, dx, extras)
-end
-
-function hvp_batched!(
-    f::F, dg::Batch, backend::SecondOrder, x, dx::Batch, extras::ForwardOverForwardHVPExtras
-) where {F}
-    @compat (; inner_gradient, outer_pushforward_extras) = extras
-    return pushforward_batched!(
-        inner_gradient, dg, outer(backend), x, dx, outer_pushforward_extras
-    )
-end
-
-function hvp_batched!(
-    f::F, dg::Batch, backend::SecondOrder, x, dx::Batch, extras::ForwardOverReverseHVPExtras
-) where {F}
-    @compat (; inner_gradient, outer_pushforward_extras) = extras
-    return pushforward_batched!(
-        inner_gradient, dg, outer(backend), x, dx, outer_pushforward_extras
-    )
-end
-
-function hvp_batched!(
-    f::F,
-    dg::Batch{B},
-    backend::SecondOrder,
-    x,
-    dx::Batch{B},
-    extras::ReverseOverForwardHVPExtras,
-) where {F,B}
-    for b in eachindex(dg.elements, dx.elements)
-        hvp!(f, dg.elements[b], backend, x, dx.elements[b], extras)
-    end
-    return dg
-end
-
-function hvp_batched!(
-    f::F, dg::Batch, backend::SecondOrder, x, dx::Batch, extras::ReverseOverReverseHVPExtras
-) where {F}
-    @compat (; inner_gradient, outer_pullback_extras) = extras
-    return pullback_batched!(
-        inner_gradient, dg, outer(backend), x, dx, outer_pullback_extras
-    )
 end

--- a/DifferentiationInterface/src/second_order/hvp_batched.jl
+++ b/DifferentiationInterface/src/second_order/hvp_batched.jl
@@ -1,0 +1,173 @@
+## Docstrings
+
+function prepare_hvp_batched end
+function prepare_hvp_batched_same_point end
+
+function hvp_batched end
+function hvp_batched! end
+
+## Preparation
+
+### Different point
+
+function prepare_hvp_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
+    return prepare_hvp_batched(f, SecondOrder(backend, backend), x, dx)
+end
+
+function prepare_hvp_batched(f::F, backend::SecondOrder, x, dx::Batch) where {F}
+    return prepare_hvp_batched_aux(f, backend, x, dx, hvp_mode(backend))
+end
+
+function prepare_hvp_batched_aux(
+    f::F, backend::SecondOrder, x, dx::Batch, ::ForwardOverForward
+) where {F}
+    # batched pushforward of gradient
+    inner_gradient = InnerGradient(f, nested(inner(backend)))
+    outer_pushforward_extras = prepare_pushforward_batched(
+        inner_gradient, outer(backend), x, dx
+    )
+    return ForwardOverForwardHVPExtras(inner_gradient, outer_pushforward_extras)
+end
+
+function prepare_hvp_batched_aux(
+    f::F, backend::SecondOrder, x, dx::Batch, ::ForwardOverReverse
+) where {F}
+    # batched pushforward of gradient
+    inner_gradient = InnerGradient(f, nested(inner(backend)))
+    outer_pushforward_extras = prepare_pushforward_batched(
+        inner_gradient, outer(backend), x, dx
+    )
+    return ForwardOverReverseHVPExtras(inner_gradient, outer_pushforward_extras)
+end
+
+function prepare_hvp_batched_aux(
+    f::F, backend::SecondOrder, x, dx::Batch, ::ReverseOverForward
+) where {F}
+    # TODO: batched version replacing the outer gradient with a pullback
+    return prepare_hvp_aux(f, backend, x, first(dx.elements), ReverseOverForward())
+end
+
+function prepare_hvp_batched_aux(
+    f::F, backend::SecondOrder, x, dx::Batch, ::ReverseOverReverse
+) where {F}
+    # batched pullback of gradient
+    inner_gradient = InnerGradient(f, nested(inner(backend)))
+    outer_pullback_extras = prepare_pullback_batched(inner_gradient, outer(backend), x, dx)
+    return ReverseOverReverseHVPExtras(inner_gradient, outer_pullback_extras)
+end
+
+### Same point
+
+function prepare_hvp_batched_same_point(
+    f::F, backend::AbstractADType, x, dx::Batch, extras::HVPExtras
+) where {F}
+    return extras
+end
+
+function prepare_hvp_batched_same_point(
+    f::F, backend::AbstractADType, x, dx::Batch
+) where {F}
+    extras = prepare_hvp_batched(f, backend, x, dx)
+    return prepare_hvp_batched_same_point(f, backend, x, dx, extras)
+end
+
+## One argument
+
+### Without extras
+
+function hvp_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
+    return hvp_batched(f, backend, x, dx, prepare_hvp_batched(f, backend, x, dx))
+end
+
+function hvp_batched!(f::F, dg::Batch, backend::AbstractADType, x, dx::Batch) where {F}
+    return hvp_batched!(f, dg, backend, x, dx, prepare_hvp_batched(f, backend, x, dx))
+end
+
+### With extras
+
+function hvp_batched(
+    f::F, backend::AbstractADType, x, dx::Batch, extras::HVPExtras
+) where {F}
+    return hvp_batched(f, SecondOrder(backend, backend), x, dx, extras)
+end
+
+function hvp_batched(
+    f::F, backend::SecondOrder, x, dx::Batch, extras::ForwardOverForwardHVPExtras
+) where {F}
+    @compat (; inner_gradient, outer_pushforward_extras) = extras
+    return pushforward_batched(
+        inner_gradient, outer(backend), x, dx, outer_pushforward_extras
+    )
+end
+
+function hvp_batched(
+    f::F, backend::SecondOrder, x, dx::Batch, extras::ForwardOverReverseHVPExtras
+) where {F}
+    @compat (; inner_gradient, outer_pushforward_extras) = extras
+    return pushforward_batched(
+        inner_gradient, outer(backend), x, dx, outer_pushforward_extras
+    )
+end
+
+function hvp_batched(
+    f::F, backend::SecondOrder, x, dx::Batch{B}, extras::ReverseOverForwardHVPExtras
+) where {F,B}
+    dg_elements = ntuple(Val(B)) do b
+        hvp(f, backend, x, dx.elements[b], extras)
+    end
+    return Batch(dg_elements)
+end
+
+function hvp_batched(
+    f::F, backend::SecondOrder, x, dx::Batch, extras::ReverseOverReverseHVPExtras
+) where {F}
+    @compat (; inner_gradient, outer_pullback_extras) = extras
+    return pullback_batched(inner_gradient, outer(backend), x, dx, outer_pullback_extras)
+end
+
+function hvp_batched!(
+    f::F, dg::Batch, backend::AbstractADType, x, dx::Batch, extras::HVPExtras
+) where {F}
+    return hvp_batched!(f, dg, SecondOrder(backend, backend), x, dx, extras)
+end
+
+function hvp_batched!(
+    f::F, dg::Batch, backend::SecondOrder, x, dx::Batch, extras::ForwardOverForwardHVPExtras
+) where {F}
+    @compat (; inner_gradient, outer_pushforward_extras) = extras
+    return pushforward_batched!(
+        inner_gradient, dg, outer(backend), x, dx, outer_pushforward_extras
+    )
+end
+
+function hvp_batched!(
+    f::F, dg::Batch, backend::SecondOrder, x, dx::Batch, extras::ForwardOverReverseHVPExtras
+) where {F}
+    @compat (; inner_gradient, outer_pushforward_extras) = extras
+    return pushforward_batched!(
+        inner_gradient, dg, outer(backend), x, dx, outer_pushforward_extras
+    )
+end
+
+function hvp_batched!(
+    f::F,
+    dg::Batch{B},
+    backend::SecondOrder,
+    x,
+    dx::Batch{B},
+    extras::ReverseOverForwardHVPExtras,
+) where {F,B}
+    for b in eachindex(dg.elements, dx.elements)
+        hvp!(f, dg.elements[b], backend, x, dx.elements[b], extras)
+    end
+    return dg
+end
+
+function hvp_batched!(
+    f::F, dg::Batch, backend::SecondOrder, x, dx::Batch, extras::ReverseOverReverseHVPExtras
+) where {F}
+    @compat (; inner_gradient, outer_pullback_extras) = extras
+    return pullback_batched!(
+        inner_gradient, dg, outer(backend), x, dx, outer_pullback_extras
+    )
+end

--- a/DifferentiationInterface/src/second_order/hvp_batched.jl
+++ b/DifferentiationInterface/src/second_order/hvp_batched.jl
@@ -110,8 +110,8 @@ function hvp_batched(
 end
 
 function hvp_batched(
-    f::F, backend::SecondOrder, x, dx::Batch{B}, extras::ReverseOverForwardHVPExtras
-) where {F,B}
+    f::F, backend::SecondOrder, x, dx::Batch, extras::ReverseOverForwardHVPExtras
+) where {F}
     dg_elements = hvp.(Ref(f), Ref(backend), Ref(x), dx.elements, Ref(extras))
     return Batch(dg_elements)
 end
@@ -148,13 +148,8 @@ function hvp_batched!(
 end
 
 function hvp_batched!(
-    f::F,
-    dg::Batch{B},
-    backend::SecondOrder,
-    x,
-    dx::Batch{B},
-    extras::ReverseOverForwardHVPExtras,
-) where {F,B}
+    f::F, dg::Batch, backend::SecondOrder, x, dx::Batch, extras::ReverseOverForwardHVPExtras
+) where {F}
     for b in eachindex(dg.elements, dx.elements)
         hvp!(f, dg.elements[b], backend, x, dx.elements[b], extras)
     end

--- a/DifferentiationInterface/src/second_order/hvp_batched.jl
+++ b/DifferentiationInterface/src/second_order/hvp_batched.jl
@@ -112,9 +112,7 @@ end
 function hvp_batched(
     f::F, backend::SecondOrder, x, dx::Batch{B}, extras::ReverseOverForwardHVPExtras
 ) where {F,B}
-    dg_elements = ntuple(Val(B)) do b
-        hvp(f, backend, x, dx.elements[b], extras)
-    end
+    dg_elements = hvp.(Ref(f), Ref(backend), Ref(x), dx.elements, Ref(extras))
     return Batch(dg_elements)
 end
 

--- a/DifferentiationInterface/src/second_order/second_derivative.jl
+++ b/DifferentiationInterface/src/second_order/second_derivative.jl
@@ -77,6 +77,8 @@ end
 
 ## One argument
 
+### Without extras
+
 function value_derivative_and_second_derivative(f::F, backend::AbstractADType, x) where {F}
     return value_derivative_and_second_derivative(
         f, backend, x, prepare_second_derivative(f, backend, x)
@@ -98,6 +100,8 @@ end
 function second_derivative!(f::F, der2, backend::AbstractADType, x) where {F}
     return second_derivative!(f, der2, backend, x, prepare_second_derivative(f, backend, x))
 end
+
+### With extras
 
 function second_derivative(
     f::F, backend::AbstractADType, x, extras::SecondDerivativeExtras

--- a/DifferentiationInterface/src/utils/batch.jl
+++ b/DifferentiationInterface/src/utils/batch.jl
@@ -22,3 +22,6 @@ struct Batch{B,T}
     elements::NTuple{B,T}
     Batch(elements::NTuple) = new{length(elements),eltype(elements)}(elements)
 end
+
+Base.length(::Batch{B}) where {B} = B
+Base.eltype(::Batch{B,T}) where {B,T} = T

--- a/DifferentiationInterface/src/utils/batch.jl
+++ b/DifferentiationInterface/src/utils/batch.jl
@@ -25,3 +25,10 @@ end
 
 Base.length(::Batch{B}) where {B} = B
 Base.eltype(::Batch{B,T}) where {B,T} = T
+
+Base.:(==)(b1::Batch{B}, b2::Batch{B}) where {B} = b1.elements == b2.elements
+Base.isequal(b1::Batch{B}, b2::Batch{B}) where {B} = isequal(b1.elements, b2.elements)
+
+function Base.isapprox(b1::Batch{B}, b2::Batch{B}; kwargs...) where {B}
+    return all(isapprox.(b1.elements, b2.elements; kwargs...))
+end

--- a/DifferentiationInterface/src/utils/batch.jl
+++ b/DifferentiationInterface/src/utils/batch.jl
@@ -23,11 +23,7 @@ struct Batch{B,T}
     Batch(elements::NTuple) = new{length(elements),eltype(elements)}(elements)
 end
 
-Base.length(::Batch{B}) where {B} = B
-Base.eltype(::Batch{B,T}) where {B,T} = T
-
 Base.:(==)(b1::Batch{B}, b2::Batch{B}) where {B} = b1.elements == b2.elements
-Base.isequal(b1::Batch{B}, b2::Batch{B}) where {B} = isequal(b1.elements, b2.elements)
 
 function Base.isapprox(b1::Batch{B}, b2::Batch{B}; kwargs...) where {B}
     return all(isapprox.(b1.elements, b2.elements; kwargs...))

--- a/DifferentiationInterface/test/Single/ForwardDiff/fromprimitive.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/fromprimitive.jl
@@ -1,5 +1,6 @@
 using DifferentiationInterface, DifferentiationInterfaceTest
 using DifferentiationInterface: AutoForwardFromPrimitive
+using DifferentiationInterfaceTest: add_batchified!
 using ForwardDiff: ForwardDiff
 using Test
 
@@ -13,10 +14,13 @@ end
 
 ## Dense backends
 
-test_differentiation(fromprimitive_backends; logging=LOGGING);
+test_differentiation(
+    fromprimitive_backends, add_batchified!(default_scenarios()); logging=LOGGING
+);
 
 test_differentiation(
-    fromprimitive_backends;
+    fromprimitive_backends,
+    add_batchified!(default_scenarios());
     correctness=false,
     type_stability=true,
     second_order=false,

--- a/DifferentiationInterface/test/Single/ForwardDiff/fromprimitive.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/fromprimitive.jl
@@ -1,0 +1,24 @@
+using DifferentiationInterface, DifferentiationInterfaceTest
+using DifferentiationInterface: AutoForwardFromPrimitive
+using ForwardDiff: ForwardDiff
+using Test
+
+fromprimitive_backends = [AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5))]
+
+for backend in vcat(fromprimitive_backends)
+    @test check_available(backend)
+    @test check_twoarg(backend)
+    @test check_hessian(backend)
+end
+
+## Dense backends
+
+test_differentiation(fromprimitive_backends; logging=LOGGING);
+
+test_differentiation(
+    fromprimitive_backends;
+    correctness=false,
+    type_stability=true,
+    second_order=false,
+    logging=LOGGING,
+);

--- a/DifferentiationInterface/test/Single/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/test.jl
@@ -1,12 +1,9 @@
 using DifferentiationInterface, DifferentiationInterfaceTest
-using DifferentiationInterface: AutoForwardFromPrimitive
 using ForwardDiff: ForwardDiff
 using SparseConnectivityTracer, SparseMatrixColorings
 using Test
 
 dense_backends = [AutoForwardDiff(), AutoForwardDiff(; chunksize=2, tag=:hello)]
-
-fromprimitive_backends = [AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5))]
 
 sparse_backends = [
     AutoSparse(
@@ -16,7 +13,7 @@ sparse_backends = [
     ),
 ]
 
-for backend in vcat(dense_backends, fromprimitive_backends, sparse_backends)
+for backend in vcat(dense_backends, sparse_backends)
     @test check_available(backend)
     @test check_twoarg(backend)
     @test check_hessian(backend)
@@ -24,10 +21,10 @@ end
 
 ## Dense backends
 
-test_differentiation(vcat(dense_backends, fromprimitive_backends); logging=LOGGING);
+test_differentiation(dense_backends; logging=LOGGING);
 
 test_differentiation(
-    vcat(dense_backends, fromprimitive_backends);
+    fromprimitive_backends;
     correctness=false,
     type_stability=true,
     second_order=false,

--- a/DifferentiationInterface/test/Single/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/test.jl
@@ -1,4 +1,5 @@
 using DifferentiationInterface, DifferentiationInterfaceTest
+using DifferentiationInterfaceTest: add_batchified!
 using ForwardDiff: ForwardDiff
 using SparseConnectivityTracer, SparseMatrixColorings
 using Test
@@ -21,10 +22,11 @@ end
 
 ## Dense backends
 
-test_differentiation(dense_backends; logging=LOGGING);
+test_differentiation(dense_backends, add_batchified!(default_scenarios()); logging=LOGGING);
 
 test_differentiation(
-    fromprimitive_backends;
+    fromprimitive_backends,
+    add_batchified!(default_scenarios());
     correctness=false,
     type_stability=true,
     second_order=false,

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -31,17 +31,25 @@ using DifferentiationInterface:
     mode,
     outer,
     twoarg_support,
+    pushforward_performance,
+    pullback_performance
+using DifferentiationInterface:
     prepare_hvp_batched,
+    prepare_hvp_batched_same_point,
     prepare_pullback_batched,
+    prepare_pullback_batched_same_point,
     prepare_pushforward_batched,
+    prepare_pushforward_batched_same_point,
     hvp_batched,
     hvp_batched!,
     pullback_batched,
     pullback_batched!,
     pushforward_batched,
     pushforward_batched!,
-    pushforward_performance,
-    pullback_performance
+    value_and_pullback_batched,
+    value_and_pullback_batched!,
+    value_and_pushforward_batched,
+    value_and_pushforward_batched!
 using DifferentiationInterface:
     DerivativeExtras,
     GradientExtras,
@@ -65,6 +73,7 @@ using StaticArrays: MArray, MMatrix, MVector, SArray, SMatrix, SVector
 using Test: @testset, @test
 
 include("scenarios/scenario.jl")
+include("scenarios/batchify.jl")
 include("scenarios/default.jl")
 include("scenarios/sparse.jl")
 include("scenarios/static.jl")

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -23,6 +23,7 @@ using ComponentArrays: ComponentVector
 using DataFrames: DataFrame
 using DifferentiationInterface
 using DifferentiationInterface:
+    Batch,
     backend_str,
     inner,
     maybe_inner,
@@ -30,6 +31,15 @@ using DifferentiationInterface:
     mode,
     outer,
     twoarg_support,
+    prepare_hvp_batched,
+    prepare_pullback_batched,
+    prepare_pushforward_batched,
+    hvp_batched,
+    hvp_batched!,
+    pullback_batched,
+    pullback_batched!,
+    pushforward_batched,
+    pushforward_batched!,
     pushforward_performance,
     pullback_performance
 using DifferentiationInterface:

--- a/DifferentiationInterfaceTest/src/scenarios/allocfree.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/allocfree.jl
@@ -63,9 +63,11 @@ function allocfree_scenarios(rng::AbstractRNG=default_rng())
     dx_6 = rand(rng, 6)
     dy_6 = rand(rng, 6)
 
-    return vcat(
+    scens = vcat(
         identity_scenarios(x_; dx=dx_, dy=dy_), #
         sum_scenarios(x_6; dx=dx_6, dy=dy_),
         copyto!_scenarios(x_6; dx=dx_6, dy=dy_6),
     )
+    add_batchified!(scens)
+    return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/allocfree.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/allocfree.jl
@@ -68,6 +68,5 @@ function allocfree_scenarios(rng::AbstractRNG=default_rng())
         sum_scenarios(x_6; dx=dx_6, dy=dy_),
         copyto!_scenarios(x_6; dx=dx_6, dy=dy_6),
     )
-    add_batchified!(scens)
     return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/batchify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/batchify.jl
@@ -13,6 +13,11 @@ function batchify(scen::Scenario{op,args,pl}) where {op,args,pl}
     end
 end
 
+"""
+    add_batchified!(scens::AbstractVector{<:Scenario})
+
+Add batchified versions to `scens` of its scenarios which support it (pushforward, pullback and HVP).
+"""
 function add_batchified!(scens::AbstractVector{<:Scenario})
     batchifiable_scens = filter(s -> operator(s) in (:pushforward, :pullback, :hvp), scens)
     return append!(scens, batchify.(batchifiable_scens))

--- a/DifferentiationInterfaceTest/src/scenarios/batchify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/batchify.jl
@@ -15,5 +15,5 @@ end
 
 function add_batchified!(scens::AbstractVector{<:Scenario})
     batchifiable_scens = filter(s -> operator(s) in (:pushforward, :pullback, :hvp), scens)
-    return vcat(scens, batchify.(batchifiable_scens))
+    return append!(scens, batchify.(batchifiable_scens))
 end

--- a/DifferentiationInterfaceTest/src/scenarios/batchify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/batchify.jl
@@ -1,0 +1,19 @@
+function batchify(scen::Scenario{op,args,pl}) where {op,args,pl}
+    @compat (; f, x, y, seed, res1, res2) = scen
+    if op == :pushforward || op == :pullback
+        new_seed = Batch((seed, -seed))
+        new_res1 = Batch((res1, -res1))
+        return Scenario{op,args,pl}(f; x, y, seed=new_seed, res1=new_res1, res2)
+    elseif op == :hvp
+        new_seed = Batch((seed, -seed))
+        new_res2 = Batch((res2, -res2))
+        return Scenario{op,args,pl}(f; x, y, seed=new_seed, res1, res2=new_res2)
+    else
+        throw(ArgumentError("Scenario $scen is not batchifiable."))
+    end
+end
+
+function add_batchified!(scens::AbstractVector{<:Scenario})
+    batchifiable_scens = filter(s -> operator(s) in (:pushforward, :pullback, :hvp), scens)
+    return vcat(scens, batchify.(batchifiable_scens))
+end

--- a/DifferentiationInterfaceTest/src/scenarios/batchify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/batchify.jl
@@ -8,8 +8,6 @@ function batchify(scen::Scenario{op,args,pl}) where {op,args,pl}
         new_seed = Batch((seed, -seed))
         new_res2 = Batch((res2, -res2))
         return Scenario{op,args,pl}(f; x, y, seed=new_seed, res1, res2=new_res2)
-    else
-        throw(ArgumentError("Scenario $scen is not batchifiable."))
     end
 end
 

--- a/DifferentiationInterfaceTest/src/scenarios/component.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/component.jl
@@ -53,9 +53,11 @@ function component_scenarios(rng::AbstractRNG=default_rng())
     x_comp = ComponentVector(; a=randn(rng, 4), b=randn(rng, 2))
     dx_comp = ComponentVector(; a=randn(rng, 4), b=randn(rng, 2))
 
-    return vcat(
+    scens = vcat(
         # one argument
         comp_to_num_scenarios_onearg(x_comp::ComponentVector; dx=dx_comp, dy=dy_),
         # two arguments
     )
+    add_batchified!(scens)
+    return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/component.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/component.jl
@@ -58,6 +58,5 @@ function component_scenarios(rng::AbstractRNG=default_rng())
         comp_to_num_scenarios_onearg(x_comp::ComponentVector; dx=dx_comp, dy=dy_),
         # two arguments
     )
-    add_batchified!(scens)
     return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -502,6 +502,5 @@ function default_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
         mat_to_vec_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_12),
         mat_to_mat_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_6_2),
     )
-    add_batchified!(scens)
     return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -483,7 +483,7 @@ function default_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
     V = Vector{Float64}
     M = Matrix{Float64}
 
-    return vcat(
+    scens = vcat(
         # one argument
         num_to_num_scenarios_onearg(x_; dx=dx_, dy=dy_),
         num_to_arr_scenarios_onearg(x_, V; dx=dx_, dy=dy_6),
@@ -502,4 +502,6 @@ function default_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
         mat_to_vec_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_12),
         mat_to_mat_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_6_2),
     )
+    add_batchified!(scens)
+    return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/gpu.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/gpu.jl
@@ -41,6 +41,5 @@ function gpu_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
         mat_to_vec_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_12),
         mat_to_mat_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_6_2),
     )
-    add_batchified!(scens)
     return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/gpu.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/gpu.jl
@@ -22,7 +22,7 @@ function gpu_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
     V = typeof(dy_6)
     M = typeof(dy_2_3)
 
-    return vcat(
+    scens = vcat(
         # one argument
         num_to_num_scenarios_onearg(x_; dx=dx_, dy=dy_),
         num_to_arr_scenarios_onearg(x_, V; dx=dx_, dy=dy_6),
@@ -41,4 +41,6 @@ function gpu_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
         mat_to_vec_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_12),
         mat_to_mat_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_6_2),
     )
+    add_batchified!(scens)
+    return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -75,6 +75,7 @@ end
 
 maybe_zero(x::Number) = zero(x)
 maybe_zero(x::AbstractArray) = zero(x)
+maybe_zero(x::Batch) = Batch(maybe_zero.(x.elements))
 maybe_zero(::Nothing) = nothing
 
 function scenario_to_zero(scen::Scenario{op,args,pl}) where {op,args,pl}

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -105,15 +105,15 @@ end
 function Base.show(
     io::IO, scen::S
 ) where {op,args,pl,F,X,Y,D,S<:Scenario{op,args,pl,F,X,Y,D}}
-    if D <: Nothing
+    if D <: Batch
         print(
             io,
-            "Scenario{$(repr(op)),$(repr(args)),$(repr(pl))} with function $(repr(scen.f)) : $X -> $Y",
+            "Scenario{$(repr(op)),$(repr(args)),$(repr(pl))} $(string(scen.f)) : $X -> $Y (batched)",
         )
     else
         print(
             io,
-            "Scenario{$(repr(op)),$(repr(args)),$(repr(pl))} with function $(repr(scen.f)) : $X -> $Y and seed $D",
+            "Scenario{$(repr(op)),$(repr(args)),$(repr(pl))} $(string(scen.f)) : $X -> $Y",
         )
     end
 end

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -75,7 +75,6 @@ end
 
 maybe_zero(x::Number) = zero(x)
 maybe_zero(x::AbstractArray) = zero(x)
-maybe_zero(x::Batch) = Batch(maybe_zero.(x.elements))
 maybe_zero(::Nothing) = nothing
 
 function scenario_to_zero(scen::Scenario{op,args,pl}) where {op,args,pl}

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -102,8 +102,20 @@ function group_by_operator(scenarios::AbstractVector{<:Scenario})
     )
 end
 
-function Base.print(io::IO, scen::S) where {op,args,pl,F,X,Y,S<:Scenario{op,args,pl,F,X,Y}}
-    return print(io, "Scenario{$op,$args,$pl}($(string(scen.f)) : $X -> $Y)")
+function Base.show(
+    io::IO, scen::S
+) where {op,args,pl,F,X,Y,D,S<:Scenario{op,args,pl,F,X,Y,D}}
+    if D <: Nothing
+        print(
+            io,
+            "Scenario{$(repr(op)),$(repr(args)),$(repr(pl))} with function $(repr(scen.f)) : $X -> $Y",
+        )
+    else
+        print(
+            io,
+            "Scenario{$(repr(op)),$(repr(args)),$(repr(pl))} with function $(repr(scen.f)) : $X -> $Y and seed $D",
+        )
+    end
 end
 
 """

--- a/DifferentiationInterfaceTest/src/scenarios/static.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/static.jl
@@ -50,5 +50,6 @@ function static_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
     scens = filter(scens) do s
         place(s) == :outofplace || s.x isa Union{Number,MArray}
     end
+    add_batchified!(scens)
     return scens
 end

--- a/DifferentiationInterfaceTest/src/scenarios/static.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/static.jl
@@ -50,6 +50,5 @@ function static_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
     scens = filter(scens) do s
         place(s) == :outofplace || s.x isa Union{Number,MArray}
     end
-    add_batchified!(scens)
     return scens
 end

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -98,6 +98,7 @@ function test_differentiation(
                             (:input_size, size(scen.x)),
                             (:output_type, typeof(scen.y)),
                             (:output_size, size(scen.y)),
+                            (:batched_seed, scen.seed isa Batch),
                         ],
                     )
                     correctness && @testset "Correctness" begin
@@ -111,6 +112,7 @@ function test_differentiation(
                     sparsity && @testset "Sparsity" begin
                         test_sparsity(backend, scen)
                     end
+                    yield()
                 end
             end
         end
@@ -185,9 +187,11 @@ function benchmark_differentiation(
                         (:input_size, size(scen.x)),
                         (:output_type, typeof(scen.y)),
                         (:output_size, size(scen.y)),
+                        (:batched_seed, scen.seed isa Batch),
                     ],
                 )
                 run_benchmark!(benchmark_data, backend, scen; logging)
+                yield()
             end
         end
     end

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -20,15 +20,29 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (),
-        (prepare_pushforward(f, ba, mycopy_random(x), mycopy_random(seed)),),
-        (prepare_pushforward_same_point(f, ba, x, mycopy_random(seed)),),
-    ])
-        y1, dy1 = value_and_pushforward(f, ba, x, seed, extras_tup...)
-        dy2 = pushforward(f, ba, x, seed, extras_tup...)
+    extras_tup_candidates = if seed isa Batch
+        [
+            prepare_pushforward_batched(f, ba, mycopy_random(x), mycopy_random(seed)),
+            prepare_pushforward_batched_same_point(f, ba, x, mycopy_random(seed)),
+        ]
+    else
+        [
+            prepare_pushforward(f, ba, mycopy_random(x), mycopy_random(seed)),
+            prepare_pushforward_same_point(f, ba, x, mycopy_random(seed)),
+        ]
+    end
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
+        if seed isa Batch
+            y1 = f(x)
+            dy1 = dy2 = pushforward_batched(f, ba, x, seed, extras_tup...)
+        else
+            y1, dy1 = value_and_pushforward(f, ba, x, seed, extras_tup...)
+            dy2 = pushforward(f, ba, x, seed, extras_tup...)
+        end
 
         let (≈)(x, y) = isapprox(x, y; atol, rtol)
             @testset "Extras type" begin
@@ -54,18 +68,33 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (),
-        (prepare_pushforward(f, ba, mycopy_random(x), mycopy_random(seed)),),
-        (prepare_pushforward_same_point(f, ba, x, mycopy_random(seed)),),
-    ])
-        dy1_in = mysimilar(y)
-        y1, dy1 = value_and_pushforward!(f, dy1_in, ba, x, seed, extras_tup...)
+    extras_tup_candidates = if seed isa Batch
+        [
+            prepare_pushforward_batched(f, ba, mycopy_random(x), mycopy_random(seed)),
+            prepare_pushforward_batched_same_point(f, ba, x, mycopy_random(seed)),
+        ]
+    else
+        [
+            prepare_pushforward(f, ba, mycopy_random(x), mycopy_random(seed)),
+            prepare_pushforward_same_point(f, ba, x, mycopy_random(seed)),
+        ]
+    end
 
-        dy2_in = mysimilar(y)
-        dy2 = pushforward!(f, dy2_in, ba, x, seed, extras_tup...)
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
+        dy1_in = mysimilar(res1)
+        dy2_in = mysimilar(res1)
+
+        if seed isa Batch
+            y1 = f(x)
+            dy1 = pushforward_batched!(f, dy1_in, ba, x, seed, extras_tup...)
+            dy2 = pushforward_batched!(f, dy2_in, ba, x, seed, extras_tup...)
+        else
+            y1, dy1 = value_and_pushforward!(f, dy1_in, ba, x, seed, extras_tup...)
+            dy2 = pushforward!(f, dy2_in, ba, x, seed, extras_tup...)
+        end
 
         let (≈)(x, y) = isapprox(x, y; atol, rtol)
             @testset "Extras type" begin
@@ -93,19 +122,43 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
     f! = f
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (),
-        (prepare_pushforward(f!, mysimilar(y), ba, mycopy_random(x), mycopy_random(seed)),),
-        (prepare_pushforward_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),),
-    ])
-        y1_in = mysimilar(y)
-        y1, dy1 = value_and_pushforward(f!, y1_in, ba, x, seed, extras_tup...)
+    extras_tup_candidates = if seed isa Batch
+        [
+            prepare_pushforward_batched(
+                f!, mysimilar(y), ba, mycopy_random(x), mycopy_random(seed)
+            ),
+            prepare_pushforward_batched_same_point(
+                f!, mysimilar(y), ba, x, mycopy_random(seed)
+            ),
+        ]
+    else
+        [
+            prepare_pushforward(
+                f!, mysimilar(y), ba, mycopy_random(x), mycopy_random(seed)
+            ),
+            prepare_pushforward_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),
+        ]
+    end
 
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
+        y1_in = mysimilar(y)
         y2_in = mysimilar(y)
-        dy2 = pushforward(f!, y2_in, ba, x, seed, extras_tup...)
+
+        if seed isa Batch
+            y1 = mysimilar(y)
+            f!(y1, x)
+            f!(y1_in, x)
+            f!(y2_in, x)
+            dy1 = pushforward_batched(f!, y1_in, ba, x, seed, extras_tup...)
+            dy2 = pushforward_batched(f!, y2_in, ba, x, seed, extras_tup...)
+        else
+            y1, dy1 = value_and_pushforward(f!, y1_in, ba, x, seed, extras_tup...)
+            dy2 = pushforward(f!, y2_in, ba, x, seed, extras_tup...)
+        end
 
         let (≈)(x, y) = isapprox(x, y; atol, rtol)
             @testset "Extras type" begin
@@ -132,19 +185,43 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
     f! = f
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (),
-        (prepare_pushforward(f!, mysimilar(y), ba, mycopy_random(x), mycopy_random(seed)),),
-        (prepare_pushforward_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),),
-    ])
-        y1_in, dy1_in = mysimilar(y), mysimilar(y)
-        y1, dy1 = value_and_pushforward!(f!, y1_in, dy1_in, ba, x, seed, extras_tup...)
+    extras_tup_candidates = if seed isa Batch
+        [
+            prepare_pushforward_batched(
+                f!, mysimilar(y), ba, mycopy_random(x), mycopy_random(seed)
+            ),
+            prepare_pushforward_batched_same_point(
+                f!, mysimilar(y), ba, x, mycopy_random(seed)
+            ),
+        ]
+    else
+        [
+            prepare_pushforward(
+                f!, mysimilar(y), ba, mycopy_random(x), mycopy_random(seed)
+            ),
+            prepare_pushforward_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),
+        ]
+    end
 
-        y2_in, dy2_in = mysimilar(y), mysimilar(y)
-        dy2 = pushforward!(f!, y2_in, dy2_in, ba, x, seed, extras_tup...)
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
+        y1_in, dy1_in = mysimilar(y), mysimilar(res1)
+        y2_in, dy2_in = mysimilar(y), mysimilar(res1)
+
+        if seed isa Batch
+            y1 = mysimilar(y)
+            f!(y1, x)
+            f!(y1_in, x)
+            f!(y2_in, x)
+            dy1 = pushforward_batched!(f!, y1_in, dy1_in, ba, x, seed, extras_tup...)
+            dy2 = pushforward_batched!(f!, y2_in, dy2_in, ba, x, seed, extras_tup...)
+        else
+            y1, dy1 = value_and_pushforward!(f!, y1_in, dy1_in, ba, x, seed, extras_tup...)
+            dy2 = pushforward!(f!, y2_in, dy2_in, ba, x, seed, extras_tup...)
+        end
 
         let (≈)(x, y) = isapprox(x, y; atol, rtol)
             @testset "Extras type" begin
@@ -175,13 +252,16 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (),
         (prepare_pullback(f, ba, mycopy_random(x), mycopy_random(seed)),),
         (prepare_pullback_same_point(f, ba, x, mycopy_random(seed)),),
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1, dx1 = value_and_pullback(f, ba, x, seed, extras_tup...)
 
         dx2 = pullback(f, ba, x, seed, extras_tup...)
@@ -206,13 +286,16 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:pullback,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (),
         (prepare_pullback(f, ba, mycopy_random(x), mycopy_random(seed)),),
         (prepare_pullback_same_point(f, ba, x, mycopy_random(seed)),),
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         dx1_in = mysimilar(x)
         y1, dx1 = value_and_pullback!(f, dx1_in, ba, x, seed, extras_tup...)
 
@@ -245,14 +328,17 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
     f! = f
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (),
         (prepare_pullback(f!, mysimilar(y), ba, mycopy_random(x), mycopy_random(seed)),),
         (prepare_pullback_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),),
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1_in = mysimilar(y)
         y1, dx1 = value_and_pullback(f!, y1_in, ba, x, seed, extras_tup...)
 
@@ -280,14 +366,17 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:pullback,2,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
     f! = f
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (),
         (prepare_pullback(f!, mysimilar(y), ba, mycopy_random(x), mycopy_random(seed)),),
         (prepare_pullback_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),),
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1_in, dx1_in = mysimilar(y), mysimilar(x)
         y1, dx1 = value_and_pullback!(f!, y1_in, dx1_in, ba, x, seed, extras_tup...)
 
@@ -323,11 +412,12 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_derivative(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_derivative(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1, der1 = value_and_derivative(f, ba, x, extras_tup...)
         der2 = derivative(f, ba, x, extras_tup...)
 
@@ -355,11 +445,12 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_derivative(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_derivative(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         der1_in = mysimilar(y)
         y1, der1 = value_and_derivative!(f, der1_in, ba, x, extras_tup...)
 
@@ -392,12 +483,15 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
     f! = f
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (), (prepare_derivative(f!, mysimilar(y), ba, mycopy_random(x)),)
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1_in = mysimilar(y)
         y1, der1 = value_and_derivative(f!, y1_in, ba, x, extras_tup...)
 
@@ -429,12 +523,15 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
     f! = f
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (), (prepare_derivative(f!, mysimilar(y), ba, mycopy_random(x)),)
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1_in, der1_in = mysimilar(y), mysimilar(y)
         y1, der1 = value_and_derivative!(f!, y1_in, der1_in, ba, x, extras_tup...)
 
@@ -470,11 +567,12 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_gradient(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_gradient(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1, grad1 = value_and_gradient(f, ba, x, extras_tup...)
 
         grad2 = gradient(f, ba, x, extras_tup...)
@@ -499,11 +597,12 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:gradient,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_gradient(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_gradient(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         grad1_in = mysimilar(x)
         y1, grad1 = value_and_gradient!(f, grad1_in, ba, x, extras_tup...)
 
@@ -538,11 +637,12 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_jacobian(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_jacobian(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1, jac1 = value_and_jacobian(f, ba, x, extras_tup...)
 
         jac2 = jacobian(f, ba, x, extras_tup...)
@@ -567,11 +667,12 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:jacobian,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_jacobian(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_jacobian(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         jac1_in = mysimilar(new_scen.res1)
         y1, jac1 = value_and_jacobian!(f, jac1_in, ba, x, extras_tup...)
 
@@ -604,12 +705,15 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
     f! = f
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (), (prepare_jacobian(f!, mysimilar(y), ba, mycopy_random(x)),)
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1_in = mysimilar(y)
         y1, jac1 = value_and_jacobian(f!, y1_in, ba, x, extras_tup...)
 
@@ -637,12 +741,15 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:jacobian,2,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
     f! = f
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (), (prepare_jacobian(f!, mysimilar(y), ba, mycopy_random(x)),)
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         y1_in, jac1_in = mysimilar(y), mysimilar(new_scen.res1)
         y1, jac1 = value_and_jacobian!(f!, y1_in, jac1_in, ba, x, extras_tup...)
 
@@ -678,11 +785,12 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_second_derivative(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_second_derivative(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         der21 = second_derivative(f, ba, x, extras_tup...)
         y2, der12, der22 = value_derivative_and_second_derivative(f, ba, x, extras_tup...)
 
@@ -713,11 +821,12 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_second_derivative(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_second_derivative(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         der21_in = mysimilar(y)
         der21 = second_derivative!(f, der21_in, ba, x, extras_tup...)
 
@@ -754,13 +863,16 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:hvp,1,:outofplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (),
         (prepare_hvp(f, ba, mycopy_random(x), mycopy_random(seed)),),
         (prepare_hvp_same_point(f, ba, x, mycopy_random(seed)),),
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         dg1 = hvp(f, ba, x, seed, extras_tup...)
 
         let (≈)(x, y) = isapprox(x, y; atol, rtol)
@@ -779,13 +891,16 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:hvp,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, seed) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
+    extras_tup_candidates = [
         (),
         (prepare_hvp(f, ba, mycopy_random(x), mycopy_random(seed)),),
         (prepare_hvp_same_point(f, ba, x, mycopy_random(seed)),),
-    ])
+    ]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         dg1_in = mysimilar(x)
         dg1 = hvp!(f, dg1_in, ba, x, seed, extras_tup...)
 
@@ -812,11 +927,12 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_hessian(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_hessian(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         hess1 = hessian(f, ba, x, extras_tup...)
         y2, grad2, hess2 = value_gradient_and_hessian(f, ba, x, extras_tup...)
 
@@ -843,11 +959,12 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:hessian,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y) = new_scen = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
 
-    @testset "$(testset_name(k))" for (k, extras_tup) in enumerate([
-        (), (prepare_hessian(f, ba, mycopy_random(x)),)
-    ])
+    extras_tup_candidates = [(), (prepare_hessian(f, ba, mycopy_random(x)),)]
+
+    @testset "$(testset_name(k))" for (k, extras_tup) in
+                                      enumerate(vcat((), Tuple.(extras_tup_candidates)))
         hess1_in = mysimilar(new_scen.res2)
         hess1 = hessian!(f, hess1_in, ba, x, extras_tup...)
         grad2_in, hess2_in = mysimilar(new_scen.res1), mysimilar(new_scen.res2)

--- a/DifferentiationInterfaceTest/src/tests/correctness.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness.jl
@@ -20,7 +20,7 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = if seed isa Batch
         [
@@ -33,7 +33,7 @@ function test_correctness(
             prepare_pushforward_same_point(f, ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         if seed isa Batch
@@ -68,7 +68,7 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = if seed isa Batch
         [
@@ -81,7 +81,7 @@ function test_correctness(
             prepare_pushforward_same_point(f, ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         dy1_in = mysimilar(res1)
@@ -121,7 +121,7 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
     f! = f
 
     extras_candidates = if seed isa Batch
@@ -141,7 +141,7 @@ function test_correctness(
             prepare_pushforward_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1_in = mysimilar(y)
@@ -180,7 +180,7 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
     f! = f
 
     extras_candidates = if seed isa Batch
@@ -200,7 +200,7 @@ function test_correctness(
             prepare_pushforward_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1_in, dy1_in = mysimilar(y), mysimilar(res1)
@@ -245,7 +245,7 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = if seed isa Batch
         [
@@ -258,7 +258,7 @@ function test_correctness(
             prepare_pullback_same_point(f, ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         if seed isa Batch
@@ -289,7 +289,7 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:pullback,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = if seed isa Batch
         [
@@ -302,7 +302,7 @@ function test_correctness(
             prepare_pullback_same_point(f, ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         dx1_in = mysimilar(res1)
@@ -342,7 +342,7 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
     f! = f
 
     extras_candidates = if seed isa Batch
@@ -360,7 +360,7 @@ function test_correctness(
             prepare_pullback_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1_in = mysimilar(y)
@@ -395,7 +395,7 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:pullback,2,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
     f! = f
 
     extras_candidates = if seed isa Batch
@@ -413,7 +413,7 @@ function test_correctness(
             prepare_pullback_same_point(f!, mysimilar(y), ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1_in, dx1_in = mysimilar(y), mysimilar(res1)
@@ -458,10 +458,10 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_derivative(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1, der1 = value_and_derivative(f, ba, x, extras_tup...)
@@ -491,10 +491,10 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_derivative(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         der1_in = mysimilar(y)
@@ -529,11 +529,11 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
     f! = f
 
     extras_candidates = [prepare_derivative(f!, mysimilar(y), ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1_in = mysimilar(y)
@@ -567,11 +567,11 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
     f! = f
 
     extras_candidates = [prepare_derivative(f!, mysimilar(y), ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1_in, der1_in = mysimilar(y), mysimilar(y)
@@ -609,10 +609,10 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_gradient(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1, grad1 = value_and_gradient(f, ba, x, extras_tup...)
@@ -639,10 +639,10 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:gradient,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_gradient(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         grad1_in = mysimilar(x)
@@ -679,10 +679,10 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_jacobian(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1, jac1 = value_and_jacobian(f, ba, x, extras_tup...)
@@ -709,10 +709,10 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:jacobian,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_jacobian(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         jac1_in = mysimilar(new_scen.res1)
@@ -747,11 +747,11 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
     f! = f
 
     extras_candidates = [prepare_jacobian(f!, mysimilar(y), ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1_in = mysimilar(y)
@@ -781,11 +781,11 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:jacobian,2,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
     f! = f
 
     extras_candidates = [prepare_jacobian(f!, mysimilar(y), ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         y1_in, jac1_in = mysimilar(y), mysimilar(new_scen.res1)
@@ -823,10 +823,10 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_second_derivative(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         der21 = second_derivative(f, ba, x, extras_tup...)
@@ -859,10 +859,10 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_second_derivative(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         der21_in = mysimilar(y)
@@ -901,7 +901,7 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:hvp,1,:outofplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = if seed isa Batch
         [
@@ -914,7 +914,7 @@ function test_correctness(
             prepare_hvp_same_point(f, ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         if seed isa Batch
@@ -939,7 +939,7 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:hvp,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = if seed isa Batch
         [
@@ -952,7 +952,7 @@ function test_correctness(
             prepare_hvp_same_point(f, ba, x, mycopy_random(seed)),
         ]
     end
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         dg1_in = mysimilar(res2)
@@ -986,10 +986,10 @@ function test_correctness(
     atol,
     rtol,
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_hessian(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         hess1 = hessian(f, ba, x, extras_tup...)
@@ -1018,10 +1018,10 @@ end
 function test_correctness(
     ba::AbstractADType, scen::Scenario{:hessian,1,:inplace}; isapprox::Function, atol, rtol
 )
-    @compat (; f, x, y, seed, res1, res2) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1, res2) = new_scen = deepcopy(scen)
 
     extras_candidates = [prepare_hessian(f, ba, mycopy_random(x))]
-    extras_tup_candidates = vcat((), Tuple.(extras_candidates))
+    extras_tup_candidates = vcat((), tuple.(extras_candidates))
 
     @testset "$(testset_name(k))" for (k, extras_tup) in enumerate(extras_tup_candidates)
         hess1_in = mysimilar(new_scen.res2)

--- a/DifferentiationInterfaceTest/src/utils/misc.jl
+++ b/DifferentiationInterfaceTest/src/utils/misc.jl
@@ -1,5 +1,10 @@
 mysimilar(x::AbstractArray) = similar(x)
+mysimilar(x::Batch) = Batch(map(mysimilar, x.elements))
 
 mycopy_random(x) = mycopy_random(default_rng(), x)
 mycopy_random(rng::AbstractRNG, x::Number) = randn(rng, typeof(x))
 mycopy_random(rng::AbstractRNG, x::AbstractArray) = map(Base.Fix1(mycopy_random, rng), x)
+
+function mycopy_random(rng::AbstractRNG, x::Batch)
+    return Batch(map(Base.Fix1(mycopy_random, rng), x.elements))
+end

--- a/DifferentiationInterfaceTest/test/zero.jl
+++ b/DifferentiationInterfaceTest/test/zero.jl
@@ -1,7 +1,12 @@
 using DifferentiationInterface
 using DifferentiationInterfaceTest
 using DifferentiationInterfaceTest:
-    AutoZeroForward, AutoZeroReverse, scenario_to_zero, test_allocfree, allocfree_scenarios
+    AutoZeroForward,
+    AutoZeroReverse,
+    scenario_to_zero,
+    test_allocfree,
+    allocfree_scenarios,
+    add_batchified!
 
 using Test
 
@@ -14,7 +19,7 @@ using Test
 
 test_differentiation(
     [AutoZeroForward(), AutoZeroReverse()],
-    scenario_to_zero.(default_scenarios());
+    add_batchified!(scenario_to_zero.(default_scenarios()));
     correctness=true,
     type_stability=true,
     logging=LOGGING,
@@ -25,7 +30,7 @@ test_differentiation(
         SecondOrder(AutoZeroForward(), AutoZeroReverse()),
         SecondOrder(AutoZeroReverse(), AutoZeroForward()),
     ],
-    scenario_to_zero.(default_scenarios(; linalg=false));
+    add_batchified!(scenario_to_zero.(default_scenarios(; linalg=false)));
     correctness=true,
     type_stability=true,
     first_order=false,


### PR DESCRIPTION
**DI source**

- Split batched `pushforward`, `pullback` and `hvp` into their own files
- Give them the same methods as their non-batched counterparts

**DI extensions**

- Improve batched mode in ForwardDiff and replace `map` with broadcast

**DI tests**

- Separate `FromPrimitive` tests in `Single/ForwardDiff`
- Test `FromPrimitive` and ForwardDiff on batchified scenarios

**DIT source**

- Add correctness tests for batched operators
- Improve test interruption by adding `yield()` to inner loops

**DIT tests**

- Test zero backends on batchified scenarios