### PR TITLE
Test ForwardDiff over ReverseDiff

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
@@ -60,6 +60,7 @@ function DI.value_and_gradient!(
     extras::ReverseDiffGradientExtras,
 )
     result = MutableDiffResult(zero(eltype(x)), (grad,))
+    println(result)
     result = gradient!(result, extras.tape, x)
     return DiffResults.value(result), DiffResults.derivative(result)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/onearg.jl
@@ -53,14 +53,14 @@ function DI.prepare_gradient(
 end
 
 function DI.value_and_gradient!(
-    _f,
+    f,
     grad::AbstractArray,
     ::AutoReverseDiff,
     x::AbstractArray,
     extras::ReverseDiffGradientExtras,
 )
-    result = MutableDiffResult(zero(eltype(x)), (grad,))
-    println(result)
+    y = f(x)  # TODO: remove once ReverseDiff#251 is fixed
+    result = MutableDiffResult(y, (grad,))
     result = gradient!(result, extras.tape, x)
     return DiffResults.value(result), DiffResults.derivative(result)
 end
@@ -170,14 +170,15 @@ function DI.hessian(
 end
 
 function DI.value_gradient_and_hessian!(
-    _f,
+    f,
     grad,
     hess::AbstractMatrix,
     ::AutoReverseDiff,
     x::AbstractArray,
     extras::ReverseDiffHessianExtras,
 )
-    result = MutableDiffResult(one(eltype(x)), (grad, hess))
+    y = f(x)  # TODO: remove once ReverseDiff#251 is fixed
+    result = MutableDiffResult(y, (grad, hess))
     result = hessian!(result, extras.tape, x)
     return (
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)
@@ -185,11 +186,10 @@ function DI.value_gradient_and_hessian!(
 end
 
 function DI.value_gradient_and_hessian(
-    _f, ::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffHessianExtras
+    f, ::AutoReverseDiff, x::AbstractArray, extras::ReverseDiffHessianExtras
 )
-    result = MutableDiffResult(
-        one(eltype(x)), (similar(x), similar(x, length(x), length(x)))
-    )
+    y = f(x)  # TODO: remove once ReverseDiff#251 is fixed
+    result = MutableDiffResult(y, (similar(x), similar(x, length(x), length(x))))
     result = hessian!(result, extras.tape, x)
     return (
         DiffResults.value(result), DiffResults.gradient(result), DiffResults.hessian(result)

--- a/DifferentiationInterface/test/Back/ReverseDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ReverseDiff/test.jl
@@ -4,6 +4,7 @@ Pkg.add("ReverseDiff")
 using DifferentiationInterface, DifferentiationInterfaceTest
 using DifferentiationInterface: AutoReverseFromPrimitive
 using ReverseDiff: ReverseDiff
+using StaticArrays: StaticArrays
 using Test
 
 dense_backends = [AutoReverseDiff(; compile=false), AutoReverseDiff(; compile=true)]
@@ -17,3 +18,5 @@ for backend in vcat(dense_backends, fromprimitive_backends)
 end
 
 test_differentiation(vcat(dense_backends, fromprimitive_backends); logging=LOGGING);
+
+test_differentiation(AutoReverseDiff(), static_scenarios(); logging=LOGGING);

--- a/DifferentiationInterface/test/Back/SecondOrder/test.jl
+++ b/DifferentiationInterface/test/Back/SecondOrder/test.jl
@@ -14,6 +14,7 @@ using Test
 ## Dense
 
 onearg_backends = [
+    SecondOrder(AutoForwardDiff(), AutoReverseDiff()),
     SecondOrder(AutoForwardDiff(), AutoZygote()),
     SecondOrder(AutoReverseDiff(), AutoZygote()),
 ]

--- a/DifferentiationInterface/test/Back/SecondOrder/test.jl
+++ b/DifferentiationInterface/test/Back/SecondOrder/test.jl
@@ -14,12 +14,12 @@ using Test
 ## Dense
 
 onearg_backends = [
-    SecondOrder(AutoForwardDiff(), AutoReverseDiff()),
     SecondOrder(AutoForwardDiff(), AutoZygote()),
     SecondOrder(AutoReverseDiff(), AutoZygote()),
 ]
 
 twoarg_backends = [
+    SecondOrder(AutoForwardDiff(), AutoReverseDiff()),
     SecondOrder(
         AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Forward, constant_function=true)
     ),


### PR DESCRIPTION
**DI extensions**

- ReverseDiff: Add separate calls to `f(x)` in `value_and_gradient` and `value_and_hessian`, to compensate for https://github.com/JuliaDiff/ReverseDiff.jl/issues/251

**DI tests**

- Add tests for `SecondOrder(AutoForwardDiff(), AutoReverseDiff())`
- Add static array tests for `AutoReverseDiff()`

> [!CAUTION]
> Without the extension modification, the new tests fail on the primal value `y = f(x)` when it comes from `value_and_gradient!(f, ::AutoReverseDiff, x)`. My best guess for the culprit is the bad use of DiffResults inside ReverseDiff (https://github.com/JuliaDiff/ReverseDiff.jl/issues/251). Funnily enough, the tests succeed if I add a `println` statement in said function, which is _very_ disturbing (see Discourse on the [side effects of `println`](https://discourse.julialang.org/t/side-effects-of-println/24037/5)).