### PR TITLE
Implement automatic preparation with eval macro

### DIFF
--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -71,6 +71,8 @@ include("second_order/hvp.jl")
 include("second_order/hvp_batched.jl")
 include("second_order/hessian.jl")
 
+include("fallbacks/no_extras.jl")
+
 include("sparse/fallbacks.jl")
 include("sparse/matrices.jl")
 include("sparse/jacobian.jl")

--- a/DifferentiationInterface/src/fallbacks/no_extras.jl
+++ b/DifferentiationInterface/src/fallbacks/no_extras.jl
@@ -1,0 +1,107 @@
+for op in (:derivative, :gradient, :jacobian)
+    op! = Symbol(op, "!")
+    val_prefix = "value_and_"
+    val_and_op = Symbol(val_prefix, op)
+    val_and_op! = Symbol(val_prefix, op!)
+    prep_op = Symbol("prepare_", op)
+    # 1-arg
+    @eval begin
+        function $op(f::F, backend::AbstractADType, x) where {F}
+            return $op(f, backend, x, $prep_op(f, backend, x))
+        end
+        function $op!(f::F, result, backend::AbstractADType, x) where {F}
+            return $op!(f, result, backend, x, $prep_op(f, backend, x))
+        end
+        function $val_and_op(f::F, backend::AbstractADType, x) where {F}
+            return $val_and_op(f, backend, x, $prep_op(f, backend, x))
+        end
+        function $val_and_op!(f::F, result, backend::AbstractADType, x) where {F}
+            return $val_and_op!(f, result, backend, x, $prep_op(f, backend, x))
+        end
+    end
+    op == :gradient && continue
+    # 2-arg
+    @eval begin
+        function $op(f!::F, y, backend::AbstractADType, x) where {F}
+            return $op(f!, y, backend, x, $prep_op(f!, y, backend, x))
+        end
+        function $op!(f!::F, y, result, backend::AbstractADType, x) where {F}
+            return $op!(f!, y, result, backend, x, $prep_op(f!, y, backend, x))
+        end
+        function $val_and_op(f!::F, y, backend::AbstractADType, x) where {F}
+            return $val_and_op(f!, y, backend, x, $prep_op(f!, y, backend, x))
+        end
+        function $val_and_op!(f!::F, y, result, backend::AbstractADType, x) where {F}
+            return $val_and_op!(f!, y, result, backend, x, $prep_op(f!, y, backend, x))
+        end
+    end
+end
+
+for op in (:second_derivative, :hessian)
+    op! = Symbol(op, "!")
+    val_prefix = if op == :second_derivative
+        "value_and_derivative_and_"
+    elseif op == :hessian
+        "value_and_gradient_and_"
+    end
+    val_and_op = Symbol("value_and_", op)
+    val_and_op! = Symbol("value_and_", op!)
+    prep_op = Symbol("prepare_", op)
+    # 1-arg
+    @eval begin
+        function $op(f::F, backend::AbstractADType, x) where {F}
+            return $op(f, backend, x, $prep_op(f, backend, x))
+        end
+        function $op!(f::F, result2, backend::AbstractADType, x) where {F}
+            return $op!(f, resul2, backend, x, $prep_op(f, backend, x))
+        end
+        function $val_and_op(f::F, backend::AbstractADType, x) where {F}
+            return $val_and_op(f, backend, x, $prep_op(f, backend, x))
+        end
+        function $val_and_op!(f::F, result1, result2, backend::AbstractADType, x) where {F}
+            return $val_and_op!(f, result1, result2, backend, x, $prep_op(f, backend, x))
+        end
+    end
+end
+
+for op in
+    (:pushforward, :pushforward_batched, :pullback, :pullback_batched, :hvp, :hvp_batched)
+    op! = Symbol(op, "!")
+    val_prefix = "value_and_"
+    val_and_op = Symbol(val_prefix, op)
+    val_and_op! = Symbol(val_prefix, op!)
+    prep_op = Symbol("prepare_", op)
+    # 1-arg
+    @eval begin
+        function $op(f::F, backend::AbstractADType, x, seed) where {F}
+            return $op(f, backend, x, seed, $prep_op(f, backend, x, seed))
+        end
+        function $op!(f::F, result, backend::AbstractADType, x, seed) where {F}
+            return $op!(f, result, backend, x, seed, $prep_op(f, backend, x, seed))
+        end
+    end
+    op == :hvp && continue
+    # 2-arg
+    @eval begin
+        function $val_and_op(f::F, backend::AbstractADType, x, seed) where {F}
+            return $val_and_op(f, backend, x, seed, $prep_op(f, backend, x, seed))
+        end
+        function $val_and_op!(f::F, result, backend::AbstractADType, x, seed) where {F}
+            return $val_and_op!(f, result, backend, x, seed, $prep_op(f, backend, x, seed))
+        end
+        function $op(f!::F, y, backend::AbstractADType, x, seed) where {F}
+            return $op(f!, y, backend, x, seed, $prep_op(f!, y, backend, x, seed))
+        end
+        function $op!(f!::F, y, result, backend::AbstractADType, x, seed) where {F}
+            return $op!(f!, y, result, backend, x, seed, $prep_op(f!, y, backend, x, seed))
+        end
+        function $val_and_op(f!::F, y, backend::AbstractADType, x, seed) where {F}
+            return $val_and_op(f!, y, backend, x, seed, $prep_op(f!, y, backend, x, seed))
+        end
+        function $val_and_op!(f!::F, y, result, backend::AbstractADType, x, seed) where {F}
+            return $val_and_op!(
+                f!, y, result, backend, x, seed, $prep_op(f!, y, backend, x, seed)
+            )
+        end
+    end
+end

