### PR TITLE
Handle closures with Enzyme

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -44,7 +44,7 @@ DifferentiationInterfaceTrackerExt = "Tracker"
 DifferentiationInterfaceZygoteExt = ["Zygote", "ForwardDiff"]
 
 [compat]
-ADTypes = "1.5.0"
+ADTypes = "1.6.1"
 ChainRulesCore = "1.23.0"
 Compat = "3,4"
 Diffractor = "=0.2.6"

--- a/DifferentiationInterface/docs/src/backends.md
+++ b/DifferentiationInterface/docs/src/backends.md
@@ -57,7 +57,7 @@ import Zygote
 
 backend_examples = [
     AutoDiffractor(),
-    AutoEnzyme(),
+    AutoEnzyme(; constant_function=true),
     AutoFastDifferentiation(),
     AutoFiniteDiff(),
     AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),

--- a/DifferentiationInterface/docs/src/tutorial1.md
+++ b/DifferentiationInterface/docs/src/tutorial1.md
@@ -116,7 +116,7 @@ Typically, for gradients, reverse mode AD might be a better fit, so let's try th
 ```@example tuto1
 import Enzyme
 
-backend2 = AutoEnzyme()
+backend2 = AutoEnzyme(constant_function=true)
 ```
 
 Once the backend is created, things run smoothly with exactly the same syntax as before:

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -38,15 +38,21 @@ using Enzyme:
     make_zero,
     make_zero!
 
-struct AutoDeferredEnzyme{M} <: ADTypes.AbstractADType
+const CONSTANT_FUNCTION_ERROR = """`AutoEnzyme(constant_function=false)` is not yet supported by DifferentiationInterface. For the time being, please use `AutoEnzyme(constant_function=true)` and avoid closures containing differentiable data."""
+
+struct AutoDeferredEnzyme{M,constant_function} <: ADTypes.AbstractADType
     mode::M
 end
 
 ADTypes.mode(backend::AutoDeferredEnzyme) = ADTypes.mode(AutoEnzyme(backend.mode))
 
-DI.nested(backend::AutoEnzyme) = AutoDeferredEnzyme(backend.mode)
+function DI.nested(backend::AutoEnzyme{M,constant_function}) where {M}
+    return AutoDeferredEnzyme{M,constant_function}(backend.mode)
+end
 
-const AnyAutoEnzyme{M} = Union{AutoEnzyme{M},AutoDeferredEnzyme{M}}
+const AnyAutoEnzyme{M,constant_function} = Union{
+    AutoEnzyme{M,constant_function},AutoDeferredEnzyme{M,constant_function}
+}
 
 # forward mode if possible
 forward_mode(backend::AnyAutoEnzyme{<:Mode}) = backend.mode

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -38,8 +38,6 @@ using Enzyme:
     make_zero,
     make_zero!
 
-const CONSTANT_FUNCTION_ERROR = """`AutoEnzyme(constant_function=false)` is not yet supported by DifferentiationInterface. For the time being, please use `AutoEnzyme(constant_function=true)` and avoid closures containing differentiable data."""
-
 struct AutoDeferredEnzyme{M,constant_function} <: ADTypes.AbstractADType
     mode::M
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -74,6 +74,15 @@ function DI.basis(::AutoEnzyme, a::AbstractArray{T}, i::CartesianIndex) where {T
     return b
 end
 
+function get_f_and_df(f, ::AnyAutoEnzyme{M,true}) where {M}
+    return Const(f)
+end
+
+function get_f_and_df(f, ::AnyAutoEnzyme{M,false}) where {M}
+    df = make_zero(f)
+    return Duplicated(f, df)
+end
+
 include("forward_onearg.jl")
 include("forward_twoarg.jl")
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -46,7 +46,7 @@ end
 
 ADTypes.mode(backend::AutoDeferredEnzyme) = ADTypes.mode(AutoEnzyme(backend.mode))
 
-function DI.nested(backend::AutoEnzyme{M,constant_function}) where {M}
+function DI.nested(backend::AutoEnzyme{M,constant_function}) where {M,constant_function}
     return AutoDeferredEnzyme{M,constant_function}(backend.mode)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -5,18 +5,9 @@ function DI.prepare_pushforward(f, ::AnyAutoEnzyme{<:Union{ForwardMode,Nothing}}
 end
 
 function DI.value_and_pushforward(
-    f,
-    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},constant_function},
-    x,
-    dx,
-    ::NoPushforwardExtras,
-) where {constant_function}
-    f_and_df = if constant_function
-        Const(f)
-    else
-        df = make_zero(f)
-        Duplicated(f, df)
-    end
+    f, backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing}}, x, dx, ::NoPushforwardExtras
+)
+    f_and_df = get_f_and_df(f, backend)
     dx_sametype = convert(typeof(x), dx)
     x_and_dx = Duplicated(x, dx_sametype)
     y, new_dy = if backend isa AutoDeferredEnzyme
