### PR TITLE
Revert handling of `AutoEnzyme(; constant_function)`

### DIFF
--- a/DifferentiationInterface/docs/src/backends.md
+++ b/DifferentiationInterface/docs/src/backends.md
@@ -57,7 +57,7 @@ import Zygote
 
 backend_examples = [
     AutoDiffractor(),
-    AutoEnzyme(; constant_function=true),
+    AutoEnzyme(),
     AutoFastDifferentiation(),
     AutoFiniteDiff(),
     AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),

--- a/DifferentiationInterface/docs/src/tutorial1.md
+++ b/DifferentiationInterface/docs/src/tutorial1.md
@@ -116,7 +116,7 @@ Typically, for gradients, reverse mode AD might be a better fit, so let's try th
 ```@example tuto1
 import Enzyme
 
-backend2 = AutoEnzyme(constant_function=true)
+backend2 = AutoEnzyme()
 ```
 
 Once the backend is created, things run smoothly with exactly the same syntax as before:

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -154,7 +154,7 @@ end
 function DI.value_and_jacobian!(
     f,
     jac,
-    backend::AnyAutoEnzyme{<:Union{ForwardMode,Nothing},true},
+    backend::AutoEnzyme{<:Union{ForwardMode,Nothing},true},
     x,
     extras::EnzymeForwardOneArgJacobianExtras,
 )

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -63,42 +63,34 @@ struct EnzymeForwardGradientExtras{B,O} <: GradientExtras
     shadow::O
 end
 
-function DI.prepare_gradient(f, backend::AutoEnzyme{<:ForwardMode,true}, x)
+function DI.prepare_gradient(f, backend::AutoEnzyme{<:ForwardMode}, x)
     B = pick_batchsize(backend, length(x))
     shadow = chunkedonehot(x, Val(B))
     return EnzymeForwardGradientExtras{B,typeof(shadow)}(shadow)
 end
 
 function DI.gradient(
-    f, backend::AutoEnzyme{<:ForwardMode,true}, x, extras::EnzymeForwardGradientExtras{B}
+    f, backend::AutoEnzyme{<:ForwardMode}, x, extras::EnzymeForwardGradientExtras{B}
 ) where {B}
     grad_tup = gradient(forward_mode(backend), f, x, Val(B); shadow=extras.shadow)
     return reshape(collect(grad_tup), size(x))
 end
 
 function DI.value_and_gradient(
-    f, backend::AutoEnzyme{<:ForwardMode,true}, x, extras::EnzymeForwardGradientExtras
+    f, backend::AutoEnzyme{<:ForwardMode}, x, extras::EnzymeForwardGradientExtras
 )
     return f(x), DI.gradient(f, backend, x, extras)
 end
 
 function DI.gradient!(
-    f,
-    grad,
-    backend::AutoEnzyme{<:ForwardMode,true},
-    x,
-    extras::EnzymeForwardGradientExtras{B},
+    f, grad, backend::AutoEnzyme{<:ForwardMode}, x, extras::EnzymeForwardGradientExtras{B}
 ) where {B}
     grad_tup = gradient(forward_mode(backend), f, x, Val(B); shadow=extras.shadow)
     return copyto!(grad, grad_tup)
 end
 
 function DI.value_and_gradient!(
-    f,
-    grad,
-    backend::AutoEnzyme{<:ForwardMode,true},
-    x,
-    extras::EnzymeForwardGradientExtras{B},
+    f, grad, backend::AutoEnzyme{<:ForwardMode}, x, extras::EnzymeForwardGradientExtras{B}
 ) where {B}
     grad_tup = gradient(forward_mode(backend), f, x, Val(B); shadow=extras.shadow)
     return f(x), copyto!(grad, grad_tup)
@@ -110,7 +102,7 @@ struct EnzymeForwardOneArgJacobianExtras{B,O} <: JacobianExtras
     shadow::O
 end
 
-function DI.prepare_jacobian(f, backend::AutoEnzyme{<:Union{ForwardMode,Nothing},true}, x)
+function DI.prepare_jacobian(f, backend::AutoEnzyme{<:Union{ForwardMode,Nothing}}, x)
     B = pick_batchsize(backend, length(x))
     if B == 1
         shadow = onehot(x)