--- a/DifferentiationInterface/src/fallbacks/no_extras.jl
+++ b/DifferentiationInterface/src/fallbacks/no_extras.jl
@@ -5,62 +5,58 @@ for op in (:derivative, :gradient, :jacobian)
     val_and_op! = Symbol(val_prefix, op!)
     prep_op = Symbol("prepare_", op)
     # 1-arg
-    @eval begin
-        function $op(f::F, backend::AbstractADType, x) where {F}
-            return $op(f, backend, x, $prep_op(f, backend, x))
-        end
-        function $op!(f::F, result, backend::AbstractADType, x) where {F}
-            return $op!(f, result, backend, x, $prep_op(f, backend, x))
-        end
-        function $val_and_op(f::F, backend::AbstractADType, x) where {F}
-            return $val_and_op(f, backend, x, $prep_op(f, backend, x))
-        end
-        function $val_and_op!(f::F, result, backend::AbstractADType, x) where {F}
-            return $val_and_op!(f, result, backend, x, $prep_op(f, backend, x))
-        end
+    @eval function $op(f::F, backend::AbstractADType, x) where {F}
+        return $op(f, backend, x, $prep_op(f, backend, x))
+    end
+    @eval function $op!(f::F, result, backend::AbstractADType, x) where {F}
+        return $op!(f, result, backend, x, $prep_op(f, backend, x))
+    end
+    @eval function $val_and_op(f::F, backend::AbstractADType, x) where {F}
+        return $val_and_op(f, backend, x, $prep_op(f, backend, x))
+    end
+    @eval function $val_and_op!(f::F, result, backend::AbstractADType, x) where {F}
+        return $val_and_op!(f, result, backend, x, $prep_op(f, backend, x))
     end
     op == :gradient && continue
     # 2-arg
