### PR TITLE
Better seed handling in Jacobian and Hessian

### DIFF
--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -11,87 +11,114 @@ end
 
 ADTypes.mode(::AutoForwardFromPrimitive) = ADTypes.ForwardMode()
 
+struct FromPrimitivePushforwardExtras{E<:PushforwardExtras} <: PushforwardExtras
+    pushforward_extras::E
+end
+
 ### Standard
 
 function prepare_pushforward(f, fromprim::AutoForwardFromPrimitive, x, dx)
-    return prepare_pushforward(f, fromprim.backend, x, dx)
+    return FromPrimitivePushforwardExtras(prepare_pushforward(f, fromprim.backend, x, dx))
 end
 
 function prepare_pushforward(f!, y, fromprim::AutoForwardFromPrimitive, x, dx)
-    return prepare_pushforward(f!, y, fromprim.backend, x, dx)
+    return FromPrimitivePushforwardExtras(
+        prepare_pushforward(f!, y, fromprim.backend, x, dx)
+    )
 end
 
 function value_and_pushforward(
-    f, fromprim::AutoForwardFromPrimitive, x, dx, extras::PushforwardExtras
+    f, fromprim::AutoForwardFromPrimitive, x, dx, extras::FromPrimitivePushforwardExtras
 )
-    return value_and_pushforward(f, fromprim.backend, x, dx, extras)
+    return value_and_pushforward(f, fromprim.backend, x, dx, extras.pushforward_extras)
 end
 
 function value_and_pushforward(
-    f!, y, fromprim::AutoForwardFromPrimitive, x, dx, extras::PushforwardExtras
+    f!, y, fromprim::AutoForwardFromPrimitive, x, dx, extras::FromPrimitivePushforwardExtras
 )
-    return value_and_pushforward(f!, y, fromprim.backend, x, dx, extras)
+    return value_and_pushforward(f!, y, fromprim.backend, x, dx, extras.pushforward_extras)
 end
 
 function value_and_pushforward!(
-    f, dy, fromprim::AutoForwardFromPrimitive, x, dx, extras::PushforwardExtras
+    f, dy, fromprim::AutoForwardFromPrimitive, x, dx, extras::FromPrimitivePushforwardExtras
 )
-    return value_and_pushforward!(f, dy, fromprim.backend, x, dx, extras)
+    return value_and_pushforward!(f, dy, fromprim.backend, x, dx, extras.pushforward_extras)
 end
 
 function value_and_pushforward!(
-    f!, y, dy, fromprim::AutoForwardFromPrimitive, x, dx, extras::PushforwardExtras
+    f!,
+    y,
+    dy,
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    dx,
+    extras::FromPrimitivePushforwardExtras,
 )
-    return value_and_pushforward!(f!, y, dy, fromprim.backend, x, dx, extras)
+    return value_and_pushforward!(
+        f!, y, dy, fromprim.backend, x, dx, extras.pushforward_extras
+    )
 end
 
 ### Batched
 