@@ -28,18 +19,9 @@ function DI.value_and_pushforward(
 end
 
 function DI.pushforward(
-    f,
-    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},constant_function},
-    x,
-    dx,
-    ::NoPushforwardExtras,
-) where {constant_function}
-    f_and_df = if constant_function
-        Const(f)
-    else
-        df = make_zero(f)
-        Duplicated(f, df)
-    end
+    f, backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing}}, x, dx, ::NoPushforwardExtras
+)
+    f_and_df = get_f_and_df(f, backend)
     dx_sametype = convert(typeof(x), dx)
     x_and_dx = Duplicated(x, dx_sametype)
     new_dy = if backend isa AutoDeferredEnzyme

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -1,33 +1,31 @@
 ## Pushforward
 
-function DI.prepare_pushforward(
-    f!, y, ::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},true}, x, dx
-)
+function DI.prepare_pushforward(f!, y, ::AnyAutoEnzyme{<:Union{ForwardMode,Nothing}}, x, dx)
     return NoPushforwardExtras()
-end
-
-function DI.prepare_pushforward(
-    f!, y, ::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},false}, x, dx
-)
-    throw(ArgumentError(CONSTANT_FUNCTION_ERROR))
 end
 
 function DI.value_and_pushforward(
     f!,
     y,
-    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},true},
+    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},constant_function},
     x,
     dx,
     ::NoPushforwardExtras,
-)
+) where {constant_function}
+    f!_and_df! = if constant_function
+        Const(f!)
+    else
+        df! = make_zero(f!)
+        Duplicated(f!, df!)
+    end
     dx_sametype = convert(typeof(x), dx)
     dy_sametype = make_zero(y)
     y_and_dy = Duplicated(y, dy_sametype)
     x_and_dx = Duplicated(x, dx_sametype)
     if backend isa AutoDeferredEnzyme
-        autodiff_deferred(forward_mode(backend), f!, Const, y_and_dy, x_and_dx)
+        autodiff_deferred(forward_mode(backend), f!_and_df!, Const, y_and_dy, x_and_dx)
     else
-        autodiff(forward_mode(backend), Const(f!), Const, y_and_dy, x_and_dx)
+        autodiff(forward_mode(backend), f!_and_df!, Const, y_and_dy, x_and_dx)
     end
     return y, dy_sametype
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -1,13 +1,21 @@
 ## Pushforward
 
-function DI.prepare_pushforward(f!, y, ::AnyAutoEnzyme{<:Union{ForwardMode,Nothing}}, x, dx)
+function DI.prepare_pushforward(
+    f!, y, ::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},true}, x, dx
+)
     return NoPushforwardExtras()
+end
+
+function DI.prepare_pushforward(
+    f!, y, ::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},false}, x, dx
+)
+    throw(ArgumentError(CONSTANT_FUNCTION_ERROR))
 end
 
 function DI.value_and_pushforward(
     f!,
     y,
-    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing}},
+    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},true},
     x,
     dx,
     ::NoPushforwardExtras,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -7,17 +7,12 @@ end
 function DI.value_and_pushforward(
     f!,
     y,
-    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},constant_function},
+    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing}},
     x,
     dx,
     ::NoPushforwardExtras,