-    @eval begin
-        function $op(f!::F, y, backend::AbstractADType, x) where {F}
-            return $op(f!, y, backend, x, $prep_op(f!, y, backend, x))
-        end
-        function $op!(f!::F, y, result, backend::AbstractADType, x) where {F}
-            return $op!(f!, y, result, backend, x, $prep_op(f!, y, backend, x))
-        end
-        function $val_and_op(f!::F, y, backend::AbstractADType, x) where {F}
-            return $val_and_op(f!, y, backend, x, $prep_op(f!, y, backend, x))
-        end
-        function $val_and_op!(f!::F, y, result, backend::AbstractADType, x) where {F}
-            return $val_and_op!(f!, y, result, backend, x, $prep_op(f!, y, backend, x))
-        end
+    @eval function $op(f!::F, y, backend::AbstractADType, x) where {F}
+        return $op(f!, y, backend, x, $prep_op(f!, y, backend, x))
+    end
+    @eval function $op!(f!::F, y, result, backend::AbstractADType, x) where {F}
+        return $op!(f!, y, result, backend, x, $prep_op(f!, y, backend, x))
+    end
+    @eval function $val_and_op(f!::F, y, backend::AbstractADType, x) where {F}
+        return $val_and_op(f!, y, backend, x, $prep_op(f!, y, backend, x))
+    end
+    @eval function $val_and_op!(f!::F, y, result, backend::AbstractADType, x) where {F}
+        return $val_and_op!(f!, y, result, backend, x, $prep_op(f!, y, backend, x))
     end
 end
 
 for op in (:second_derivative, :hessian)
     op! = Symbol(op, "!")
     val_prefix = if op == :second_derivative
-        "value_and_derivative_and_"
+        "value_derivative_and_"
     elseif op == :hessian
-        "value_and_gradient_and_"
+        "value_gradient_and_"
     end
-    val_and_op = Symbol("value_and_", op)
-    val_and_op! = Symbol("value_and_", op!)
+    val_and_op = Symbol(val_prefix, op)
+    val_and_op! = Symbol(val_prefix, op!)
     prep_op = Symbol("prepare_", op)
     # 1-arg
-    @eval begin
-        function $op(f::F, backend::AbstractADType, x) where {F}
-            return $op(f, backend, x, $prep_op(f, backend, x))
-        end
-        function $op!(f::F, result2, backend::AbstractADType, x) where {F}
-            return $op!(f, resul2, backend, x, $prep_op(f, backend, x))
-        end
-        function $val_and_op(f::F, backend::AbstractADType, x) where {F}
-            return $val_and_op(f, backend, x, $prep_op(f, backend, x))
-        end
-        function $val_and_op!(f::F, result1, result2, backend::AbstractADType, x) where {F}
-            return $val_and_op!(f, result1, result2, backend, x, $prep_op(f, backend, x))
-        end
+    @eval function $op(f::F, backend::AbstractADType, x) where {F}
+        return $op(f, backend, x, $prep_op(f, backend, x))
+    end
+    @eval function $op!(f::F, result2, backend::AbstractADType, x) where {F}
+        return $op!(f, result2, backend, x, $prep_op(f, backend, x))
+    end
+    @eval function $val_and_op(f::F, backend::AbstractADType, x) where {F}
+        return $val_and_op(f, backend, x, $prep_op(f, backend, x))
+    end
+    @eval function $val_and_op!(
+        f::F, result1, result2, backend::AbstractADType, x
+    ) where {F}
+        return $val_and_op!(f, result1, result2, backend, x, $prep_op(f, backend, x))
     end
 end
 
@@ -72,36 +68,34 @@ for op in
     val_and_op! = Symbol(val_prefix, op!)
     prep_op = Symbol("prepare_", op)
     # 1-arg
-    @eval begin
-        function $op(f::F, backend::AbstractADType, x, seed) where {F}
-            return $op(f, backend, x, seed, $prep_op(f, backend, x, seed))
-        end
-        function $op!(f::F, result, backend::AbstractADType, x, seed) where {F}
-            return $op!(f, result, backend, x, seed, $prep_op(f, backend, x, seed))
-        end
+    @eval function $op(f::F, backend::AbstractADType, x, seed) where {F}
+        return $op(f, backend, x, seed, $prep_op(f, backend, x, seed))
+    end
+    @eval function $op!(f::F, result, backend::AbstractADType, x, seed) where {F}
+        return $op!(f, result, backend, x, seed, $prep_op(f, backend, x, seed))
     end
     op == :hvp && continue
     # 2-arg