-function prepare_pushforward_batched(
-    f, fromprim::AutoForwardFromPrimitive, x, dx::Batch{B}
-) where {B}
-    return prepare_pushforward_batched(f, fromprim.backend, x, dx)
+function prepare_pushforward_batched(f, fromprim::AutoForwardFromPrimitive, x, dx::Batch)
+    return FromPrimitivePushforwardExtras(
+        prepare_pushforward_batched(f, fromprim.backend, x, dx)
+    )
 end
 
 function prepare_pushforward_batched(
-    f!, y, fromprim::AutoForwardFromPrimitive, x, dx::Batch{B}
-) where {B}
-    return prepare_pushforward_batched(f!, y, fromprim.backend, x, dx)
+    f!, y, fromprim::AutoForwardFromPrimitive, x, dx::Batch
+)
+    return FromPrimitivePushforwardExtras(
+        prepare_pushforward_batched(f!, y, fromprim.backend, x, dx)
+    )
 end
 
 function pushforward_batched(
-    f, fromprim::AutoForwardFromPrimitive, x, dx::Batch{B}, extras::PushforwardExtras
-) where {B}
-    return pushforward_batched(f, fromprim.backend, x, dx, extras)
+    f,
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    dx::Batch,
+    extras::FromPrimitivePushforwardExtras,
+)
+    return pushforward_batched(f, fromprim.backend, x, dx, extras.pushforward_extras)
 end
 
 function pushforward_batched(
-    f!, y, fromprim::AutoForwardFromPrimitive, x, dx::Batch{B}, extras::PushforwardExtras
-) where {B}
-    return pushforward_batched(f!, y, fromprim.backend, x, dx, extras)
+    f!,
+    y,
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    dx::Batch,
+    extras::FromPrimitivePushforwardExtras,
+)
+    return pushforward_batched(f!, y, fromprim.backend, x, dx, extras.pushforward_extras)
 end
 
 function pushforward_batched!(
     f,
-    dy::Batch{B},
+    dy::Batch,
     fromprim::AutoForwardFromPrimitive,
     x,
-    dx::Batch{B},
-    extras::PushforwardExtras,
-) where {B}
-    return pushforward_batched!(f, dy, fromprim.backend, x, dx, extras)
+    dx::Batch,
+    extras::FromPrimitivePushforwardExtras,
+)
+    return pushforward_batched!(f, dy, fromprim.backend, x, dx, extras.pushforward_extras)
 end
 
 function pushforward_batched!(
     f!,
     y,
-    dy::Batch{B},
+    dy::Batch,
     fromprim::AutoForwardFromPrimitive,
     x,
-    dx::Batch{B},
-    extras::PushforwardExtras,
-) where {B}
-    return pushforward_batched!(f!, y, dy, fromprim.backend, x, dx, extras)
+    dx::Batch,
+    extras::FromPrimitivePushforwardExtras,
+)
+    return pushforward_batched!(
+        f!, y, dy, fromprim.backend, x, dx, extras.pushforward_extras
+    )
 end
 
 ## Reverse
@@ -102,85 +129,98 @@ end
 
 ADTypes.mode(::AutoReverseFromPrimitive) = ADTypes.ReverseMode()
 
+struct FromPrimitivePullbackExtras{E<:PullbackExtras} <: PullbackExtras
+    pullback_extras::E
+end
+
 ### Standard
 
 function prepare_pullback(f, fromprim::AutoReverseFromPrimitive, x, dy)
-    return prepare_pullback(f, fromprim.backend, x, dy)
+    return FromPrimitivePullbackExtras(prepare_pullback(f, fromprim.backend, x, dy))
 end
 
 function prepare_pullback(f!, y, fromprim::AutoReverseFromPrimitive, x, dy)
-    return prepare_pullback(f!, y, fromprim.backend, x, dy)
+    return FromPrimitivePullbackExtras(prepare_pullback(f!, y, fromprim.backend, x, dy))
 end
 
 function value_and_pullback(
-    f, fromprim::AutoReverseFromPrimitive, x, dy, extras::PullbackExtras
+    f, fromprim::AutoReverseFromPrimitive, x, dy, extras::FromPrimitivePullbackExtras
 )
-    return value_and_pullback(f, fromprim.backend, x, dy, extras)
+    return value_and_pullback(f, fromprim.backend, x, dy, extras.pullback_extras)
 end
 
 function value_and_pullback(
-    f!, y, fromprim::AutoReverseFromPrimitive, x, dy, extras::PullbackExtras
+    f!, y, fromprim::AutoReverseFromPrimitive, x, dy, extras::FromPrimitivePullbackExtras
 )
-    return value_and_pullback(f!, y, fromprim.backend, x, dy, extras)
+    return value_and_pullback(f!, y, fromprim.backend, x, dy, extras.pullback_extras)
 end
 
 function value_and_pullback!(
-    f, dx, fromprim::AutoReverseFromPrimitive, x, dy, extras::PullbackExtras
+    f, dx, fromprim::AutoReverseFromPrimitive, x, dy, extras::FromPrimitivePullbackExtras
 )
