### PR TITLE
Fix tag construction in ForwardDiff

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -2,7 +2,7 @@ choose_chunk(::AutoForwardDiff{nothing}, x) = Chunk(x)
 choose_chunk(::AutoForwardDiff{C}, x) where {C} = Chunk{min(length(x), C)}()
 
 tag_type(f, ::AutoForwardDiff{C,T}, x) where {C,T} = T
-tag_type(f, ::AutoForwardDiff{C,Nothing}, x) where {C} = Tag{typeof(f),eltype(x)}
+tag_type(f, ::AutoForwardDiff{C,Nothing}, x) where {C} = typeof(Tag(f, eltype(x)))
 
 make_dual_similar(::Type{T}, x::Number, dx::Number) where {T} = Dual{T}(x, dx)
 make_dual_similar(::Type{T}, x, dx) where {T} = similar(x, Dual{T,eltype(x),1})


### PR DESCRIPTION
**DI extensions**

- Tags were not properly constructed in ForwardDiff extension: we need to use the [`Tag(f, R)` constructor](https://github.com/JuliaDiff/ForwardDiff.jl/blob/309f760a2293f5a8595369476c43b5cac268b02f/src/config.jl#L5-L21) to increment the global tag counter, whereas `Tag{F, R}` fails. Examples of correct tag construction: [here](https://github.com/JuliaDiff/ForwardDiff.jl/blob/309f760a2293f5a8595369476c43b5cac268b02f/src/derivative.jl#L13), [here](https://github.com/JuliaDiff/ForwardDiff.jl/blob/309f760a2293f5a8595369476c43b5cac268b02f/src/config.jl#L120).