### PR TITLE
Add same-point preparation to fallback macros

### DIFF
--- a/DifferentiationInterface/src/fallbacks/no_extras.jl
+++ b/DifferentiationInterface/src/fallbacks/no_extras.jl
@@ -67,7 +67,23 @@ for op in
     val_and_op = Symbol(val_prefix, op)
     val_and_op! = Symbol(val_prefix, op!)
     prep_op = Symbol("prepare_", op)
+    prep_op_same_point = Symbol("prepare_", op, "_same_point")
+    E = if startswith(string(op), "pushforward")
+        PushforwardExtras
+    elseif startswith(string(op), "pullback")
+        PullbackExtras
+    elseif startswith(string(op), "hvp")
+        HVPExtras
+    end
     # 1-arg
+    @eval function $prep_op_same_point(f::F, backend::AbstractADType, x, seed) where {F}
+        return $prep_op_same_point(f, backend, x, seed, $prep_op(f, backend, x, seed))
+    end
+    @eval function $prep_op_same_point(
+        f::F, backend::AbstractADType, x, seed, ex::$E
+    ) where {F}
+        return ex
+    end
     @eval function $op(f::F, backend::AbstractADType, x, seed) where {F}
         return $op(f, backend, x, seed, $prep_op(f, backend, x, seed))
     end
@@ -75,12 +91,22 @@ for op in
         return $op!(f, result, backend, x, seed, $prep_op(f, backend, x, seed))
     end
     op == :hvp && continue
-    # 2-arg
     @eval function $val_and_op(f::F, backend::AbstractADType, x, seed) where {F}
         return $val_and_op(f, backend, x, seed, $prep_op(f, backend, x, seed))
     end
     @eval function $val_and_op!(f::F, result, backend::AbstractADType, x, seed) where {F}
         return $val_and_op!(f, result, backend, x, seed, $prep_op(f, backend, x, seed))
+    end
+    # 2-arg
+    @eval function $prep_op_same_point(f!::F, y, backend::AbstractADType, x, seed) where {F}
+        return $prep_op_same_point(
+            f!, y, backend, x, seed, $prep_op(f!, y, backend, x, seed)
+        )
+    end
+    @eval function $prep_op_same_point(
+        f!::F, y, backend::AbstractADType, x, seed, ex::$E
+    ) where {F}
+        return ex
     end
     @eval function $op(f!::F, y, backend::AbstractADType, x, seed) where {F}
         return $op(f!, y, backend, x, seed, $prep_op(f!, y, backend, x, seed))

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -100,8 +100,6 @@ struct PushforwardPullbackExtras{E} <: PullbackExtras
     pushforward_extras::E
 end
 
-## Different point
-
 function prepare_pullback(f::F, backend::AbstractADType, x, dy) where {F}
     return prepare_pullback_aux(f, backend, x, dy, pullback_performance(backend))
 end
@@ -132,30 +130,6 @@ end
 
 function prepare_pullback_aux(f!, y, backend::AbstractADType, x, dy, ::PullbackFast)
     throw(MissingBackendError(backend))