-    return value_and_pullback!(f, dx, fromprim.backend, x, dy, extras)
+    return value_and_pullback!(f, dx, fromprim.backend, x, dy, extras.pullback_extras)
 end
 
 function value_and_pullback!(
-    f!, y, dx, fromprim::AutoReverseFromPrimitive, x, dy, extras::PullbackExtras
+    f!,
+    y,
+    dx,
+    fromprim::AutoReverseFromPrimitive,
+    x,
+    dy,
+    extras::FromPrimitivePullbackExtras,
 )
-    return value_and_pullback!(f!, y, dx, fromprim.backend, x, dy, extras)
+    return value_and_pullback!(f!, y, dx, fromprim.backend, x, dy, extras.pullback_extras)
 end
 
 ### Batched
 
-function prepare_pullback_batched(
-    f, fromprim::AutoReverseFromPrimitive, x, dy::Batch{B}
-) where {B}
-    return prepare_pullback_batched(f, fromprim.backend, x, dy)
+function prepare_pullback_batched(f, fromprim::AutoReverseFromPrimitive, x, dy::Batch)
+    return FromPrimitivePullbackExtras(prepare_pullback_batched(f, fromprim.backend, x, dy))
 end
 
-function prepare_pullback_batched(
-    f!, y, fromprim::AutoReverseFromPrimitive, x, dy::Batch{B}
-) where {B}
-    return prepare_pullback_batched(f!, y, fromprim.backend, x, dy)
-end
-
-function pullback_batched(
-    f, fromprim::AutoReverseFromPrimitive, x, dy::Batch{B}, extras::PullbackExtras
-) where {B}
-    return pullback_batched(f, fromprim.backend, x, dy, extras)
+function prepare_pullback_batched(f!, y, fromprim::AutoReverseFromPrimitive, x, dy::Batch)
+    return FromPrimitivePullbackExtras(
+        prepare_pullback_batched(f!, y, fromprim.backend, x, dy)
+    )
 end
 
 function pullback_batched(
-    f!, y, fromprim::AutoReverseFromPrimitive, x, dy::Batch{B}, extras::PullbackExtras
-) where {B}
-    return pullback_batched(f!, y, fromprim.backend, x, dy, extras)
+    f, fromprim::AutoReverseFromPrimitive, x, dy::Batch, extras::FromPrimitivePullbackExtras
+)
+    return pullback_batched(f, fromprim.backend, x, dy, extras.pullback_extras)
+end
+
+function pullback_batched(
+    f!,
+    y,
+    fromprim::AutoReverseFromPrimitive,
+    x,
+    dy::Batch,
+    extras::FromPrimitivePullbackExtras,
+)
+    return pullback_batched(f!, y, fromprim.backend, x, dy, extras.pullback_extras)
 end
 
 function pullback_batched!(
     f,
-    dx::Batch{B},
+    dx::Batch,
     fromprim::AutoReverseFromPrimitive,
     x,
-    dy::Batch{B},
-    extras::PullbackExtras,
-) where {B}
-    return pullback_batched!(f, dx, fromprim.backend, x, dy, extras)
+    dy::Batch,
+    extras::FromPrimitivePullbackExtras,
+)
+    return pullback_batched!(f, dx, fromprim.backend, x, dy, extras.pullback_extras)
 end
 
 function pullback_batched!(
     f!,
     y,
-    dx::Batch{B},
+    dx::Batch,
     fromprim::AutoReverseFromPrimitive,
     x,
-    dy::Batch{B},
-    extras::PullbackExtras,
-) where {B}
-    return pullback_batched!(f!, y, dx, fromprim.backend, x, dy, extras)
+    dy::Batch,
+    extras::FromPrimitivePullbackExtras,
+)
+    return pullback_batched!(f!, y, dx, fromprim.backend, x, dy, extras.pullback_extras)
 end