-) where {constant_function}
-    f!_and_df! = if constant_function
-        Const(f!)
-    else
-        df! = make_zero(f!)
-        Duplicated(f!, df!)
-    end
+)
+    f!_and_df! = get_f_and_df(f!, backend)
     dx_sametype = convert(typeof(x), dx)
     dy_sametype = make_zero(y)
     y_and_dy = Duplicated(y, dy_sametype)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -8,17 +8,12 @@ end
 
 function DI.value_and_pullback(
     f,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},constant_function},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     dy::Number,
     ::NoPullbackExtras,
-) where {constant_function}
-    f_and_df = if constant_function
-        Const(f)
-    else
-        df = make_zero(f)
-        Duplicated(f, df)
-    end
+)
+    f_and_df = get_f_and_df(f, backend)
     der, y = if backend isa AutoDeferredEnzyme
         autodiff_deferred(ReverseWithPrimal, f_and_df, Active, Active(x))
     else
@@ -30,17 +25,12 @@ end
 
 function DI.value_and_pullback(
     f,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},constant_function},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     dy,
     ::NoPullbackExtras,
-) where {constant_function}
-    f_and_df = if constant_function
-        Const(f)
-    else
-        df = make_zero(f)
-        Duplicated(f, df)
-    end
+)
+    f_and_df = get_f_and_df(f, backend)
     forw, rev = autodiff_thunk(
         ReverseSplitWithPrimal, typeof(f_and_df), Duplicated, typeof(Active(x))
     )
@@ -52,17 +42,12 @@ end
 
 function DI.value_and_pullback(
     f,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},constant_function},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     dy::Number,
     ::NoPullbackExtras,
-) where {constant_function}
-    f_and_df = if constant_function
-        Const(f)
-    else
-        df = make_zero(f)
-        Duplicated(f, df)
-    end
+)
+    f_and_df = get_f_and_df(f, backend)
     dx_sametype = make_zero(x)
     x_and_dx = Duplicated(x, dx_sametype)
     _, y = if backend isa AutoDeferredEnzyme
@@ -95,17 +80,12 @@ end
 function DI.value_and_pullback!(
     f,
     dx,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},constant_function},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     dy::Number,
     ::NoPullbackExtras,
-) where {constant_function}
-    f_and_df = if constant_function
-        Const(f)
-    else
-        df = make_zero(f)
-        Duplicated(f, df)
-    end
+)
+    f_and_df = get_f_and_df(f, backend)
     dx_sametype = convert(typeof(x), dx)
     make_zero!(dx_sametype)
     x_and_dx = Duplicated(x, dx_sametype)
@@ -122,19 +102,9 @@ function DI.value_and_pullback!(
 end
 
 function DI.value_and_pullback!(
-    f,
-    dx,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},constant_function},
-    x,
-    dy,
-    ::NoPullbackExtras,
-) where {constant_function}
-    f_and_df = if constant_function
-        Const(f)
-    else
-        df = make_zero(f)
-        Duplicated(f, df)
-    end
+    f, dx, backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}}, x, dy, ::NoPullbackExtras
+)
+    f_and_df = get_f_and_df(f, backend)
     dx_sametype = convert(typeof(x), dx)
     make_zero!(dx_sametype)
     x_and_dx = Duplicated(x, dx_sametype)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -1,13 +1,21 @@
 ## Pullback
 
-function DI.prepare_pullback(f!, y, ::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}}, x, dy)
+function DI.prepare_pullback(
+    f!, y, ::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true}, x, dy
+)
     return NoPullbackExtras()
+end
+
+function DI.prepare_pullback(
+    f!, y, ::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},false}, x, dy
+)
+    throw(ArgumentError(CONSTANT_FUNCTION_ERROR))
 end
 
 function DI.value_and_pullback(
     f!,
     y,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true},
     x::Number,
     dy,
     ::NoPullbackExtras,