-end
-
-### Same point
-
-function prepare_pullback_same_point(
-    f::F, backend::AbstractADType, x, dy, extras::PullbackExtras
-) where {F}
-    return extras
-end
-
-function prepare_pullback_same_point(
-    f!::F, y, backend::AbstractADType, x, dy, extras::PullbackExtras
-) where {F}
-    return extras
-end
-
-function prepare_pullback_same_point(f::F, backend::AbstractADType, x, dy) where {F}
-    extras = prepare_pullback(f, backend, x, dy)
-    return prepare_pullback_same_point(f, backend, x, dy, extras)
-end
-
-function prepare_pullback_same_point(f!::F, y, backend::AbstractADType, x, dy) where {F}
-    extras = prepare_pullback(f!, y, backend, x, dy)
-    return prepare_pullback_same_point(f!, y, backend, x, dy, extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/first_order/pullback_batched.jl
+++ b/DifferentiationInterface/src/first_order/pullback_batched.jl
@@ -10,42 +10,12 @@ function pullback_batched! end
 
 ## Preparation
 
-### Different point
-
 function prepare_pullback_batched(f::F, backend::AbstractADType, x, dy::Batch) where {F}
     return prepare_pullback(f, backend, x, first(dy.elements))
 end
 
 function prepare_pullback_batched(f!::F, y, backend::AbstractADType, x, dy::Batch) where {F}
     return prepare_pullback(f!, y, backend, x, first(dy.elements))
-end
-
-### Same point
-
-function prepare_pullback_batched_same_point(
-    f::F, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
-) where {F}
-    return prepare_pullback_same_point(f, backend, x, first(dy.elements), extras)
-end
-
-function prepare_pullback_batched_same_point(
-    f!::F, y, backend::AbstractADType, x, dy::Batch, extras::PullbackExtras
-) where {F}
-    return prepare_pullback_same_point(f!, y, backend, x, first(dy.elements), extras)
-end
-
-function prepare_pullback_batched_same_point(
-    f::F, backend::AbstractADType, x, dy::Batch
-) where {F}
-    extras = prepare_pullback_batched(f, backend, x, dy)
-    return prepare_pullback_batched_same_point(f, backend, x, dy, extras)
-end
-
-function prepare_pullback_batched_same_point(
-    f!::F, y, backend::AbstractADType, x, dy::Batch
-) where {F}
-    extras = prepare_pullback_batched(f!, y, backend, x, dy)
-    return prepare_pullback_batched_same_point(f!, y, backend, x, dy, extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -100,8 +100,6 @@ struct PullbackPushforwardExtras{E} <: PushforwardExtras
     pullback_extras::E
 end
 
-### Different point
-
 function prepare_pushforward(f::F, backend::AbstractADType, x, dx) where {F}
     return prepare_pushforward_aux(f, backend, x, dx, pushforward_performance(backend))
 end
@@ -133,30 +131,6 @@ end
 
 function prepare_pushforward_aux(f!, y, backend::AbstractADType, x, dx, ::PushforwardFast)
     throw(MissingBackendError(backend))
-end
-
-### Same point
-
-function prepare_pushforward_same_point(
-    f::F, backend::AbstractADType, x, dx, extras::PushforwardExtras
-) where {F}
-    return extras
-end
-
-function prepare_pushforward_same_point(
-    f!::F, y, backend::AbstractADType, x, dx, extras::PushforwardExtras
-) where {F}
-    return extras
-end
-
-function prepare_pushforward_same_point(f::F, backend::AbstractADType, x, dx) where {F}
-    extras = prepare_pushforward(f, backend, x, dx)
-    return prepare_pushforward_same_point(f, backend, x, dx, extras)
-end
-
-function prepare_pushforward_same_point(f!::F, y, backend::AbstractADType, x, dx) where {F}
-    extras = prepare_pushforward(f!, y, backend, x, dx)
-    return prepare_pushforward_same_point(f!, y, backend, x, dx, extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/first_order/pushforward_batched.jl
+++ b/DifferentiationInterface/src/first_order/pushforward_batched.jl
@@ -10,8 +10,6 @@ function pushforward_batched! end
 
 ## Preparation
 
-### Different point
-
 function prepare_pushforward_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
     return prepare_pushforward(f, backend, x, first(dx.elements))
 end
@@ -20,34 +18,6 @@ function prepare_pushforward_batched(
     f!::F, y, backend::AbstractADType, x, dx::Batch
 ) where {F}
     return prepare_pushforward(f!, y, backend, x, first(dx.elements))
-end
-
-### Same point
-
-function prepare_pushforward_batched_same_point(
-    f::F, backend::AbstractADType, x, dx::Batch
-) where {F}
-    extras = prepare_pushforward_batched(f, backend, x, dx)
-    return prepare_pushforward_batched_same_point(f, backend, x, dx, extras)
-end
-
-function prepare_pushforward_batched_same_point(
-    f!::F, y, backend::AbstractADType, x, dx::Batch
-) where {F}
-    extras = prepare_pushforward_batched(f!, y, backend, x, dx)
-    return prepare_pushforward_batched_same_point(f!, y, backend, x, dx, extras)
-end
-
-function prepare_pushforward_batched_same_point(
-    f::F, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
-) where {F}
-    return prepare_pushforward_same_point(f, backend, x, first(dx.elements), extras)
-end
-
-function prepare_pushforward_batched_same_point(
-    f!::F, y, backend::AbstractADType, x, dx::Batch, extras::PushforwardExtras
-) where {F}
-    return prepare_pushforward_same_point(f!, y, backend, x, first(dx.elements), extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -70,8 +70,6 @@ struct ReverseOverReverseHVPExtras{G<:Gradient,E<:PullbackExtras} <: HVPExtras
     outer_pullback_extras::E
 end
 
-### Different point
-
 function prepare_hvp(f::F, backend::AbstractADType, x, dx) where {F}
     return prepare_hvp(f, SecondOrder(backend, backend), x, dx)
 end
@@ -107,19 +105,6 @@ function prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ReverseOverReverse
     inner_gradient = Gradient(f, nested(inner(backend)))
     outer_pullback_extras = prepare_pullback(inner_gradient, outer(backend), x, dx)
     return ReverseOverReverseHVPExtras(inner_gradient, outer_pullback_extras)
-end
-
-### Same point
-
-function prepare_hvp_same_point(
-    f::F, backend::AbstractADType, x, dx, extras::HVPExtras
-) where {F}
-    return extras
-end
-
-function prepare_hvp_same_point(f::F, backend::AbstractADType, x, dx) where {F}
-    extras = prepare_hvp(f, backend, x, dx)
-    return prepare_hvp_same_point(f, backend, x, dx, extras)
 end
 
 ## One argument

--- a/DifferentiationInterface/src/second_order/hvp_batched.jl
+++ b/DifferentiationInterface/src/second_order/hvp_batched.jl
@@ -8,8 +8,6 @@ function hvp_batched! end
 
 ## Preparation
 
-### Different point
-
 function prepare_hvp_batched(f::F, backend::AbstractADType, x, dx::Batch) where {F}
     return prepare_hvp_batched(f, SecondOrder(backend, backend), x, dx)
 end
@@ -54,21 +52,6 @@ function prepare_hvp_batched_aux(
     inner_gradient = Gradient(f, nested(inner(backend)))
     outer_pullback_extras = prepare_pullback_batched(inner_gradient, outer(backend), x, dx)
     return ReverseOverReverseHVPExtras(inner_gradient, outer_pullback_extras)
-end
-
-### Same point
-
-function prepare_hvp_batched_same_point(
-    f::F, backend::AbstractADType, x, dx::Batch, extras::HVPExtras
-) where {F}
-    return extras
-end
-
-function prepare_hvp_batched_same_point(
-    f::F, backend::AbstractADType, x, dx::Batch
-) where {F}
-    extras = prepare_hvp_batched(f, backend, x, dx)
-    return prepare_hvp_batched_same_point(f, backend, x, dx, extras)
 end
 
 ## One argument


### PR DESCRIPTION
**DI source**

- Implement same-point preparation defaults with the rest of the `@eval`-based fallbacks