### PR TITLE
Get rid of `constant_function` in `AutoEnzyme`

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.5.10"
+version = "0.5.11"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -44,7 +44,7 @@ DifferentiationInterfaceTrackerExt = "Tracker"
 DifferentiationInterfaceZygoteExt = ["Zygote", "ForwardDiff"]
 
 [compat]
-ADTypes = "1.6.1"
+ADTypes = "1.6.2"
 ChainRulesCore = "1.23.0"
 Compat = "3.46,4.2"
 Diffractor = "=0.2.6"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -1,11 +1,11 @@
-struct AutoDeferredEnzyme{M,constant_function} <: ADTypes.AbstractADType
+struct AutoDeferredEnzyme{M} <: ADTypes.AbstractADType
     mode::M
 end
 
 ADTypes.mode(backend::AutoDeferredEnzyme) = ADTypes.mode(AutoEnzyme(backend.mode))
 
-function DI.nested(backend::AutoEnzyme{M,constant_function}) where {M,constant_function}
-    return AutoDeferredEnzyme{M,constant_function}(backend.mode)
+function DI.nested(backend::AutoEnzyme{M}) where {M}
+    return AutoDeferredEnzyme{M}(backend.mode)
 end
 
 const AnyAutoEnzyme{M,constant_function} = Union{
@@ -33,20 +33,3 @@ function DI.basis(::AnyAutoEnzyme, a::AbstractArray{T}, i::CartesianIndex) where
 end
 
 get_f_and_df(f, ::AnyAutoEnzyme) = Const(f)
-
-#=
-# commented out until Enzyme errors when non-duplicated data is written to
-
-function get_f_and_df(f, backend::AnyAutoEnzyme{M,false}) where {M}
-    mode = isnothing(backend.mode) ? Reverse : backend.mode
-    A = guess_activity(typeof(f), mode)
-    if A <: Const || A <: Active
-        return Const(f)
-    elseif A <: Duplicated || A <: DuplicatedNoNeed || A <: MixedDuplicated
-        df = make_zero(f)
-        return Duplicated(f, df)
-    else
-        error("Unexpected activity guessed for the function `f`.")
-    end
-end
-=#

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -8,9 +8,7 @@ function DI.nested(backend::AutoEnzyme{M}) where {M}
     return AutoDeferredEnzyme{M}(backend.mode)
 end
 
-const AnyAutoEnzyme{M,constant_function} = Union{
-    AutoEnzyme{M,constant_function},AutoDeferredEnzyme{M,constant_function}
-}
+const AnyAutoEnzyme{M} = Union{AutoEnzyme{M},AutoDeferredEnzyme{M}}
 
 # forward mode if possible
 forward_mode(backend::AnyAutoEnzyme{<:Mode}) = backend.mode

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -38,7 +38,7 @@ DifferentiationInterfaceTestLuxExt = ["ComponentArrays", "FiniteDiff", "Lux", "L
 DifferentiationInterfaceTestStaticArraysExt = "StaticArrays"
 
 [compat]
-ADTypes = "1.0.0"
+ADTypes = "1.6.2"
 Chairmarks = "1.2.1"
 Compat = "3.46,4.2"
 ComponentArrays = "0.15"


### PR DESCRIPTION
**Versions**

- Bump DI to v0.5.11
- Bump ADTypes compat to v1.6.2 following https://github.com/SciML/ADTypes.jl/pull/74

**DI extensions**

- Enzyme: Remove all traces of `constant_function`