@@ -25,7 +33,7 @@ end
 function DI.value_and_pullback(
     f!,
     y,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true},
     x::AbstractArray,
     dy,
     ::NoPullbackExtras,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -7,17 +7,12 @@ end
 function DI.value_and_pullback(
     f!,
     y,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},constant_function},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     dy,
     ::NoPullbackExtras,
-) where {constant_function}
-    f!_and_df! = if constant_function
-        Const(f!)
-    else
-        df! = make_zero(f!)
-        Duplicated(f!, df!)
-    end
+)
+    f!_and_df! = get_f_and_df(f!, backend)
     dy_sametype = convert(typeof(y), copy(dy))
     y_and_dy = Duplicated(y, dy_sametype)
     _, new_dx = if backend isa AutoDeferredEnzyme
@@ -36,12 +31,7 @@ function DI.value_and_pullback(
     dy,
     ::NoPullbackExtras,
 )
-    f!_and_df! = if constant_function
-        Const(f!)
-    else
-        df! = make_zero(f!)
-        Duplicated(f!, df!)
-    end
+    f!_and_df! = get_f_and_df(f!, backend)
     dx_sametype = make_zero(x)
     dy_sametype = convert(typeof(y), copy(dy))
     y_and_dy = Duplicated(y, dy_sametype)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -26,7 +26,7 @@ end
 function DI.value_and_pullback(
     f!,
     y,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::AbstractArray,
     dy,
     ::NoPullbackExtras,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -1,31 +1,29 @@
 ## Pullback
 
-function DI.prepare_pullback(
-    f!, y, ::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true}, x, dy
-)
+function DI.prepare_pullback(f!, y, ::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}}, x, dy)
     return NoPullbackExtras()
-end
-
-function DI.prepare_pullback(
-    f!, y, ::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},false}, x, dy
-)
-    throw(ArgumentError(CONSTANT_FUNCTION_ERROR))
 end
 
 function DI.value_and_pullback(
     f!,
     y,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},constant_function},
     x::Number,
     dy,
     ::NoPullbackExtras,
-)
+) where {constant_function}
+    f!_and_df! = if constant_function
+        Const(f!)
+    else
+        df! = make_zero(f!)
+        Duplicated(f!, df!)
+    end
     dy_sametype = convert(typeof(y), copy(dy))
     y_and_dy = Duplicated(y, dy_sametype)
     _, new_dx = if backend isa AutoDeferredEnzyme
-        only(autodiff_deferred(reverse_mode(backend), f!, Const, y_and_dy, Active(x)))
+        only(autodiff_deferred(reverse_mode(backend), f!_and_df!, Const, y_and_dy, Active(x)))
     else
-        only(autodiff(reverse_mode(backend), Const(f!), Const, y_and_dy, Active(x)))
+        only(autodiff(reverse_mode(backend), f!_and_df!, Const, y_and_dy, Active(x)))
     end
     return y, new_dx
 end
@@ -38,14 +36,20 @@ function DI.value_and_pullback(
     dy,
     ::NoPullbackExtras,
 )
+    f!_and_df! = if constant_function
+        Const(f!)
+    else
+        df! = make_zero(f!)
+        Duplicated(f!, df!)
+    end
     dx_sametype = make_zero(x)
     dy_sametype = convert(typeof(y), copy(dy))
     y_and_dy = Duplicated(y, dy_sametype)
     x_and_dx = Duplicated(x, dx_sametype)
     if backend isa AutoDeferredEnzyme
-        autodiff_deferred(reverse_mode(backend), f!, Const, y_and_dy, x_and_dx)
+        autodiff_deferred(reverse_mode(backend), f!_and_df!, Const, y_and_dy, x_and_dx)
     else