@@ -122,7 +114,7 @@ end
 
 function DI.jacobian(
     f,
-    backend::AutoEnzyme{<:Union{ForwardMode,Nothing},true},
+    backend::AutoEnzyme{<:Union{ForwardMode,Nothing}},
     x,
     extras::EnzymeForwardOneArgJacobianExtras{B},
 ) where {B}
@@ -134,7 +126,7 @@ end
 
 function DI.value_and_jacobian(
     f,
-    backend::AutoEnzyme{<:Union{ForwardMode,Nothing},true},
+    backend::AutoEnzyme{<:Union{ForwardMode,Nothing}},
     x,
     extras::EnzymeForwardOneArgJacobianExtras,
 )
@@ -144,7 +136,7 @@ end
 function DI.jacobian!(
     f,
     jac,
-    backend::AutoEnzyme{<:Union{ForwardMode,Nothing},true},
+    backend::AutoEnzyme{<:Union{ForwardMode,Nothing}},
     x,
     extras::EnzymeForwardOneArgJacobianExtras,
 )
@@ -154,7 +146,7 @@ end
 function DI.value_and_jacobian!(
     f,
     jac,
-    backend::AutoEnzyme{<:Union{ForwardMode,Nothing},true},
+    backend::AutoEnzyme{<:Union{ForwardMode,Nothing}},
     x,
     extras::EnzymeForwardOneArgJacobianExtras,
 )

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -130,12 +130,12 @@ end
 
 ## Gradient
 
-function DI.prepare_gradient(f, ::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true}, x)
+function DI.prepare_gradient(f, ::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}}, x)
     return NoGradientExtras()
 end
 
 function DI.gradient(
-    f, backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true}, x, ::NoGradientExtras
+    f, backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}}, x, ::NoGradientExtras
 )
     if backend isa AutoDeferredEnzyme
         grad = make_zero(x)
@@ -149,7 +149,7 @@ end
 function DI.gradient!(
     f,
     grad,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true},
+    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     extras::NoGradientExtras,
 )
