### PR TITLE
Remove custom printing

### DIFF
--- a/DifferentiationInterface/docs/src/backends.md
+++ b/DifferentiationInterface/docs/src/backends.md
@@ -9,7 +9,6 @@ We support all dense backend choices from [ADTypes.jl](https://github.com/SciML/
 
 ```@setup backends
 using DifferentiationInterface
-using DifferentiationInterface: backend_str
 import Markdown
 
 import Diffractor
@@ -25,21 +24,21 @@ import Tapir
 import Tracker
 import Zygote
 
-const backend_examples = (
-    "AutoDiffractor()",
-    "AutoEnzyme(; mode=Enzyme.Forward)",
-    "AutoEnzyme(; mode=Enzyme.Reverse)",
-    "AutoFastDifferentiation()",
-    "AutoFiniteDiff()",
-    "AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1))",
-    "AutoForwardDiff()",
-    "AutoPolyesterForwardDiff(; chunksize=1)",
-    "AutoReverseDiff()",
-    "AutoSymbolics()",
-    "AutoTapir(; safe_mode=false)",
-    "AutoTracker()",
-    "AutoZygote()",
-)
+backend_examples = [
+    AutoDiffractor(),
+    AutoEnzyme(; mode=Enzyme.Forward),
+    AutoEnzyme(; mode=Enzyme.Reverse),
+    AutoFastDifferentiation(),
+    AutoFiniteDiff(),
+    AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),
+    AutoForwardDiff(),
+    AutoPolyesterForwardDiff(; chunksize=1),
+    AutoReverseDiff(),
+    AutoSymbolics(),
+    AutoTapir(; safe_mode=false),
+    AutoTracker(),
+    AutoZygote(),
+]
 
 checkmark(x::Bool) = x ? '✅' : '❌'
 unicode_check_available(backend) = checkmark(check_available(backend))
@@ -49,12 +48,11 @@ unicode_check_twoarg(backend)    = checkmark(check_twoarg(backend))
 io = IOBuffer()
 
 # Table header 
-println(io, "| Backend | Availability | Two-argument functions | Hessian support | Example |")
-println(io, "|:--------|:------------:|:----------------------:|:---------------:|:--------|")
+println(io, "| Backend | Availability | Two-argument functions | Hessian support |")
+println(io, "|:--------|:------------:|:----------------------:|:---------------:|")
 
-for example in backend_examples
-    b = eval(Meta.parse(example)) # backend
-    join(io, [backend_str(b), unicode_check_available(b), unicode_check_twoarg(b), unicode_check_hessian(b), "`$example`"], '|')
+for b in backend_examples
+    join(io, [string(b), unicode_check_available(b), unicode_check_twoarg(b), unicode_check_hessian(b)], '|')
     println(io, '|' )
 end
 backend_table = Markdown.parse(String(take!(io)))

--- a/DifferentiationInterface/docs/src/overloads.md
+++ b/DifferentiationInterface/docs/src/overloads.md
@@ -22,7 +22,7 @@ The cells can have three values:
 ```@setup overloads
 using ADTypes: AbstractADType
 using DifferentiationInterface
-using DifferentiationInterface: backend_str, twoarg_support, TwoArgSupported
+using DifferentiationInterface: twoarg_support, TwoArgSupported
 using Markdown: Markdown
 
 using Diffractor: Diffractor

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -43,7 +43,7 @@ end
 
 ADTypes.mode(backend::AutoDeferredEnzyme) = ADTypes.mode(AutoEnzyme(backend.mode))
 
-DI.backend_package_name(::AutoDeferredEnzyme) = "DeferredEnzyme"
+DI.package_name(::AutoDeferredEnzyme) = "Enzyme"
 
 DI.nested(backend::AutoEnzyme) = AutoDeferredEnzyme(backend.mode)
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -43,8 +43,6 @@ end
 
 ADTypes.mode(backend::AutoDeferredEnzyme) = ADTypes.mode(AutoEnzyme(backend.mode))
 
-DI.package_name(::AutoDeferredEnzyme) = "Enzyme"
-
 DI.nested(backend::AutoEnzyme) = AutoDeferredEnzyme(backend.mode)
 
 const AnyAutoEnzyme{M} = Union{AutoEnzyme{M},AutoDeferredEnzyme{M}}

--- a/DifferentiationInterface/src/misc/differentiate_with.jl
+++ b/DifferentiationInterface/src/misc/differentiate_with.jl
@@ -55,7 +55,6 @@ Call the underlying function `dw.f` of a [`DifferentiateWith`](@ref) wrapper.
 function Base.show(io::IO, dw::DifferentiateWith)
     @compat (; f, backend) = dw
     return print(
-        io,
-        "$(repr(DifferentiateWith; context=io))($(repr(f; context=io)), $(repr(backend; context=io)))",
+        io, DifferentiateWith, "(", repr(f; context=io), ",", repr(backend; context=io), ")"
     )
 end

--- a/DifferentiationInterface/src/misc/differentiate_with.jl
+++ b/DifferentiationInterface/src/misc/differentiate_with.jl
@@ -54,5 +54,7 @@ Call the underlying function `dw.f` of a [`DifferentiateWith`](@ref) wrapper.
 
 function Base.show(io::IO, dw::DifferentiateWith)
     @compat (; f, backend) = dw
-    return print(io, "$f differentiated with $(backend_str(backend))")
+    return print(
+        io, "DifferentiateWith($(repr(f; context=io)), $(repr(backend; context=io))"
+    )
 end

--- a/DifferentiationInterface/src/misc/differentiate_with.jl
+++ b/DifferentiationInterface/src/misc/differentiate_with.jl
@@ -55,6 +55,7 @@ Call the underlying function `dw.f` of a [`DifferentiateWith`](@ref) wrapper.
 function Base.show(io::IO, dw::DifferentiateWith)
     @compat (; f, backend) = dw
     return print(
-        io, "DifferentiateWith($(repr(f; context=io)), $(repr(backend; context=io))"
+        io,
+        "$(repr(DifferentiateWith; context=io))($(repr(f; context=io)), $(repr(backend; context=io)))",
     )
 end

--- a/DifferentiationInterface/src/misc/sparsity_detector.jl
+++ b/DifferentiationInterface/src/misc/sparsity_detector.jl
@@ -75,7 +75,12 @@ function Base.show(io::IO, detector::DenseSparsityDetector{method}) where {metho
     @compat (; backend, atol) = detector
     return print(
         io,
-        "$(repr(DenseSparsityDetector; context=io))($(repr(backend; context=io)); atol=$atol, method=$(repr(method; context=io)))",
+        DenseSparsityDetector,
+        "(",
+        repr(backend; context=io),
+        "; atol=$atol, method=",
+        repr(method; context=io),
+        ")",
     )
 end
 

--- a/DifferentiationInterface/src/misc/sparsity_detector.jl
+++ b/DifferentiationInterface/src/misc/sparsity_detector.jl
@@ -73,7 +73,10 @@ end
 
 function Base.show(io::IO, detector::DenseSparsityDetector{method}) where {method}
     @compat (; backend, atol) = detector
-    return print(io, "DenseSparsityDetector{:$method}($backend; atol=$atol)")
+    return print(
+        io,
+        "$(repr(DenseSparsityDetector; context=io))($(repr(backend; context=io)); atol=$atol, method=$(repr(method; context=io)))",
+    )
 end
 
 function DenseSparsityDetector(

--- a/DifferentiationInterface/src/second_order/second_order.jl
+++ b/DifferentiationInterface/src/second_order/second_order.jl
@@ -24,7 +24,12 @@ end
 function Base.show(io::IO, backend::SecondOrder)
     return print(
         io,
-        "$(repr(SecondOrder; context=io))($(repr(outer(backend); context=io)), $(repr(inner(backend); context=io)))",
+        SecondOrder,
+        "(",
+        repr(outer(backend); context=io),
+        ", ",
+        repr(inner(backend); context=io),
+        ")",
     )
 end
 

--- a/DifferentiationInterface/src/second_order/second_order.jl
+++ b/DifferentiationInterface/src/second_order/second_order.jl
@@ -24,7 +24,7 @@ end
 function Base.show(io::IO, backend::SecondOrder)
     return print(
         io,
-        "SecondOrder($(repr(outer(backend); context=io)), $(repr(inner(backend); context=io)))",
+        "$(repr(SecondOrder; context=io))($(repr(outer(backend); context=io)), $(repr(inner(backend); context=io)))",
     )
 end
 

--- a/DifferentiationInterface/src/second_order/second_order.jl
+++ b/DifferentiationInterface/src/second_order/second_order.jl
@@ -22,7 +22,10 @@ struct SecondOrder{ADO<:AbstractADType,ADI<:AbstractADType} <: AbstractADType
 end
 
 function Base.show(io::IO, backend::SecondOrder)
-    return print(io, "SecondOrder($(outer(backend)) / $(inner(backend)))")
+    return print(
+        io,
+        "SecondOrder($(repr(outer(backend); context=io)), $(repr(inner(backend); context=io)))",
+    )
 end
 
 """

--- a/DifferentiationInterface/src/utils/exceptions.jl
+++ b/DifferentiationInterface/src/utils/exceptions.jl
@@ -3,13 +3,13 @@ struct MissingBackendError <: Exception
 end
 
 function Base.showerror(io::IO, e::MissingBackendError)
-    println(io, "failed to use $(backend_str(e.backend)) backend.")
+    println(io, "MissingBackendError: Failed to use $(e.backend).")
     if !check_available(e.backend)
         print(
             io,
-            """Backend package is not loaded. To fix, run
+            """Backend package is probably not loaded. To fix this, try to run
 
-              import $(backend_package_name(e.backend))
+                import $(package_name(e.backend))
             """,
         )
     else

--- a/DifferentiationInterface/src/utils/printing.jl
+++ b/DifferentiationInterface/src/utils/printing.jl
@@ -1,40 +1,6 @@
-backend_package_name(b::AbstractADType) = strip(string(b), ['(', ')'])
-backend_package_name(b::AutoSparse) = backend_package_name(dense_ad(b))
-
-backend_package_name(::AutoChainRules) = "ChainRules"
-backend_package_name(::AutoDiffractor) = "Diffractor"
-backend_package_name(::AutoEnzyme) = "Enzyme"
-backend_package_name(::AutoFastDifferentiation) = "FastDifferentiation"
-backend_package_name(::AutoFiniteDiff) = "FiniteDiff"
-backend_package_name(::AutoFiniteDifferences) = "FiniteDifferences"
-backend_package_name(::AutoForwardDiff) = "ForwardDiff"
-backend_package_name(::AutoPolyesterForwardDiff) = "PolyesterForwardDiff"
-backend_package_name(::AutoSymbolics) = "Symbolics"
-backend_package_name(::AutoTapir) = "Tapir"
-backend_package_name(::AutoTracker) = "Tracker"
-backend_package_name(::AutoZygote) = "Zygote"
-backend_package_name(::AutoReverseDiff) = "ReverseDiff"
-
-backend_package_name(::AF) where {AF<:AutoForwardFromPrimitive} = string(AF)
-backend_package_name(::AR) where {AR<:AutoReverseFromPrimitive} = string(AR)
-
-function backend_str(backend::AbstractADType)
-    bs = backend_package_name(backend)
-    if mode(backend) isa ForwardMode
-        return "$bs (forward)"
-    elseif mode(backend) isa ReverseMode
-        return "$bs (reverse)"
-    elseif mode(backend) isa SymbolicMode
-        return "$bs (symbolic)"
-    elseif mode(backend) isa ForwardOrReverseMode
-        return "$bs (forward or reverse)"
-    else
-        error("Unknown mode")
-    end
+function package_name(b::AbstractADType)
+    s = string(b)
+    return s[5:(findfirst('(', s) - 1)]
 end
 
-backend_str(backend::AutoSparse) = "Sparse $(backend_str(dense_ad(backend)))"
-
-function backend_str(backend::SecondOrder)
-    return "$(backend_str(outer(backend))) / $(backend_str(inner(backend)))"
-end
+package_name(b::AutoSparse) = package_name(dense_ad(b))

--- a/DifferentiationInterface/src/utils/printing.jl
+++ b/DifferentiationInterface/src/utils/printing.jl
@@ -1,6 +1,11 @@
 function package_name(b::AbstractADType)
     s = string(b)
-    return s[5:(findfirst('(', s) - 1)]
+    k = findfirst('(', s)
+    if isnothing(k)
+        throw(ArgumentError("Cannot parse backend into package"))
+    else
+        return s[5:(k - 1)]
+    end
 end
 
 package_name(b::AutoSparse) = package_name(dense_ad(b))

--- a/DifferentiationInterface/test/Internals/display.jl
+++ b/DifferentiationInterface/test/Internals/display.jl
@@ -1,0 +1,15 @@
+using ADTypes
+using DifferentiationInterface
+using Test
+
+backend = SecondOrder(AutoForwardDiff(), AutoZygote())
+@test startswith(string(backend), "SecondOrder(")
+@test endswith(string(backend), ")")
+
+detector = DenseSparsityDetector(AutoForwardDiff(); atol=1e-23)
+@test startswith(string(detector), "DenseSparsityDetector(")
+@test endswith(string(detector), ")")
+
+diffwith = DifferentiateWith(exp, AutoForwardDiff())
+@test startswith(string(diffwith), "DifferentiateWith(")
+@test endswith(string(diffwith), ")")

--- a/DifferentiationInterface/test/Internals/display.jl
+++ b/DifferentiationInterface/test/Internals/display.jl
@@ -13,3 +13,6 @@ detector = DenseSparsityDetector(AutoForwardDiff(); atol=1e-23)
 diffwith = DifferentiateWith(exp, AutoForwardDiff())
 @test startswith(string(diffwith), "DifferentiateWith(")
 @test endswith(string(diffwith), ")")
+
+@test DifferentiationInterface.package_name(AutoForwardDiff()) == "ForwardDiff"
+@test DifferentiationInterface.package_name(AutoZygote()) == "Zygote"

--- a/DifferentiationInterface/test/Internals/second_order.jl
+++ b/DifferentiationInterface/test/Internals/second_order.jl
@@ -5,6 +5,5 @@ using Test
 backend = SecondOrder(AutoForwardDiff(), AutoZygote())
 
 @test ADTypes.mode(backend) isa ADTypes.ForwardMode
-@test startswith(string(backend), "SecondOrder")
 @test DifferentiationInterface.outer(backend) isa AutoForwardDiff
 @test DifferentiationInterface.inner(backend) isa AutoZygote

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -23,7 +23,6 @@ using ComponentArrays: ComponentVector
 using DataFrames: DataFrame
 using DifferentiationInterface
 using DifferentiationInterface:
-    backend_str,
     inner,
     maybe_inner,
     maybe_dense_ad,

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -78,8 +78,7 @@ function test_differentiation(
     prog = ProgressUnknown(; desc="$title", spinner=true, enabled=logging)
 
     @testset verbose = true "$title" begin
-        @testset verbose = detailed "$(backend_str(backend))" for (i, backend) in
-                                                                  enumerate(backends)
+        @testset verbose = detailed "$backend" for (i, backend) in enumerate(backends)
             filtered_scenarios = filter(s -> compatible(backend, s), scenarios)
             grouped_scenarios = group_by_operator(filtered_scenarios)
             @testset verbose = detailed "$op" for (j, (op, op_group)) in
@@ -88,7 +87,7 @@ function test_differentiation(
                     next!(
                         prog;
                         showvalues=[
-                            (:backend, "$(backend_str(backend)) - $i/$(length(backends))"),
+                            (:backend, "$backend - $i/$(length(backends))"),
                             (:scenario_type, "$op - $j/$(length(grouped_scenarios))"),
                             (:scenario, "$k/$(length(op_group))"),
                             (:arguments, nb_args(scen)),
@@ -175,7 +174,7 @@ function benchmark_differentiation(
                 next!(
                     prog;
                     showvalues=[
-                        (:backend, "$(backend_str(backend)) - $i/$(length(backends))"),
+                        (:backend, "$backend - $i/$(length(backends))"),
                         (:scenario_type, "$op - $j/$(length(grouped_scenarios))"),
                         (:scenario, "$k/$(length(op_group))"),
                         (:arguments, nb_args(scen)),


### PR DESCRIPTION
Following https://github.com/SciML/ADTypes.jl/pull/64, there is no more need for the custom printing utilities in DI.

**DI source**

- Remove `backend_str`, replace `backend_package_name` with `package_name` (with a much simpler implementation that extracts `"Something"` from `"AutoSomething(...)"`.
- Fix display of `SecondOrder` and `DifferentiateWith`

**DI docs**

- Remove uses of `backend_str`

**DIT source**

- Remove uses of `backend_str`