-        autodiff(reverse_mode(backend), Const(f!), Const, y_and_dy, x_and_dx)
+        autodiff(reverse_mode(backend), f!_and_df!, Const, y_and_dy, x_and_dx)
     end
     return y, dx_sametype
 end

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -46,11 +46,11 @@ test_differentiation(
 );
 
 test_differentiation(
-    AutoEnzyme(; constant_function=true),
+    AutoEnzyme(; mode=Enzyme.Forward, constant_function=false),
     DIT.make_closure.(default_scenarios());
     second_order=false,
     logging=LOGGING,
-);  # all of these should fail?
+);
 
 test_differentiation(
     [

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -6,14 +6,18 @@ using StableRNGs
 using Test
 
 dense_backends = [
-    AutoEnzyme(; mode=nothing),
-    AutoEnzyme(; mode=Enzyme.Forward),
-    AutoEnzyme(; mode=Enzyme.Reverse),
+    AutoEnzyme(; mode=nothing, constant_function=true),
+    AutoEnzyme(; mode=Enzyme.Forward, constant_function=true),
+    AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true),
 ]
 
 nested_dense_backends = [
-    DifferentiationInterface.nested(AutoEnzyme(; mode=Enzyme.Forward)),
-    DifferentiationInterface.nested(AutoEnzyme(; mode=Enzyme.Reverse)),
+    DifferentiationInterface.nested(
+        AutoEnzyme(; mode=Enzyme.Forward, constant_function=true)
+    ),
+    DifferentiationInterface.nested(
+        AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true)
+    ),
 ]
 
 sparse_backends =

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -46,7 +46,10 @@ test_differentiation(
 );
 
 test_differentiation(
-    AutoEnzyme(; mode=Enzyme.Forward, constant_function=false),
+    [
+        AutoEnzyme(; mode=Enzyme.Forward, constant_function=false),
+        AutoEnzyme(; mode=Enzyme.Reverse, constant_function=false),
+    ],
     DIT.make_closure.(default_scenarios());
     second_order=false,
     logging=LOGGING,

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -57,10 +57,16 @@ test_differentiation(
 
 test_differentiation(
     [
-        AutoEnzyme(; mode=nothing),
-        AutoEnzyme(; mode=Enzyme.Reverse),
-        SecondOrder(AutoEnzyme(; mode=Enzyme.Reverse), AutoEnzyme(; mode=Enzyme.Reverse)),
-        SecondOrder(AutoEnzyme(; mode=Enzyme.Forward), AutoEnzyme(; mode=Enzyme.Reverse)),
+        AutoEnzyme(; mode=nothing, constant_function=true),
+        AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true),
+        SecondOrder(
+            AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true),
+            AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true),
+        ),
+        SecondOrder(
+            AutoEnzyme(; mode=Enzyme.Forward, constant_function=true),
+            AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true),
+        ),
     ];
     first_order=false,
     excluded=[:second_derivative],
@@ -68,14 +74,17 @@ test_differentiation(
 );
 
 test_differentiation(
-    [AutoEnzyme(; mode=nothing), AutoEnzyme(; mode=Enzyme.Forward)];
+    [
+        AutoEnzyme(; mode=nothing, constant_function=true),
+        AutoEnzyme(; mode=Enzyme.Forward, constant_function=true),
+    ];
     first_order=false,
     excluded=[:hessian, :hvp],
     logging=LOGGING,
 );
 
 test_differentiation(
-    AutoEnzyme(; mode=Enzyme.Forward);  # TODO: add more
+    AutoEnzyme(; mode=Enzyme.Forward, constant_function=true);  # TODO: add more
     correctness=false,
     type_stability=true,
     second_order=false,

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -1,5 +1,6 @@
 using ADTypes: ADTypes
 using DifferentiationInterface, DifferentiationInterfaceTest
+import DifferentiationInterfaceTest as DIT
 using Enzyme: Enzyme
 using SparseConnectivityTracer, SparseMatrixColorings
 using StableRNGs
@@ -43,6 +44,13 @@ test_differentiation(
     second_order=false,
     logging=LOGGING,
 );
+
+test_differentiation(
+    AutoEnzyme(; constant_function=true),
+    DIT.make_closure.(default_scenarios());
+    second_order=false,
+    logging=LOGGING,
+);  # all of these should fail?
 
 test_differentiation(
     [

--- a/DifferentiationInterface/test/Back/SecondOrder/test.jl
+++ b/DifferentiationInterface/test/Back/SecondOrder/test.jl
@@ -16,8 +16,12 @@ onearg_backends = [
 ]
 
 twoarg_backends = [
-    SecondOrder(AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Forward)),
-    SecondOrder(AutoEnzyme(; mode=Enzyme.Reverse), AutoForwardDiff()),
+    SecondOrder(
+        AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Forward, constant_function=true)
+    ),
+    SecondOrder(
+        AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true), AutoForwardDiff()
+    ),
 ]
 
 for backend in vcat(onearg_backends, twoarg_backends)

