### PR TITLE
Add Tracker to Lux tests

### DIFF
--- a/DifferentiationInterface/test/Down/Lux/test.jl
+++ b/DifferentiationInterface/test/Down/Lux/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-Pkg.add(["FiniteDiff", "Lux", "LuxTestUtils", "Zygote"])
+Pkg.add(["FiniteDiff", "Lux", "LuxTestUtils", "Tracker", "Zygote"])
 
 using ComponentArrays: ComponentArrays
 using DifferentiationInterface, DifferentiationInterfaceTest
@@ -12,7 +12,7 @@ using Random
 Random.seed!(0)
 
 test_differentiation(
-    AutoZygote(),
+    [AutoZygote(), AutoTracker()],
     DIT.lux_scenarios(Random.Xoshiro(63));
     isequal=DIT.lux_isequal,
     isapprox=DIT.lux_isapprox,

--- a/DifferentiationInterface/test/Down/Lux/test.jl
+++ b/DifferentiationInterface/test/Down/Lux/test.jl
@@ -8,6 +8,8 @@ using FiniteDiff: FiniteDiff
 using Lux: Lux
 using LuxTestUtils: LuxTestUtils
 using Random
+using Tracker: Tracker
+using Zygote: Zygote
 
 Random.seed!(0)
 


### PR DESCRIPTION
**DI tests**

- Add Tracker as a second backend for Lux tests