### PR TITLE
Fix size-1 Jacobian with Enzyme

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -36,7 +36,8 @@ using Enzyme:
     gradient!,
     jacobian,
     make_zero,
-    make_zero!
+    make_zero!,
+    onehot
 
 struct AutoDeferredEnzyme{M} <: ADTypes.AbstractADType
     mode::M

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -102,7 +102,11 @@ end
 
 function DI.prepare_jacobian(f, backend::AutoEnzyme{<:Union{ForwardMode,Nothing}}, x)
     B = pick_batchsize(backend, length(x))
-    shadow = chunkedonehot(x, Val(B))
+    if B == 1
+        shadow = onehot(x)
+    else
+        shadow = chunkedonehot(x, Val(B))
+    end
     return EnzymeForwardOneArgJacobianExtras{B,typeof(shadow)}(shadow)
 end
 

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestJLArraysExt/DifferentiationInterfaceTestJLArraysExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestJLArraysExt/DifferentiationInterfaceTestJLArraysExt.jl
@@ -32,7 +32,6 @@ function DIT.gpu_scenarios(rng::AbstractRNG=default_rng(); linalg=true)
 
     scens = vcat(
         # one argument
-        DIT.num_to_num_scenarios_onearg(x_; dx=dx_, dy=dy_),
         DIT.num_to_arr_scenarios_onearg(x_, V; dx=dx_, dy=dy_6),
         DIT.num_to_arr_scenarios_onearg(x_, M; dx=dx_, dy=dy_2_3),
         DIT.arr_to_num_scenarios_onearg(x_6; dx=dx_6, dy=dy_, linalg),

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -37,7 +37,10 @@ function num_to_num_scenarios_onearg(x::Number; dx::Number, dy::Number)
 
     # add scenarios [x] -> [y] to test 1-sized everything
     f_vec(x) = [f(only(x))]
-    f_vec!(y, x) = y[only(eachindex(y))] = f(only(x))
+    function f_vec!(y, x)
+        y[only(eachindex(y))] = f(only(x))
+        return nothing
+    end
 
     for place in (:outofplace, :inplace)
         append!(


### PR DESCRIPTION
**DI extensions**

- Use `onehot` instead of `chunkedonehot` to initialize shadows for Enzyme's Jacobian when the batch size is `1`

**DIT source**

- Add functions from $R^1$ to $R^1$ to the default scenarios