--- a/DifferentiationInterface/test/Down/Detector/detector.jl
+++ b/DifferentiationInterface/test/Down/Detector/detector.jl
@@ -24,7 +24,7 @@ g(x::AbstractVector) = dot(x, Hc, x)
 g(x::AbstractMatrix) = g(vec(x))
 
 @testset verbose = true "$(typeof(backend))" for backend in [
-    AutoEnzyme(; mode=Enzyme.Reverse), AutoForwardDiff()
+    AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true), AutoForwardDiff()
 ]
     @test_throws ArgumentError DenseSparsityDetector(backend; atol=1e-5, method=:random)
     @testset "$method" for method in (:iterative, :direct)

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -61,6 +61,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
@@ -77,4 +78,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "DifferentiationInterface", "FiniteDifferences", "Flux", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StaticArrays", "Test", "Zygote"]
+test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "DifferentiationInterface", "FiniteDiff", "FiniteDifferences", "Flux", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StaticArrays", "Test", "Zygote"]

--- a/DifferentiationInterfaceTest/docs/src/tutorial.md
+++ b/DifferentiationInterfaceTest/docs/src/tutorial.md
@@ -12,7 +12,7 @@ import ForwardDiff, Enzyme
 The AD backends we want to compare are [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) and [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl).
 
 ```@example tuto
-backends = [AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Reverse)]
+backends = [AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true)]
 ```
 
 To do that, we are going to take gradients of a simple function:

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -76,6 +76,7 @@ include("scenarios/default.jl")
 include("scenarios/sparse.jl")
 include("scenarios/allocfree.jl")
 include("scenarios/extensions.jl")
+include("scenarios/modify.jl")
 
 include("utils/zero_backends.jl")
 include("utils/misc.jl")