--- a/DifferentiationInterface/src/sparse/jacobian.jl
+++ b/DifferentiationInterface/src/sparse/jacobian.jl
@@ -3,63 +3,70 @@
 abstract type SparseJacobianExtras <: JacobianExtras end
 
 struct PushforwardSparseJacobianExtras{
-    B,
-    S<:AbstractMatrix{Bool},
-    C<:AbstractMatrix{<:Real},
-    K<:AbstractVector{<:Integer},
-    D<:AbstractVector,
-    P<:AbstractVector,
-    E<:PushforwardExtras,
+    B,S<:AbstractMatrix{Bool},C<:AbstractMatrix{<:Real},D,E<:PushforwardExtras,Y
 } <: SparseJacobianExtras
     sparsity::S
+    colors::Vector{Int}
+    groups::Vector{Vector{Int}}
     compressed::C
-    colors::K
-    seeds::D
-    products::P
+    batched_seeds::Vector{Batch{B,D}}
     pushforward_batched_extras::E
+    y_example::Y
 end
 
 struct PullbackSparseJacobianExtras{
-    B,
-    S<:AbstractMatrix{Bool},
-    C<:AbstractMatrix{<:Real},
-    K<:AbstractVector{<:Integer},
-    D<:AbstractVector,
-    P<:AbstractVector,
-    E<:PullbackExtras,
+    B,S<:AbstractMatrix{Bool},C<:AbstractMatrix{<:Real},D,E<:PullbackExtras,Y
 } <: SparseJacobianExtras
     sparsity::S
+    colors::Vector{Int}
+    groups::Vector{Vector{Int}}
     compressed::C
-    colors::K
-    seeds::D
-    products::P
+    batched_seeds::Vector{Batch{B,D}}
     pullback_batched_extras::E
+    y_example::Y
 end
 
 function PushforwardSparseJacobianExtras{B}(;
     sparsity::S,
+    colors,
+    groups,
     compressed::C,
-    colors::K,
-    seeds::D,
-    products::P,
+    batched_seeds::Vector{Batch{B,D}},
     pushforward_batched_extras::E,
-) where {B,S,C,K,D,P,E}
-    @assert length(seeds) == length(products) == size(compressed, 2)
+    y_example::Y,
+) where {B,S,C,D,E,Y}
     @assert size(sparsity, 1) == size(compressed, 1)
     @assert size(sparsity, 2) == length(colors)
-    return PushforwardSparseJacobianExtras{B,S,C,K,D,P,E}(
-        sparsity, compressed, colors, seeds, products, pushforward_batched_extras
+    return PushforwardSparseJacobianExtras{B,S,C,D,E,Y}(
+        sparsity,
+        colors,
+        groups,
+        compressed,
+        batched_seeds,
+        pushforward_batched_extras,
+        y_example,
     )
 end
 
 function PullbackSparseJacobianExtras{B}(;
-    sparsity::S, compressed::C, colors::K, seeds::D, products::P, pullback_batched_extras::E
-) where {B,S,C,K,D,P,E}
-    @assert length(seeds) == length(products) == size(compressed, 1)
+    sparsity::S,
+    colors,
+    groups,
+    compressed::C,
+    batched_seeds::Vector{Batch{B,D}},
+    pullback_batched_extras::E,
+    y_example::Y,
+) where {B,S,C,D,E,Y}
     @assert size(sparsity, 2) == size(compressed, 2)
     @assert size(sparsity, 1) == length(colors)
