### PR TITLE
Refactor `pushforward` and `pullback`

### DIFF
--- a/DifferentiationInterface/src/first_order/jacobian.jl
+++ b/DifferentiationInterface/src/first_order/jacobian.jl
@@ -70,14 +70,14 @@ end
 
 function prepare_jacobian(f::F, backend::AbstractADType, x) where {F}
     y = f(x)
-    return prepare_jacobian_aux((f,), backend, x, y, pushforward_performance(backend))
+    return _prepare_jacobian_aux((f,), backend, x, y, pushforward_performance(backend))
 end
 
 function prepare_jacobian(f!::F, y, backend::AbstractADType, x) where {F}
-    return prepare_jacobian_aux((f!, y), backend, x, y, pushforward_performance(backend))
+    return _prepare_jacobian_aux((f!, y), backend, x, y, pushforward_performance(backend))
 end
 
-function prepare_jacobian_aux(
+function _prepare_jacobian_aux(
     f_or_f!y::FY, backend::AbstractADType, x, y, ::PushforwardFast
 ) where {FY}
     N = length(x)
@@ -100,7 +100,7 @@ function prepare_jacobian_aux(
     )
 end
 
-function prepare_jacobian_aux(
+function _prepare_jacobian_aux(
     f_or_f!y::FY, backend::AbstractADType, x, y, ::PushforwardSlow
 ) where {FY}
     M = length(y)
@@ -126,11 +126,11 @@ end
 ## One argument
 
 function jacobian(f::F, backend::AbstractADType, x, extras::JacobianExtras) where {F}
-    return jacobian_aux((f,), backend, x, extras)
+    return _jacobian_aux((f,), backend, x, extras)
 end
 
 function jacobian!(f::F, jac, backend::AbstractADType, x, extras::JacobianExtras) where {F}
-    return jacobian_aux!((f,), jac, backend, x, extras)
+    return _jacobian_aux!((f,), jac, backend, x, extras)
 end
 
 function value_and_jacobian(
@@ -148,13 +148,13 @@ end
 ## Two arguments
 
 function jacobian(f!::F, y, backend::AbstractADType, x, extras::JacobianExtras) where {F}
-    return jacobian_aux((f!, y), backend, x, extras)
+    return _jacobian_aux((f!, y), backend, x, extras)
 end
 
 function jacobian!(
     f!::F, y, jac, backend::AbstractADType, x, extras::JacobianExtras
 ) where {F}
-    return jacobian_aux!((f!, y), jac, backend, x, extras)
+    return _jacobian_aux!((f!, y), jac, backend, x, extras)
 end
 
 function value_and_jacobian(
@@ -175,7 +175,7 @@ end
 
 ## Common auxiliaries
 
-function jacobian_aux(
+function _jacobian_aux(
     f_or_f!y::FY, backend::AbstractADType, x, extras::PushforwardJacobianExtras{B}
 ) where {FY,B}
     @compat (; batched_seeds, pushforward_batched_extras, N) = extras
@@ -198,7 +198,7 @@ function jacobian_aux(
     return jac
 end
 
-function jacobian_aux(
+function _jacobian_aux(
     f_or_f!y::FY, backend::AbstractADType, x, extras::PullbackJacobianExtras{B}
 ) where {FY,B}
     @compat (; batched_seeds, pullback_batched_extras, M) = extras
@@ -221,7 +221,7 @@ function jacobian_aux(
     return jac
 end
 
-function jacobian_aux!(
+function _jacobian_aux!(
     f_or_f!y::FY, jac, backend::AbstractADType, x, extras::PushforwardJacobianExtras{B}
 ) where {FY,B}
     @compat (; batched_seeds, batched_results, pushforward_batched_extras, N) = extras
@@ -251,7 +251,7 @@ function jacobian_aux!(
     return jac
 end
 
-function jacobian_aux!(
+function _jacobian_aux!(
     f_or_f!y::FY, jac, backend::AbstractADType, x, extras::PullbackJacobianExtras{B}
 ) where {FY,B}
     @compat (; batched_seeds, batched_results, pullback_batched_extras, M) = extras

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -94,14 +94,14 @@ end
 ## Different point
 
 function prepare_pullback(f::F, backend::AbstractADType, x, dy) where {F}
-    return prepare_pullback_aux(f, backend, x, dy, pullback_performance(backend))
+    return _prepare_pullback_aux(f, backend, x, dy, pullback_performance(backend))
 end
 
 function prepare_pullback(f!::F, y, backend::AbstractADType, x, dy) where {F}
-    return prepare_pullback_aux(f!, y, backend, x, dy, pullback_performance(backend))
+    return _prepare_pullback_aux(f!, y, backend, x, dy, pullback_performance(backend))
 end
 
-function prepare_pullback_aux(
+function _prepare_pullback_aux(
     f::F, backend::AbstractADType, x, dy, ::PullbackSlow
 ) where {F}
     dx = x isa Number ? one(x) : basis(backend, x, first(CartesianIndices(x)))
@@ -109,7 +109,7 @@ function prepare_pullback_aux(
     return PushforwardPullbackExtras(pushforward_extras)
 end
 
-function prepare_pullback_aux(
+function _prepare_pullback_aux(
     f!::F, y, backend::AbstractADType, x, dy, ::PullbackSlow
 ) where {F}
     dx = x isa Number ? one(x) : basis(backend, x, first(CartesianIndices(x)))
@@ -117,11 +117,11 @@ function prepare_pullback_aux(
     return PushforwardPullbackExtras(pushforward_extras)
 end
 
-function prepare_pullback_aux(f, backend::AbstractADType, x, dy, ::PullbackFast)
+function _prepare_pullback_aux(f, backend::AbstractADType, x, dy, ::PullbackFast)
     throw(MissingBackendError(backend))
 end
 
-function prepare_pullback_aux(f!, y, backend::AbstractADType, x, dy, ::PullbackFast)
+function _prepare_pullback_aux(f!, y, backend::AbstractADType, x, dy, ::PullbackFast)
     throw(MissingBackendError(backend))
 end
 
@@ -151,24 +151,32 @@ end
 
 ## One argument
 
+function _pullback_via_pushforward(
+    f::F, backend::AbstractADType, x::Number, dy, pushforward_extras::PushforwardExtras
+) where {F}
+    dx = dot(dy, pushforward(f, backend, x, one(x), pushforward_extras))
+    return dx
+end
+
+function _pullback_via_pushforward(
+    f::F,
+    backend::AbstractADType,
+    x::AbstractArray,
+    dy,
+    pushforward_extras::PushforwardExtras,
+) where {F}
+    dx = map(CartesianIndices(x)) do j
+        dot(dy, pushforward(f, backend, x, basis(backend, x, j), pushforward_extras))
+    end
+    return dx
+end
+
 function value_and_pullback(
     f::F, backend::AbstractADType, x, dy, extras::PushforwardPullbackExtras
 ) where {F}
     @compat (; pushforward_extras) = extras
     y = f(x)
-    dx = if x isa Number && y isa Number
-        dy * pushforward(f, backend, x, one(x), pushforward_extras)
-    elseif x isa Number && y isa AbstractArray
-        dot(dy, pushforward(f, backend, x, one(x), pushforward_extras))
-    elseif x isa AbstractArray && y isa Number
-        map(CartesianIndices(x)) do j
-            dy * pushforward(f, backend, x, basis(backend, x, j), pushforward_extras)
-        end
-    elseif x isa AbstractArray && y isa AbstractArray
-        map(CartesianIndices(x)) do j
-            dot(dy, pushforward(f, backend, x, basis(backend, x, j), pushforward_extras))
-        end
-    end
+    dx = _pullback_via_pushforward(f, backend, x, dy, pushforward_extras)
     return y, dx
 end
 
@@ -191,17 +199,32 @@ end
 
 ## Two arguments
 
+function _pullback_via_pushforward(
+    f!::F, y, backend::AbstractADType, x::Number, dy, pushforward_extras::PushforwardExtras
+) where {F}
+    dx = dot(dy, pushforward(f!, y, backend, x, one(x), pushforward_extras))
+    return dx
+end
+
+function _pullback_via_pushforward(
+    f!::F,
+    y,
+    backend::AbstractADType,
+    x::AbstractArray,
+    dy,
+    pushforward_extras::PushforwardExtras,
+) where {F}
+    dx = map(CartesianIndices(x)) do j
+        dot(dy, pushforward(f!, y, backend, x, basis(backend, x, j), pushforward_extras))
+    end
+    return dx
+end
+
 function value_and_pullback(
     f!::F, y, backend::AbstractADType, x, dy, extras::PushforwardPullbackExtras
 ) where {F}
     @compat (; pushforward_extras) = extras
-    dx = if x isa Number && y isa AbstractArray
-        dot(dy, pushforward(f!, y, backend, x, one(x), pushforward_extras))
-    elseif x isa AbstractArray && y isa AbstractArray
-        map(CartesianIndices(x)) do j
-            dot(dy, pushforward(f!, y, backend, x, basis(backend, x, j), pushforward_extras))
-        end
-    end
+    dx = _pullback_via_pushforward(f!, y, backend, x, dy, pushforward_extras)
     f!(y, x)
     return y, dx
 end

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -155,7 +155,7 @@ end
 function _pushforward_via_pullback(
     f::F, backend::AbstractADType, x, dx, pullback_extras::PullbackExtras, y::Number
 ) where {F}
-    dy = dot(dx, pullback(f, backend, x, dx, pullback_extras))
+    dy = dot(dx, pullback(f, backend, x, one(y), pullback_extras))
     return dy
 end
 

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -94,14 +94,14 @@ end
 ### Different point
 
 function prepare_pushforward(f::F, backend::AbstractADType, x, dx) where {F}
-    return prepare_pushforward_aux(f, backend, x, dx, pushforward_performance(backend))
+    return _prepare_pushforward_aux(f, backend, x, dx, pushforward_performance(backend))
 end
 
 function prepare_pushforward(f!::F, y, backend::AbstractADType, x, dx) where {F}
-    return prepare_pushforward_aux(f!, y, backend, x, dx, pushforward_performance(backend))
+    return _prepare_pushforward_aux(f!, y, backend, x, dx, pushforward_performance(backend))
 end
 
-function prepare_pushforward_aux(
+function _prepare_pushforward_aux(
     f::F, backend::AbstractADType, x, dx, ::PushforwardSlow
 ) where {F}
     y = f(x)
@@ -110,7 +110,7 @@ function prepare_pushforward_aux(
     return PullbackPushforwardExtras(pullback_extras)
 end
 
-function prepare_pushforward_aux(
+function _prepare_pushforward_aux(
     f!::F, y, backend::AbstractADType, x, dx, ::PushforwardSlow
 ) where {F}
     dy = y isa Number ? one(y) : basis(backend, y, first(CartesianIndices(y)))
@@ -118,11 +118,11 @@ function prepare_pushforward_aux(
     return PullbackPushforwardExtras(pullback_extras)
 end
 
-function prepare_pushforward_aux(f, backend::AbstractADType, x, dx, ::PushforwardFast)
+function _prepare_pushforward_aux(f, backend::AbstractADType, x, dx, ::PushforwardFast)
     throw(MissingBackendError(backend))
 end
 
-function prepare_pushforward_aux(f!, y, backend::AbstractADType, x, dx, ::PushforwardFast)
+function _prepare_pushforward_aux(f!, y, backend::AbstractADType, x, dx, ::PushforwardFast)
     throw(MissingBackendError(backend))
 end
 
@@ -152,24 +152,28 @@ end
 
 ## One argument
 
+function _pushforward_via_pullback(
+    f::F, backend::AbstractADType, x, dx, pullback_extras::PullbackExtras, y::Number
+) where {F}
+    dy = dot(dx, pullback(f, backend, x, dx, pullback_extras))
+    return dy
+end
+
+function _pushforward_via_pullback(
+    f::F, backend::AbstractADType, x, dx, pullback_extras::PullbackExtras, y::AbstractArray
+) where {F}
+    dy = map(CartesianIndices(y)) do i
+        dot(dx, pullback(f, backend, x, basis(backend, y, i), pullback_extras))
+    end
+    return dy
+end
+
 function value_and_pushforward(
     f::F, backend::AbstractADType, x, dx, extras::PullbackPushforwardExtras
 ) where {F}
     @compat (; pullback_extras) = extras
     y = f(x)
-    dy = if x isa Number && y isa Number
-        dx * pullback(f, backend, x, one(y), pullback_extras)
-    elseif x isa AbstractArray && y isa Number
-        dot(dx, pullback(f, backend, x, one(y), pullback_extras))
-    elseif x isa Number && y isa AbstractArray
-        map(CartesianIndices(y)) do i
-            dx * pullback(f, backend, x, basis(backend, y, i), pullback_extras)
-        end
-    elseif x isa AbstractArray && y isa AbstractArray
-        map(CartesianIndices(y)) do i
-            dot(dx, pullback(f, backend, x, basis(backend, y, i), pullback_extras))
-        end
-    end
+    dy = _pushforward_via_pullback(f, backend, x, dx, pullback_extras, y)
     return y, dy
 end
 
@@ -194,19 +198,20 @@ end
 
 ## Two arguments
 
+function _pushforward_via_pullback(
+    f!::F, y::AbstractArray, backend::AbstractADType, x, dx, pullback_extras::PullbackExtras
+) where {F}
+    dy = map(CartesianIndices(y)) do i
+        dot(dx, pullback(f!, y, backend, x, basis(backend, y, i), pullback_extras))
+    end
+    return dy
+end
+
 function value_and_pushforward(
     f!::F, y, backend::AbstractADType, x, dx, extras::PullbackPushforwardExtras
 ) where {F}
     @compat (; pullback_extras) = extras
-    dy = if x isa Number && y isa AbstractArray
-        map(CartesianIndices(y)) do i
-            dx * pullback(f!, y, backend, x, basis(backend, y, i), pullback_extras)
-        end
-    elseif x isa AbstractArray && y isa AbstractArray
-        map(CartesianIndices(y)) do i
-            dot(dx, pullback(f!, y, backend, x, basis(backend, y, i), pullback_extras))
-        end
-    end
+    dy = _pushforward_via_pullback(f!, y, backend, x, dx, pullback_extras)
     f!(y, x)
     return y, dy
 end

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -68,24 +68,24 @@ function prepare_hvp(f::F, backend::AbstractADType, x, dx) where {F}
 end
 
 function prepare_hvp(f::F, backend::SecondOrder, x, dx) where {F}
-    return prepare_hvp_aux(f, backend, x, dx, hvp_mode(backend))
+    return _prepare_hvp_aux(f, backend, x, dx, hvp_mode(backend))
 end
 
-function prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ForwardOverForward) where {F}
+function _prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ForwardOverForward) where {F}
     # pushforward of many pushforwards in theory, but pushforward of gradient in practice
     inner_gradient = Gradient(f, nested(inner(backend)))
     outer_pushforward_extras = prepare_pushforward(inner_gradient, outer(backend), x, dx)
     return ForwardOverForwardHVPExtras(inner_gradient, outer_pushforward_extras)
 end
 
-function prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ForwardOverReverse) where {F}
+function _prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ForwardOverReverse) where {F}
     # pushforward of gradient
     inner_gradient = Gradient(f, nested(inner(backend)))
     outer_pushforward_extras = prepare_pushforward(inner_gradient, outer(backend), x, dx)
     return ForwardOverReverseHVPExtras(inner_gradient, outer_pushforward_extras)
 end
 
-function prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ReverseOverForward) where {F}
+function _prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ReverseOverForward) where {F}
     # gradient of pushforward
     # uses dx in the closure so it can't be stored
     inner_pushforward = PushforwardFixedSeed(f, nested(inner(backend)), dx)
@@ -93,7 +93,7 @@ function prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ReverseOverForward
     return ReverseOverForwardHVPExtras(outer_gradient_extras)
 end
 
-function prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ReverseOverReverse) where {F}
+function _prepare_hvp_aux(f::F, backend::SecondOrder, x, dx, ::ReverseOverReverse) where {F}
     # pullback of gradient
     inner_gradient = Gradient(f, nested(inner(backend)))
     outer_pullback_extras = prepare_pullback(inner_gradient, outer(backend), x, dx)

--- a/DifferentiationInterface/src/second_order/hvp_batched.jl
+++ b/DifferentiationInterface/src/second_order/hvp_batched.jl
@@ -15,10 +15,10 @@ function prepare_hvp_batched(f::F, backend::AbstractADType, x, dx::Batch) where 
 end
 
 function prepare_hvp_batched(f::F, backend::SecondOrder, x, dx::Batch) where {F}
-    return prepare_hvp_batched_aux(f, backend, x, dx, hvp_mode(backend))
+    return _prepare_hvp_batched_aux(f, backend, x, dx, hvp_mode(backend))
 end
 
-function prepare_hvp_batched_aux(
+function _prepare_hvp_batched_aux(
     f::F, backend::SecondOrder, x, dx::Batch, ::ForwardOverForward
 ) where {F}
     # batched pushforward of gradient
@@ -29,7 +29,7 @@ function prepare_hvp_batched_aux(
     return ForwardOverForwardHVPExtras(inner_gradient, outer_pushforward_extras)
 end
 
-function prepare_hvp_batched_aux(
+function _prepare_hvp_batched_aux(
     f::F, backend::SecondOrder, x, dx::Batch, ::ForwardOverReverse
 ) where {F}
     # batched pushforward of gradient
@@ -40,14 +40,14 @@ function prepare_hvp_batched_aux(
     return ForwardOverReverseHVPExtras(inner_gradient, outer_pushforward_extras)
 end
 
-function prepare_hvp_batched_aux(
+function _prepare_hvp_batched_aux(
     f::F, backend::SecondOrder, x, dx::Batch, ::ReverseOverForward
 ) where {F}
     # TODO: batched version replacing the outer gradient with a pullback
-    return prepare_hvp_aux(f, backend, x, first(dx.elements), ReverseOverForward())
+    return _prepare_hvp_aux(f, backend, x, first(dx.elements), ReverseOverForward())
 end
 
-function prepare_hvp_batched_aux(
+function _prepare_hvp_batched_aux(
     f::F, backend::SecondOrder, x, dx::Batch, ::ReverseOverReverse
 ) where {F}
     # batched pullback of gradient

--- a/DifferentiationInterface/src/sparse/jacobian.jl
+++ b/DifferentiationInterface/src/sparse/jacobian.jl
@@ -66,18 +66,18 @@ end
 
 function prepare_jacobian(f::F, backend::AutoSparse, x) where {F}
     y = f(x)
-    return prepare_sparse_jacobian_aux(
+    return _prepare_sparse_jacobian_aux(
         (f,), backend, x, y, pushforward_performance(backend)
     )
 end
 
 function prepare_jacobian(f!::F, y, backend::AutoSparse, x) where {F}
-    return prepare_sparse_jacobian_aux(
+    return _prepare_sparse_jacobian_aux(
         (f!, y), backend, x, y, pushforward_performance(backend)
     )
 end
 
-function prepare_sparse_jacobian_aux(
+function _prepare_sparse_jacobian_aux(
     f_or_f!y::FY, backend::AutoSparse, x, y, ::PushforwardFast
 ) where {FY}
     dense_backend = dense_ad(backend)
@@ -112,7 +112,7 @@ function prepare_sparse_jacobian_aux(
     )
 end
 
-function prepare_sparse_jacobian_aux(
+function _prepare_sparse_jacobian_aux(
     f_or_f!y::FY, backend::AutoSparse, x, y, ::PushforwardSlow
 ) where {FY}
     dense_backend = dense_ad(backend)
@@ -150,13 +150,13 @@ end
 ## One argument
 
 function jacobian(f::F, backend::AutoSparse, x, extras::SparseJacobianExtras) where {F}
-    return sparse_jacobian_aux((f,), backend, x, extras)
+    return _sparse_jacobian_aux((f,), backend, x, extras)
 end
 
 function jacobian!(
     f::F, jac, backend::AutoSparse, x, extras::SparseJacobianExtras
 ) where {F}
-    return sparse_jacobian_aux!((f,), jac, backend, x, extras)
+    return _sparse_jacobian_aux!((f,), jac, backend, x, extras)
 end
 
 function value_and_jacobian(
@@ -174,13 +174,13 @@ end
 ## Two arguments
 
 function jacobian(f!::F, y, backend::AutoSparse, x, extras::SparseJacobianExtras) where {F}
-    return sparse_jacobian_aux((f!, y), backend, x, extras)
+    return _sparse_jacobian_aux((f!, y), backend, x, extras)
 end
 
 function jacobian!(
     f!::F, y, jac, backend::AutoSparse, x, extras::SparseJacobianExtras
 ) where {F}
-    return sparse_jacobian_aux!((f!, y), jac, backend, x, extras)
+    return _sparse_jacobian_aux!((f!, y), jac, backend, x, extras)
 end
 
 function value_and_jacobian(
@@ -201,7 +201,7 @@ end
 
 ## Common auxiliaries
 
-function sparse_jacobian_aux(
+function _sparse_jacobian_aux(
     f_or_f!y::FY, backend::AutoSparse, x, extras::PushforwardSparseJacobianExtras{B}
 ) where {FY,B}
     @compat (; coloring_result, batched_seeds, pushforward_batched_extras) = extras
@@ -230,7 +230,7 @@ function sparse_jacobian_aux(
     return decompress(compressed_matrix, coloring_result)
 end
 
-function sparse_jacobian_aux(
+function _sparse_jacobian_aux(
     f_or_f!y::FY, backend::AutoSparse, x, extras::PullbackSparseJacobianExtras{B}
 ) where {FY,B}
     @compat (; coloring_result, batched_seeds, pullback_batched_extras) = extras
@@ -259,7 +259,7 @@ function sparse_jacobian_aux(
     return decompress(compressed_matrix, coloring_result)
 end
 
-function sparse_jacobian_aux!(
+function _sparse_jacobian_aux!(
     f_or_f!y::FY, jac, backend::AutoSparse, x, extras::PushforwardSparseJacobianExtras{B}
 ) where {FY,B}
     @compat (;
@@ -298,7 +298,7 @@ function sparse_jacobian_aux!(
     return jac
 end
 
-function sparse_jacobian_aux!(
+function _sparse_jacobian_aux!(
     f_or_f!y::FY, jac, backend::AutoSparse, x, extras::PullbackSparseJacobianExtras{B}
 ) where {FY,B}
     @compat (;


### PR DESCRIPTION
**DI source**

- Rewrite wrong-mode `pushforward` and `pullback` using helper functions, reducing the number of cases from 4 to 2
- Prefix all auxiliary functions with an underscore so that they don't show up in autocompletion