--- a/DifferentiationInterfaceTest/src/scenarios/modify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/modify.jl
@@ -23,7 +23,7 @@ end
 Return a new [`Scenario`](@ref) with a modified function `f` or `f!` that closes over differentiable data.
 """
 function make_closure(scen::Scenario)
-    (; f, x, y) = scen
+    @compat (; f, x, y) = scen
     x_buffer = [zero(x)]
     y_buffer = [zero(y)]
     closure_f = MyClosure{nb_args(scen),typeof(f),typeof(x),typeof(y)}(

--- a/DifferentiationInterfaceTest/src/scenarios/modify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/modify.jl
@@ -1,22 +1,33 @@
+struct MyClosure{args,F,X,Y}
+    f::F
+    x_buffer::Vector{X}
+    y_buffer::Vector{Y}
+end
+
+function (mc::MyClosure{1})(x)
+    mc.x_buffer[1] = x
+    mc.y_buffer[1] = mc.f(x)
+    return copy(mc.y_buffer[1])
+end
+
+function (mc::MyClosure{2})(y, x)
+    mc.x_buffer[1] = x
+    mc.f(mc.y_buffer[1], mc.x_buffer[1])
+    copyto!(y, mc.y_buffer[1])
+    return nothing
+end
+
 """
     make_closure(scen::Scenario)
 
 Return a new [`Scenario`](@ref) with a modified function `f` or `f!` that closes over differentiable data.
 """
 function make_closure(scen::Scenario)
-    closed_data = Ref(zero(scen.y))
-    if nb_args(scen) == 1
-        function closure_f(x)
-            closed_data[] = scen.f(x)
-            return copy(closed_data[])
-        end
-        return change_function(scen, closure_f)
-    elseif nb_args(scen) == 2
-        function closure_f!(y, x)
-            scen.f(closed_data[], x)
-            copyto!(y, closed_data[])
-            return nothing
-        end
-        return change_function(scen, closure_f!)
-    end
+    (; f, x, y) = scen
+    x_buffer = [zero(x)]
+    y_buffer = [zero(y)]
+    closure_f = MyClosure{nb_args(scen),typeof(f),typeof(x),typeof(y)}(
+        f, x_buffer, y_buffer
+    )
+    return change_function(scen, closure_f)
 end

--- a/DifferentiationInterfaceTest/src/scenarios/modify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/modify.jl
@@ -1,0 +1,22 @@
+"""
+    make_closure(scen::Scenario)
+
+Return a new [`Scenario`](@ref) with a modified function `f` or `f!` that closes over differentiable data.
+"""
+function make_closure(scen::Scenario)
+    closed_data = Ref(zero(scen.y))
+    if nb_args(scen) == 1
+        function closure_f(x)
+            closed_data[] = scen.f(x)
+            return copy(closed_data[])
+        end
+        return change_function(scen, closure_f)
+    elseif nb_args(scen) == 2
+        function closure_f!(y, x)
+            scen.f(closed_data[], x)
+            copyto!(y, closed_data[])
+            return nothing
+        end
+        return change_function(scen, closure_f!)
+    end
+end

--- a/DifferentiationInterfaceTest/test/weird.jl
+++ b/DifferentiationInterfaceTest/test/weird.jl
@@ -21,6 +21,13 @@ test_differentiation(
 )
 
 test_differentiation(
+    AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),
+    DIT.make_closure.(default_scenarios());
+    second_order=false,
+    logging=LOGGING,
+);
+
+test_differentiation(
     AutoZygote(), gpu_scenarios(); correctness=true, second_order=false, logging=LOGGING
 )
 

--- a/DifferentiationInterfaceTest/test/weird.jl
+++ b/DifferentiationInterfaceTest/test/weird.jl
@@ -3,6 +3,7 @@ using ComponentArrays: ComponentArrays
 using DifferentiationInterface
 using DifferentiationInterfaceTest
 import DifferentiationInterfaceTest as DIT
+using FiniteDiff: FiniteDiff
 using FiniteDifferences: FiniteDifferences
 using Flux: Flux
 using ForwardDiff: ForwardDiff
@@ -21,7 +22,7 @@ test_differentiation(
 )
 
 test_differentiation(
-    AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),
+    AutoFiniteDiff(),
     DIT.make_closure.(default_scenarios());
     second_order=false,
     logging=LOGGING,


### PR DESCRIPTION
**DI extensions**

- Handle the new `AutoEnzyme(constant_function=false)` by providing `Duplicated(f, df)` instead of `Const(f)` to `autodiff`
- Restrict calls to high-level API to `constant_function=true` because of https://github.com/EnzymeAD/Enzyme.jl/issues/1670
- At the moment, `constant_function=false` will fail for functions that don't close over mutable data. It would require `Active` or `MixedDuplicated` to make it work, see https://github.com/EnzymeAD/Enzyme.jl/issues/1669

**DIT source**

- Implement `make_closure(scenario)` which creates a closure over `x` and `y` buffers (differentiable data) and calls it instead

**DIT tests**

- Test the closure scenarios with FiniteDiff (they would fail with ForwardDiff for lack of a Dual cache)

**DI tests**

- Add tests over closure scenarios for `AutoEnzyme(constant_function=false)`