-    @eval begin
-        function $val_and_op(f::F, backend::AbstractADType, x, seed) where {F}
-            return $val_and_op(f, backend, x, seed, $prep_op(f, backend, x, seed))
-        end
-        function $val_and_op!(f::F, result, backend::AbstractADType, x, seed) where {F}
-            return $val_and_op!(f, result, backend, x, seed, $prep_op(f, backend, x, seed))
-        end
-        function $op(f!::F, y, backend::AbstractADType, x, seed) where {F}
-            return $op(f!, y, backend, x, seed, $prep_op(f!, y, backend, x, seed))
-        end
-        function $op!(f!::F, y, result, backend::AbstractADType, x, seed) where {F}
-            return $op!(f!, y, result, backend, x, seed, $prep_op(f!, y, backend, x, seed))
-        end
-        function $val_and_op(f!::F, y, backend::AbstractADType, x, seed) where {F}
-            return $val_and_op(f!, y, backend, x, seed, $prep_op(f!, y, backend, x, seed))
-        end
-        function $val_and_op!(f!::F, y, result, backend::AbstractADType, x, seed) where {F}
-            return $val_and_op!(
-                f!, y, result, backend, x, seed, $prep_op(f!, y, backend, x, seed)
-            )
-        end
+    @eval function $val_and_op(f::F, backend::AbstractADType, x, seed) where {F}
+        return $val_and_op(f, backend, x, seed, $prep_op(f, backend, x, seed))
+    end
+    @eval function $val_and_op!(f::F, result, backend::AbstractADType, x, seed) where {F}
+        return $val_and_op!(f, result, backend, x, seed, $prep_op(f, backend, x, seed))
+    end
+    @eval function $op(f!::F, y, backend::AbstractADType, x, seed) where {F}
+        return $op(f!, y, backend, x, seed, $prep_op(f!, y, backend, x, seed))
+    end
+    @eval function $op!(f!::F, y, result, backend::AbstractADType, x, seed) where {F}
+        return $op!(f!, y, result, backend, x, seed, $prep_op(f!, y, backend, x, seed))
+    end
+    @eval function $val_and_op(f!::F, y, backend::AbstractADType, x, seed) where {F}
+        return $val_and_op(f!, y, backend, x, seed, $prep_op(f!, y, backend, x, seed))
+    end
+    @eval function $val_and_op!(
+        f!::F, y, result, backend::AbstractADType, x, seed
+    ) where {F}
+        return $val_and_op!(
+            f!, y, result, backend, x, seed, $prep_op(f!, y, backend, x, seed)
+        )
     end
 end

--- a/DifferentiationInterface/src/first_order/derivative.jl
+++ b/DifferentiationInterface/src/first_order/derivative.jl
@@ -80,26 +80,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function value_and_derivative(f::F, backend::AbstractADType, x) where {F}
-    return value_and_derivative(f, backend, x, prepare_derivative(f, backend, x))
-end
-
-function value_and_derivative!(f::F, der, backend::AbstractADType, x) where {F}
-    return value_and_derivative!(f, der, backend, x, prepare_derivative(f, backend, x))
-end
-
-function derivative(f::F, backend::AbstractADType, x) where {F}
-    return derivative(f, backend, x, prepare_derivative(f, backend, x))
-end
-
-function derivative!(f::F, der, backend::AbstractADType, x) where {F}
-    return derivative!(f, der, backend, x, prepare_derivative(f, backend, x))
-end
-
-### With extras
-
 function value_and_derivative(
     f::F, backend::AbstractADType, x, extras::PushforwardDerivativeExtras
 ) where {F}