@@ -164,17 +164,13 @@ function DI.gradient!(
 end
 
 function DI.value_and_gradient(
-    f, backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true}, x, ::NoGradientExtras
+    f, backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}}, x, ::NoGradientExtras
 )
     return DI.value_and_pullback(f, backend, x, true, NoPullbackExtras())
 end
 
 function DI.value_and_gradient!(
-    f,
-    grad,
-    backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing},true},
-    x,
-    ::NoGradientExtras,
+    f, grad, backend::AnyAutoEnzyme{<:Union{ReverseMode,Nothing}}, x, ::NoGradientExtras
 )
     return DI.value_and_pullback!(f, grad, backend, x, true, NoPullbackExtras())
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -32,7 +32,7 @@ function DI.basis(::AutoEnzyme, a::AbstractArray{T}, i::CartesianIndex) where {T
     return b
 end
 
-get_f_and_df(f, ::AnyAutoEnzyme) = f
+get_f_and_df(f, ::AnyAutoEnzyme) = Const(f)
 
 #=
 # commented out until Enzyme errors when non-duplicated data is written to

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -26,7 +26,7 @@ DI.check_available(::AutoEnzyme) = true
 DI.pick_batchsize(::AnyAutoEnzyme, dimension::Integer) = min(dimension, 16)
 
 # Enzyme's `Duplicated(x, dx)` expects both arguments to be of the same type
-function DI.basis(::AutoEnzyme, a::AbstractArray{T}, i::CartesianIndex) where {T}
+function DI.basis(::AnyAutoEnzyme, a::AbstractArray{T}, i::CartesianIndex) where {T}
     b = zero(a)
     b[i] = one(T)
     return b

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -32,7 +32,7 @@ function DI.basis(::AutoEnzyme, a::AbstractArray{T}, i::CartesianIndex) where {T
     return b
 end
 
-get_f_and_df(f, ::AnyAutoEnzyme) = Const(f)
+get_f_and_df(f, ::AnyAutoEnzyme) = f
 
 #=
 # commented out until Enzyme errors when non-duplicated data is written to

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -32,9 +32,10 @@ function DI.basis(::AutoEnzyme, a::AbstractArray{T}, i::CartesianIndex) where {T
     return b
 end
 
-function get_f_and_df(f, ::AnyAutoEnzyme{M,true}) where {M}
-    return Const(f)
-end
+get_f_and_df(f, ::AnyAutoEnzyme) = Const(f)
+
+#=
+# commented out until Enzyme errors when non-duplicated data is written to
 
 function get_f_and_df(f, backend::AnyAutoEnzyme{M,false}) where {M}
     mode = isnothing(backend.mode) ? Reverse : backend.mode
@@ -48,3 +49,4 @@ function get_f_and_df(f, backend::AnyAutoEnzyme{M,false}) where {M}
         error("Unexpected activity guessed for the function `f`.")
     end
 end
+=#

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -13,8 +13,6 @@ dense_backends = [
     AutoEnzyme(; mode=nothing),
     AutoEnzyme(; mode=Enzyme.Forward),
     AutoEnzyme(; mode=Enzyme.Reverse),
-    AutoEnzyme(; mode=Enzyme.Forward, constant_function=false),
-    AutoEnzyme(; mode=Enzyme.Reverse, constant_function=false),
 ]
 
 nested_dense_backends = [
@@ -42,16 +40,6 @@ end
 test_differentiation(
     vcat(dense_backends, nested_dense_backends),
     default_scenarios();
-    second_order=false,
-    logging=LOGGING,
-);
-
-test_differentiation(
-    [
-        AutoEnzyme(; mode=Enzyme.Forward, constant_function=false),
-        AutoEnzyme(; mode=Enzyme.Reverse, constant_function=false),
-    ],
-    DIT.make_closure.(default_scenarios());
     second_order=false,
     logging=LOGGING,
 );

--- a/DifferentiationInterface/test/Back/SecondOrder/test.jl
+++ b/DifferentiationInterface/test/Back/SecondOrder/test.jl
@@ -21,12 +21,8 @@ onearg_backends = [
 twoarg_backends = [
     SecondOrder(AutoForwardDiff(), AutoReverseDiff(; compile=true)),
     SecondOrder(AutoForwardDiff(; tag=:mytag), AutoReverseDiff(; compile=false)),
-    SecondOrder(
-        AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Forward, constant_function=true)
-    ),
-    SecondOrder(
-        AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true), AutoForwardDiff()
-    ),
+    SecondOrder(AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Forward)),
+    SecondOrder(AutoEnzyme(; mode=Enzyme.Reverse), AutoForwardDiff()),
 ]
 
 for backend in vcat(onearg_backends, twoarg_backends)

--- a/DifferentiationInterface/test/Down/Detector/test.jl
+++ b/DifferentiationInterface/test/Down/Detector/test.jl
@@ -27,7 +27,7 @@ g(x::AbstractVector) = dot(x, Hc, x)
 g(x::AbstractMatrix) = g(vec(x))
 
 @testset verbose = true "$(typeof(backend))" for backend in [
-    AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true), AutoForwardDiff()
+    AutoEnzyme(; mode=Enzyme.Reverse), AutoForwardDiff()
 ]
     @test_throws ArgumentError DenseSparsityDetector(backend; atol=1e-5, method=:random)
     @testset "$method" for method in (:iterative, :direct)

--- a/DifferentiationInterfaceTest/docs/src/tutorial.md
+++ b/DifferentiationInterfaceTest/docs/src/tutorial.md
@@ -12,7 +12,7 @@ import ForwardDiff, Enzyme
 The AD backends we want to compare are [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) and [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl).
 
 ```@example tuto
-backends = [AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Reverse, constant_function=true)]
+backends = [AutoForwardDiff(), AutoEnzyme(; mode=Enzyme.Reverse)]
 ```
 
 To do that, we are going to take gradients of a simple function:


### PR DESCRIPTION
> [!WARNING]  
> This is a temporary reversion, until @wsmoses can throw an Enzyme error when closures are insufficiently `Duplicated`. Then we will probably yank a few ADTypes releases and change the default to `AutoEnzyme(constant_function=nothing)`. The goal right now is to make a new release of DI without breaking any code.

**DI extensions**

- Enzyme: Comment out the more complicated `get_f_and_df` from #375 and #382. All functions are considered constant regardless of the `constant_function=true` argument to `AutoEnzyme`

**DI tests and docs**

- Remove `constant_function=true` everywhere