-    return PullbackSparseJacobianExtras{B,S,C,K,D,P,E}(
-        sparsity, compressed, colors, seeds, products, pullback_batched_extras
+    return PullbackSparseJacobianExtras{B,S,C,D,E,Y}(
+        sparsity,
+        colors,
+        groups,
+        compressed,
+        batched_seeds,
+        pullback_batched_extras,
+        y_example,
     )
 end
 
@@ -84,17 +91,26 @@ function prepare_sparse_jacobian_aux(
     sparsity = col_major(initial_sparsity)
     colors = column_coloring(sparsity, coloring_algorithm(backend))
     groups = color_groups(colors)
+    Ng = length(groups)
+    B = pick_batchsize(dense_backend, Ng)
     seeds = map(group -> make_seed(x, group), groups)
-    G = length(seeds)
-    B = pick_batchsize(dense_backend, G)
-    dx_batch = Batch(ntuple(Returns(seeds[1]), Val(B)))
+    compressed = stack(_ -> vec(similar(y)), groups; dims=2)
+    batched_seeds =
+        Batch.([
+            ntuple(b -> seeds[1 + ((a - 1) * B + (b - 1)) % Ng], Val(B)) for
+            a in 1:div(Ng, B, RoundUp)
+        ])
     pushforward_batched_extras = prepare_pushforward_batched(
-        f_or_f!y..., dense_backend, x, dx_batch
+        f_or_f!y..., dense_backend, x, batched_seeds[1]
     )
-    products = map(_ -> similar(y), seeds)
-    compressed = stack(vec, products; dims=2)
     return PushforwardSparseJacobianExtras{B}(;
-        sparsity, compressed, colors, seeds, products, pushforward_batched_extras
+        sparsity,
+        colors,
+        groups,
+        compressed,
+        batched_seeds,
+        pushforward_batched_extras,
+        y_example=copy(y),
     )
 end
 
@@ -106,17 +122,26 @@ function prepare_sparse_jacobian_aux(
     sparsity = row_major(initial_sparsity)
     colors = row_coloring(sparsity, coloring_algorithm(backend))
     groups = color_groups(colors)
+    Ng = length(groups)
+    B = pick_batchsize(dense_backend, Ng)
     seeds = map(group -> make_seed(y, group), groups)
-    G = length(seeds)
-    B = pick_batchsize(dense_backend, G)
-    dx_batch = Batch(ntuple(Returns(seeds[1]), Val(B)))
+    compressed = stack(_ -> vec(similar(x)), groups; dims=1)
+    batched_seeds =
+        Batch.([
+            ntuple(b -> seeds[1 + ((a - 1) * B + (b - 1)) % Ng], Val(B)) for
+            a in 1:div(Ng, B, RoundUp)
+        ])
     pullback_batched_extras = prepare_pullback_batched(
-        f_or_f!y..., dense_backend, x, dx_batch
+        f_or_f!y..., dense_backend, x, batched_seeds[1]
     )
-    products = map(_ -> similar(x), seeds)
-    compressed = stack(vec, products; dims=1)
     return PullbackSparseJacobianExtras{B}(;
-        sparsity, compressed, colors, seeds, products, pullback_batched_extras
+        sparsity,
+        colors,
+        groups,
+        compressed,
+        batched_seeds,
+        pullback_batched_extras,
+        y_example=copy(y),
     )
 end
 
@@ -177,36 +202,30 @@ end
 function sparse_jacobian_aux(
     f_or_f!y::FY, backend::AutoSparse, x, extras::PushforwardSparseJacobianExtras{B}
 ) where {FY,B}
-    @compat (; sparsity, compressed, colors, seeds, products, pushforward_batched_extras) =
-        extras
+    @compat (;
+        sparsity, compressed, colors, groups, batched_seeds, pushforward_batched_extras
+    ) = extras
     dense_backend = dense_ad(backend)
-    G = length(seeds)
+    Ng = length(groups)
 
     pushforward_batched_extras_same = prepare_pushforward_batched_same_point(
-        f_or_f!y...,
-        dense_backend,
-        x,
-        Batch(ntuple(Returns(seeds[1]), Val(B))),
-        pushforward_batched_extras,
+        f_or_f!y..., dense_backend, x, batched_seeds[1], pushforward_batched_extras
     )
 
-    compressed_blocks = map(1:div(G, B, RoundUp)) do a
-        dx_batch_elements = ntuple(Val(B)) do b
-            seeds[1 + ((a - 1) * B + (b - 1)) % G]
-        end
+    compressed_blocks = map(eachindex(batched_seeds)) do a
         dy_batch = pushforward_batched(
             f_or_f!y...,
             dense_backend,
             x,
-            Batch(dx_batch_elements),
+            batched_seeds[a],
             pushforward_batched_extras_same,
         )
         stack(vec, dy_batch.elements; dims=2)
     end
 
     compressed = reduce(hcat, compressed_blocks)
-    if G < size(compressed, 2)
-        compressed = compressed[:, 1:G]
+    if Ng < size(compressed, 2)
+        compressed = compressed[:, 1:Ng]
     end
     return decompress_columns(sparsity, compressed, colors)
 end
@@ -214,36 +233,30 @@ end
 function sparse_jacobian_aux(
     f_or_f!y::FY, backend::AutoSparse, x, extras::PullbackSparseJacobianExtras{B}
 ) where {FY,B}
-    @compat (; sparsity, compressed, colors, seeds, products, pullback_batched_extras) =
-        extras
+    @compat (;
+        sparsity, compressed, colors, groups, batched_seeds, pullback_batched_extras
+    ) = extras
     dense_backend = dense_ad(backend)
-    G = length(seeds)
+    Ng = length(groups)
 
     pullback_batched_extras_same = prepare_pullback_batched_same_point(
-        f_or_f!y...,
-        dense_backend,
-        x,
-        Batch(ntuple(Returns(seeds[1]), Val(B))),
-        pullback_batched_extras,
+        f_or_f!y..., dense_backend, x, batched_seeds[1], pullback_batched_extras
     )
 
-    compressed_blocks = map(1:div(G, B, RoundUp)) do a
-        dy_batch_elements = ntuple(Val(B)) do b
-            seeds[1 + ((a - 1) * B + (b - 1)) % G]
-        end
+    compressed_blocks = map(eachindex(batched_seeds)) do a
         dx_batch = pullback_batched(
             f_or_f!y...,
             dense_backend,
             x,
-            Batch(dy_batch_elements),
+            batched_seeds[a],
             pullback_batched_extras_same,
         )
         stack(vec, dx_batch.elements; dims=1)
     end
 
     compressed = reduce(vcat, compressed_blocks)
-    if G < size(compressed, 1)
-        compressed = compressed[1:G, :]
+    if Ng < size(compressed, 1)
+        compressed = compressed[1:Ng, :]
     end
     return decompress_rows(sparsity, compressed, colors)
 end
@@ -251,38 +264,34 @@ end
 function sparse_jacobian_aux!(
     f_or_f!y::FY, jac, backend::AutoSparse, x, extras::PushforwardSparseJacobianExtras{B}
 ) where {FY,B}
-    @compat (; sparsity, compressed, colors, seeds, products, pushforward_batched_extras) =
-        extras
+    @compat (;
+        sparsity,
+        compressed,
+        colors,
+        groups,
+        batched_seeds,
+        pushforward_batched_extras,
+        y_example,
+    ) = extras
     dense_backend = dense_ad(backend)
-    G = length(seeds)
+    Ng = length(groups)
 
     pushforward_batched_extras_same = prepare_pushforward_batched_same_point(
-        f_or_f!y...,
-        dense_backend,
-        x,
-        Batch(ntuple(Returns(seeds[1]), Val(B))),
-        pushforward_batched_extras,
+        f_or_f!y..., dense_backend, x, batched_seeds[1], pushforward_batched_extras
     )
 
-    for a in 1:div(G, B, RoundUp)
-        dx_batch_elements = ntuple(Val(B)) do b
-            seeds[1 + ((a - 1) * B + (b - 1)) % G]
-        end
+    for a in eachindex(batched_seeds)
         dy_batch_elements = ntuple(Val(B)) do b
-            products[1 + ((a - 1) * B + (b - 1)) % G]
+            reshape(view(compressed, :, 1 + ((a - 1) * B + (b - 1)) % Ng), size(y_example))
         end
         pushforward_batched!(
             f_or_f!y...,
             Batch(dy_batch_elements),
             dense_backend,
             x,
-            Batch(dx_batch_elements),
+            batched_seeds[a],
             pushforward_batched_extras_same,
         )
-    end
-
-    for k in eachindex(products)
-        copyto!(view(compressed, :, k), vec(products[k]))
     end
 
     decompress_columns!(jac, sparsity, compressed, colors)
@@ -292,38 +301,28 @@ end
 function sparse_jacobian_aux!(
     f_or_f!y::FY, jac, backend::AutoSparse, x, extras::PullbackSparseJacobianExtras{B}
 ) where {FY,B}
-    @compat (; sparsity, compressed, colors, seeds, products, pullback_batched_extras) =
-        extras
+    @compat (;
+        sparsity, compressed, colors, groups, batched_seeds, pullback_batched_extras
+    ) = extras
     dense_backend = dense_ad(backend)
-    G = length(seeds)
+    Ng = length(groups)
 
     pullback_batched_extras_same = prepare_pullback_batched_same_point(
-        f_or_f!y...,
-        dense_backend,
-        x,
-        Batch(ntuple(Returns(seeds[1]), Val(B))),
-        pullback_batched_extras,
+        f_or_f!y..., dense_backend, x, batched_seeds[1], pullback_batched_extras
     )
 
-    for a in 1:div(G, B, RoundUp)
-        dy_batch_elements = ntuple(Val(B)) do b
-            seeds[1 + ((a - 1) * B + (b - 1)) % G]
-        end
+    for a in eachindex(batched_seeds)
         dx_batch_elements = ntuple(Val(B)) do b
-            products[1 + ((a - 1) * B + (b - 1)) % G]
+            reshape(view(compressed, 1 + ((a - 1) * B + (b - 1)) % Ng, :), size(x))
         end
         pullback_batched!(
             f_or_f!y...,
             Batch(dx_batch_elements),
             dense_backend,
             x,
-            Batch(dy_batch_elements),
+            batched_seeds[a],
             pullback_batched_extras_same,
         )
-    end
-
-    for k in eachindex(products)
-        copyto!(view(compressed, k, :), vec(products[k]))
     end
 
     decompress_rows!(jac, sparsity, compressed, colors)

--- a/DifferentiationInterface/test/Single/ForwardDiff/fromprimitive.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/fromprimitive.jl
@@ -1,10 +1,13 @@
 using DifferentiationInterface, DifferentiationInterfaceTest
-using DifferentiationInterface: AutoForwardFromPrimitive
+using DifferentiationInterface: AutoForwardFromPrimitive, AutoReverseFromPrimitive
 using DifferentiationInterfaceTest: add_batchified!
 using ForwardDiff: ForwardDiff
 using Test
 
-fromprimitive_backends = [AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5))]
+fromprimitive_backends = [ #
+    AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
+    AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
+]
 
 for backend in vcat(fromprimitive_backends)
     @test check_available(backend)
@@ -19,7 +22,7 @@ test_differentiation(
 );
 
 test_differentiation(
-    fromprimitive_backends,
+    fromprimitive_backends[1],
     add_batchified!(default_scenarios());
     correctness=false,
     type_stability=true,

--- a/DifferentiationInterface/test/Single/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Single/ForwardDiff/test.jl
@@ -4,11 +4,11 @@ using ForwardDiff: ForwardDiff
 using SparseConnectivityTracer, SparseMatrixColorings
 using Test
 
-dense_backends = [AutoForwardDiff(), AutoForwardDiff(; chunksize=2, tag=:hello)]
+dense_backends = [AutoForwardDiff(), AutoForwardDiff(; chunksize=5, tag=:hello)]
 
 sparse_backends = [
     AutoSparse(
-        AutoForwardDiff();
+        AutoForwardDiff(; chunksize=5);
         sparsity_detector=TracerSparsityDetector(),
         coloring_algorithm=GreedyColoringAlgorithm(),
     ),
@@ -25,7 +25,7 @@ end
 test_differentiation(dense_backends, add_batchified!(default_scenarios()); logging=LOGGING);
 
 test_differentiation(
-    fromprimitive_backends,
+    dense_backends,
     add_batchified!(default_scenarios());
     correctness=false,
     type_stability=true,


### PR DESCRIPTION
**DI source**

- Prepare batched seeds in the preparation phase for Jacobian and Hessian
- Remove `products` storage in the sparse version to imitate dense ones (reshape a view of the returned matrix instead)
- Change `extras` handling in `FromPrimitive` backends (internals) to avoid ambiguities

**DI tests**

- Test `AutoReverseFromPrimitive` with ForwardDiff