@@ -125,28 +105,6 @@ function derivative!(
 end
 
 ## Two arguments
-
-### Without extras
-
-function value_and_derivative(f!::F, y, backend::AbstractADType, x) where {F}
-    return value_and_derivative(f!, y, backend, x, prepare_derivative(f!, y, backend, x))
-end
-
-function value_and_derivative!(f!::F, y, der, backend::AbstractADType, x) where {F}
-    return value_and_derivative!(
-        f!, y, der, backend, x, prepare_derivative(f!, y, backend, x)
-    )
-end
-
-function derivative(f!::F, y, backend::AbstractADType, x) where {F}
-    return derivative(f!, y, backend, x, prepare_derivative(f!, y, backend, x))
-end
-
-function derivative!(f!::F, y, der, backend::AbstractADType, x) where {F}
-    return derivative!(f!, y, der, backend, x, prepare_derivative(f!, y, backend, x))
-end
-
-### With extras
 
 function value_and_derivative(
     f!::F, y, backend::AbstractADType, x, extras::PushforwardDerivativeExtras

--- a/DifferentiationInterface/src/first_order/gradient.jl
+++ b/DifferentiationInterface/src/first_order/gradient.jl
@@ -68,26 +68,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function value_and_gradient(f::F, backend::AbstractADType, x) where {F}
-    return value_and_gradient(f, backend, x, prepare_gradient(f, backend, x))
-end
-
-function value_and_gradient!(f::F, der, backend::AbstractADType, x) where {F}
-    return value_and_gradient!(f, der, backend, x, prepare_gradient(f, backend, x))
-end
-
-function gradient(f::F, backend::AbstractADType, x) where {F}
-    return gradient(f, backend, x, prepare_gradient(f, backend, x))
-end
-
-function gradient!(f::F, der, backend::AbstractADType, x) where {F}
-    return gradient!(f, der, backend, x, prepare_gradient(f, backend, x))
-end
-
-### With extras
-
 function value_and_gradient(
     f::F, backend::AbstractADType, x, extras::PullbackGradientExtras
 ) where {F}

--- a/DifferentiationInterface/src/first_order/jacobian.jl
+++ b/DifferentiationInterface/src/first_order/jacobian.jl
@@ -134,26 +134,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function jacobian(f::F, backend::AbstractADType, x) where {F}
-    return jacobian(f, backend, x, prepare_jacobian(f, backend, x))
-end
-
-function jacobian!(f::F, jac, backend::AbstractADType, x) where {F}
-    return jacobian!(f, jac, backend, x, prepare_jacobian(f, backend, x))
-end
-
-function value_and_jacobian(f::F, backend::AbstractADType, x) where {F}
-    return value_and_jacobian(f, backend, x, prepare_jacobian(f, backend, x))
-end
-
-function value_and_jacobian!(f::F, jac, backend::AbstractADType, x) where {F}
-    return value_and_jacobian!(f, jac, backend, x, prepare_jacobian(f, backend, x))
-end
-
-### With extras
-
 function jacobian(f::F, backend::AbstractADType, x, extras::JacobianExtras) where {F}
     return jacobian_aux((f,), backend, x, extras)
 end
@@ -175,26 +155,6 @@ function value_and_jacobian!(
 end
 
 ## Two arguments
-
-### Without extras
-
-function jacobian(f!::F, y, backend::AbstractADType, x) where {F}
-    return jacobian(f!, y, backend, x, prepare_jacobian(f!, y, backend, x))
-end
-
-function jacobian!(f!::F, y, jac, backend::AbstractADType, x) where {F}
-    return jacobian!(f!, y, jac, backend, x, prepare_jacobian(f!, y, backend, x))
-end
-
-function value_and_jacobian(f!::F, y, backend::AbstractADType, x) where {F}
-    return value_and_jacobian(f!, y, backend, x, prepare_jacobian(f!, y, backend, x))
-end
-
-function value_and_jacobian!(f!::F, y, jac, backend::AbstractADType, x) where {F}
-    return value_and_jacobian!(f!, y, jac, backend, x, prepare_jacobian(f!, y, backend, x))
-end
-
-### With extras
 
 function jacobian(f!::F, y, backend::AbstractADType, x, extras::JacobianExtras) where {F}
     return jacobian_aux((f!, y), backend, x, extras)

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -160,26 +160,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function value_and_pullback(f::F, backend::AbstractADType, x, dy) where {F}
-    return value_and_pullback(f, backend, x, dy, prepare_pullback(f, backend, x, dy))
-end
-
-function value_and_pullback!(f::F, dx, backend::AbstractADType, x, dy) where {F}
-    return value_and_pullback!(f, dx, backend, x, dy, prepare_pullback(f, backend, x, dy))
-end
-
-function pullback(f::F, backend::AbstractADType, x, dy) where {F}
-    return pullback(f, backend, x, dy, prepare_pullback(f, backend, x, dy))
-end
-
-function pullback!(f::F, dx, backend::AbstractADType, x, dy) where {F}
-    return pullback!(f, dx, backend, x, dy, prepare_pullback(f, backend, x, dy))
-end
-
-### With extras
-
 function value_and_pullback(
     f::F, backend::AbstractADType, x, dy, extras::PushforwardPullbackExtras
 ) where {F}
@@ -219,30 +199,6 @@ function pullback!(
 end
 
 ## Two arguments
-
-### Without extras
-
-function value_and_pullback(f!::F, y, backend::AbstractADType, x, dy) where {F}
-    return value_and_pullback(
-        f!, y, backend, x, dy, prepare_pullback(f!, y, backend, x, dy)
-    )
-end
-
-function value_and_pullback!(f!::F, y, dx, backend::AbstractADType, x, dy) where {F}
-    return value_and_pullback!(
-        f!, y, dx, backend, x, dy, prepare_pullback(f!, y, backend, x, dy)
-    )
-end
-
-function pullback(f!::F, y, backend::AbstractADType, x, dy) where {F}
-    return pullback(f!, y, backend, x, dy, prepare_pullback(f!, y, backend, x, dy))
-end
-
-function pullback!(f!::F, y, dx, backend::AbstractADType, x, dy) where {F}
-    return pullback!(f!, y, dx, backend, x, dy, prepare_pullback(f!, y, backend, x, dy))
-end
-
-### With extras
 
 function value_and_pullback(
     f!::F, y, backend::AbstractADType, x, dy, extras::PushforwardPullbackExtras

--- a/DifferentiationInterface/src/first_order/pullback_batched.jl
+++ b/DifferentiationInterface/src/first_order/pullback_batched.jl
@@ -50,34 +50,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function value_and_pullback_batched(f::F, backend::AbstractADType, x, dy::Batch) where {F}
-    return value_and_pullback_batched(
-        f, backend, x, dy, prepare_pullback_batched(f, backend, x, dy)
-    )
-end
-
-function value_and_pullback_batched!(
-    f::F, dx::Batch, backend::AbstractADType, x, dy::Batch
-) where {F}
-    return value_and_pullback_batched!(
-        f, dx, backend, x, dy, prepare_pullback_batched(f, backend, x, dy)
-    )
-end
-
-function pullback_batched(f::F, backend::AbstractADType, x, dy::Batch) where {F}
-    return pullback_batched(f, backend, x, dy, prepare_pullback_batched(f, backend, x, dy))
-end
-
-function pullback_batched!(f::F, dx::Batch, backend::AbstractADType, x, dy::Batch) where {F}
-    return pullback_batched!(
-        f, dx, backend, x, dy, prepare_pullback_batched(f, backend, x, dy)
-    )
-end
-
-### With extras
-
 function pullback_batched(
     f::F, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
 ) where {F}
@@ -107,40 +79,6 @@ function value_and_pullback_batched!(
 end
 
 ## Two arguments
-
-### Without extras
-
-function value_and_pullback_batched(
-    f!::F, y, backend::AbstractADType, x, dy::Batch
-) where {F}
-    return value_and_pullback_batched(
-        f!, y, backend, x, dy, prepare_pullback_batched(f!, y, backend, x, dy)
-    )
-end
-
-function value_and_pullback_batched!(
-    f!::F, y, dx::Batch, backend::AbstractADType, x, dy::Batch
-) where {F}
-    return value_and_pullback_batched!(
-        f!, y, dx, backend, x, dy, prepare_pullback_batched(f!, y, backend, x, dy)
-    )
-end
-
-function pullback_batched(f!::F, y, backend::AbstractADType, x, dy::Batch) where {F}
-    return pullback_batched(
-        f!, y, backend, x, dy, prepare_pullback_batched(f!, y, backend, x, dy)
-    )
-end
-
-function pullback_batched!(
-    f!::F, y, dx::Batch, backend::AbstractADType, x, dy::Batch
-) where {F}
-    return pullback_batched!(
-        f!, y, dx, backend, x, dy, prepare_pullback_batched(f!, y, backend, x, dy)
-    )
-end
-
-### With extras
 
 function pullback_batched(
     f!::F, y, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -161,28 +161,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function value_and_pushforward(f::F, backend::AbstractADType, x, dx) where {F}
-    return value_and_pushforward(f, backend, x, dx, prepare_pushforward(f, backend, x, dx))
-end
-
-function value_and_pushforward!(f::F, dy, backend::AbstractADType, x, dx) where {F}
-    return value_and_pushforward!(
-        f, dy, backend, x, dx, prepare_pushforward(f, backend, x, dx)
-    )
-end
-
-function pushforward(f::F, backend::AbstractADType, x, dx) where {F}
-    return pushforward(f, backend, x, dx, prepare_pushforward(f, backend, x, dx))
-end
-
-function pushforward!(f::F, dy, backend::AbstractADType, x, dx) where {F}
-    return pushforward!(f, dy, backend, x, dx, prepare_pushforward(f, backend, x, dx))
-end
-
-### With extras
-
 function value_and_pushforward(
     f::F, backend::AbstractADType, x, dx, extras::PullbackPushforwardExtras
 ) where {F}
@@ -224,32 +202,6 @@ function pushforward!(
 end
 
 ## Two arguments
-
-### Without extras
-
-function value_and_pushforward(f!::F, y, backend::AbstractADType, x, dx) where {F}
-    return value_and_pushforward(
-        f!, y, backend, x, dx, prepare_pushforward(f!, y, backend, x, dx)
-    )
-end
-
-function value_and_pushforward!(f!::F, y, dy, backend::AbstractADType, x, dx) where {F}
-    return value_and_pushforward!(
-        f!, y, dy, backend, x, dx, prepare_pushforward(f!, y, backend, x, dx)
-    )
-end
-
-function pushforward(f!::F, y, backend::AbstractADType, x, dx) where {F}
-    return pushforward(f!, y, backend, x, dx, prepare_pushforward(f!, y, backend, x, dx))
-end
-
-function pushforward!(f!::F, y, dy, backend::AbstractADType, x, dx) where {F}
-    return pushforward!(
-        f!, y, dy, backend, x, dx, prepare_pushforward(f!, y, backend, x, dx)
-    )
-end
-
-### With extras
 
 function value_and_pushforward(
     f!::F, y, backend::AbstractADType, x, dx, extras::PullbackPushforwardExtras

--- a/DifferentiationInterface/src/first_order/pushforward_batched.jl
+++ b/DifferentiationInterface/src/first_order/pushforward_batched.jl
@@ -52,40 +52,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function value_and_pushforward_batched(
-    f::F, backend::AbstractADType, x, dx::Batch
-) where {F}
-    return value_and_pushforward_batched(
-        f, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
-    )
-end
-
-function value_and_pushforward_batched!(
-    f::F, dy::Batch, backend::AbstractADType, x, dx::Batch
-) where {F}
-    return value_and_pushforward_batched!(
-        f, dy, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
-    )
-end
-
-function pushforward_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
-    return pushforward_batched(
-        f, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
-    )
-end
-
-function pushforward_batched!(
-    f::F, dy::Batch, backend::AbstractADType, x, dx::Batch
-) where {F}
-    return pushforward_batched!(
-        f, dy, backend, x, dx, prepare_pushforward_batched(f, backend, x, dx)
-    )
-end
-
-### With extras
-
 function pushforward_batched(
     f::F, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
 ) where {F}
@@ -115,40 +81,6 @@ function value_and_pushforward_batched!(
 end
 
 ## Two arguments
-
-### Without extras
-
-function value_and_pushforward_batched(
-    f!::F, y, backend::AbstractADType, x, dx::Batch
-) where {F}
-    return value_and_pushforward_batched(
-        f!, y, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
-    )
-end
-
-function value_and_pushforward_batched!(
-    f!::F, y, dy::Batch, backend::AbstractADType, x, dx::Batch
-) where {F}
-    return value_and_pushforward_batched!(
-        f!, y, dy, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
-    )
-end
-
-function pushforward_batched(f!::F, y, backend::AbstractADType, x, dx::Batch) where {F}
-    return pushforward_batched(
-        f!, y, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
-    )
-end
-
-function pushforward_batched!(
-    f!::F, y, dy::Batch, backend::AbstractADType, x, dx::Batch
-) where {F}
-    return pushforward_batched!(
-        f!, y, dy, backend, x, dx, prepare_pushforward_batched(f!, y, backend, x, dx)
-    )
-end
-
-### With extras
 
 function pushforward_batched(
     f!::F, y, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -87,28 +87,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function value_gradient_and_hessian(f::F, backend::AbstractADType, x) where {F}
-    return value_gradient_and_hessian(f, backend, x, prepare_hessian(f, backend, x))
-end
-
-function value_gradient_and_hessian!(f::F, grad, hess, backend::AbstractADType, x) where {F}
-    return value_gradient_and_hessian!(
-        f, grad, hess, backend, x, prepare_hessian(f, backend, x)
-    )
-end
-
-function hessian(f::F, backend::AbstractADType, x) where {F}
-    return hessian(f, backend, x, prepare_hessian(f, backend, x))
-end
-
-function hessian!(f::F, hess, backend::AbstractADType, x) where {F}
-    return hessian!(f, hess, backend, x, prepare_hessian(f, backend, x))
-end
-
-### With extras
-
 function hessian(
     f::F, backend::AbstractADType, x, extras::HVPGradientHessianExtras{B}
 ) where {F,B}

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -124,18 +124,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function hvp(f::F, backend::AbstractADType, x, dx) where {F}
-    return hvp(f, backend, x, dx, prepare_hvp(f, backend, x, dx))
-end
-
-function hvp!(f::F, dg, backend::AbstractADType, x, dx) where {F}
-    return hvp!(f, dg, backend, x, dx, prepare_hvp(f, backend, x, dx))
-end
-
-### With extras
-
 function hvp(f::F, backend::AbstractADType, x, dx, extras::HVPExtras) where {F}
     return hvp(f, SecondOrder(backend, backend), x, dx, extras)
 end

--- a/DifferentiationInterface/src/second_order/hvp_batched.jl
+++ b/DifferentiationInterface/src/second_order/hvp_batched.jl
@@ -73,18 +73,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function hvp_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
-    return hvp_batched(f, backend, x, dx, prepare_hvp_batched(f, backend, x, dx))
-end
-
-function hvp_batched!(f::F, dg::Batch, backend::AbstractADType, x, dx::Batch) where {F}
-    return hvp_batched!(f, dg, backend, x, dx, prepare_hvp_batched(f, backend, x, dx))
-end
-
-### With extras
-
 function hvp_batched(
     f::F, backend::AbstractADType, x, dx::Batch, extras::HVPExtras
 ) where {F}

--- a/DifferentiationInterface/src/second_order/second_derivative.jl
+++ b/DifferentiationInterface/src/second_order/second_derivative.jl
@@ -85,32 +85,6 @@ end
 
 ## One argument
 
-### Without extras
-
-function value_derivative_and_second_derivative(f::F, backend::AbstractADType, x) where {F}
-    return value_derivative_and_second_derivative(
-        f, backend, x, prepare_second_derivative(f, backend, x)
-    )
-end
-
-function value_derivative_and_second_derivative!(
-    f::F, der, der2, backend::AbstractADType, x
-) where {F}
-    return value_derivative_and_second_derivative!(
-        f, der, der2, backend, x, prepare_second_derivative(f, backend, x)
-    )
-end
-
-function second_derivative(f::F, backend::AbstractADType, x) where {F}
-    return second_derivative(f, backend, x, prepare_second_derivative(f, backend, x))
-end
-
-function second_derivative!(f::F, der2, backend::AbstractADType, x) where {F}
-    return second_derivative!(f, der2, backend, x, prepare_second_derivative(f, backend, x))
-end
-
-### With extras
-
 function second_derivative(
     f::F, backend::AbstractADType, x, extras::SecondDerivativeExtras
 ) where {F}


### PR DESCRIPTION
**DI source**

- For every operator variant, implement the following with the `@eval` macro:

```julia
operator(f, backend, x) = operator(f, backend, x, prepare_operator(f, backend, x))
```