### PR TITLE
Improve type stability tests, better use of `AutoZero` backends

### DIFF
--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -77,6 +77,7 @@ include("sparse/hessian.jl")
 include("misc/differentiate_with.jl")
 include("misc/sparsity_detector.jl")
 include("misc/from_primitive.jl")
+include("misc/zero_backends.jl")
 
 function __init__()
     @require_extensions

--- a/DifferentiationInterface/src/fallbacks/no_tangents.jl
+++ b/DifferentiationInterface/src/fallbacks/no_tangents.jl
@@ -28,7 +28,7 @@ for op in (:pushforward, :pullback, :hvp)
         return only(t)
     end
     @eval function $op!(f::F, result, backend::AbstractADType, x, seed, ex::$E) where {F}
-        @assert !isa(seed, Tangents)
+        @assert !isa(seed, Tangents) && !isa(result, Tangents)
         t = $op!(f, SingleTangent(result), backend, x, SingleTangent(seed), ex)
         return only(t)
     end
@@ -41,7 +41,7 @@ for op in (:pushforward, :pullback, :hvp)
     @eval function $val_and_op!(
         f::F, result, backend::AbstractADType, x, seed, ex::$E
     ) where {F}
-        @assert !isa(seed, Tangents)
+        @assert !isa(seed, Tangents) && !isa(result, Tangents)
         y, t = $val_and_op!(f, SingleTangent(result), backend, x, SingleTangent(seed), ex)
         return y, only(t)
     end
@@ -60,7 +60,7 @@ for op in (:pushforward, :pullback, :hvp)
     @eval function $op!(
         f!::F, y, result, backend::AbstractADType, x, seed, ex::$E
     ) where {F}
-        @assert !isa(seed, Tangents)
+        @assert !isa(seed, Tangents) && !isa(result, Tangents)
         t = $op!(f!, y, SingleTangent(result), backend, x, SingleTangent(seed), ex)
         return only(t)
     end
@@ -72,7 +72,7 @@ for op in (:pushforward, :pullback, :hvp)
     @eval function $val_and_op!(
         f!::F, y, result, backend::AbstractADType, x, seed, ex::$E
     ) where {F}
-        @assert !isa(seed, Tangents)
+        @assert !isa(seed, Tangents) && !isa(result, Tangents)
         y, t = $val_and_op!(
             f!, y, SingleTangent(result), backend, x, SingleTangent(seed), ex
         )

--- a/DifferentiationInterface/src/misc/zero_backends.jl
+++ b/DifferentiationInterface/src/misc/zero_backends.jl
@@ -1,4 +1,10 @@
-zero!(x::AbstractArray) = x .= zero(eltype(x))
+struct ReturnZero{T}
+    template::T
+end
+
+(rz::ReturnZero)(i) = zero(rz.template)
+
+_zero!(x::AbstractArray) = x .= zero(eltype(x))
 
 ## Forward
 
@@ -21,7 +27,7 @@ function value_and_pushforward(
     f, ::AutoZeroForward, x, tx::Tangents{B}, ::NoPushforwardExtras
 ) where {B}
     y = f(x)
-    dys = ntuple(Returns(zero(y)), Val(B))
+    dys = ntuple(ReturnZero(y), Val(B))
     return y, Tangents(dys)
 end
 
@@ -29,16 +35,17 @@ function value_and_pushforward(
     f!, y, ::AutoZeroForward, x, tx::Tangents{B}, ::NoPushforwardExtras
 ) where {B}
     f!(y, x)
-    dys = ntuple(Returns(zero(y)), Val(B))
+    dys = ntuple(ReturnZero(y), Val(B))
     return y, Tangents(dys)
 end
 
 function value_and_pushforward!(
     f, ty::Tangents, ::AutoZeroForward, x, tx::Tangents, ::NoPushforwardExtras
 )
+    error()
     y = f(x)
     for b in eachindex(ty.d)
-        zero!(ty.d[b])
+        _zero!(ty.d[b])
     end
     return y, ty
 end
@@ -46,9 +53,10 @@ end
 function value_and_pushforward!(
     f!, y, ty::Tangents, ::AutoZeroForward, x, tx::Tangents, ::NoPushforwardExtras
 )
+    error()
     f!(y, x)
     for b in eachindex(ty.d)
-        zero!(ty.d[b])
+        _zero!(ty.d[b])
     end
     return y, ty
 end
@@ -74,7 +82,7 @@ function value_and_pullback(
     f, ::AutoZeroReverse, x, ty::Tangents{B}, ::NoPullbackExtras
 ) where {B}
     y = f(x)
-    dxs = ntuple(Returns(zero(x)), Val(B))
+    dxs = ntuple(ReturnZero(x), Val(B))
     return y, Tangents(dxs)
 end
 
@@ -82,7 +90,7 @@ function value_and_pullback(
     f!, y, ::AutoZeroReverse, x, ty::Tangents{B}, ::NoPullbackExtras
 ) where {B}
     f!(y, x)
-    dxs = ntuple(Returns(zero(x)), Val(B))
+    dxs = ntuple(ReturnZero(x), Val(B))
     return y, Tangents(dxs)
 end
 
@@ -91,7 +99,7 @@ function value_and_pullback!(
 )
     y = f(x)
     for b in eachindex(tx.d)
-        zero!(tx.d[b])
+        _zero!(tx.d[b])
     end
     return y, tx
 end
@@ -101,7 +109,7 @@ function value_and_pullback!(
 )
     f!(y, x)
     for b in eachindex(tx.d)
-        zero!(tx.d[b])
+        _zero!(tx.d[b])
     end
     return y, tx
 end

--- a/DifferentiationInterface/src/misc/zero_backends.jl
+++ b/DifferentiationInterface/src/misc/zero_backends.jl
@@ -11,13 +11,13 @@ Used in testing and benchmarking.
 struct AutoZeroForward <: AbstractADType end
 
 ADTypes.mode(::AutoZeroForward) = ForwardMode()
-DI.check_available(::AutoZeroForward) = true
-DI.twoarg_support(::AutoZeroForward) = DI.TwoArgSupported()
+check_available(::AutoZeroForward) = true
+twoarg_support(::AutoZeroForward) = TwoArgSupported()
 
-DI.prepare_pushforward(f, ::AutoZeroForward, x, tx::Tangents) = NoPushforwardExtras()
-DI.prepare_pushforward(f!, y, ::AutoZeroForward, x, tx::Tangents) = NoPushforwardExtras()
+prepare_pushforward(f, ::AutoZeroForward, x, tx::Tangents) = NoPushforwardExtras()
+prepare_pushforward(f!, y, ::AutoZeroForward, x, tx::Tangents) = NoPushforwardExtras()
 
-function DI.value_and_pushforward(
+function value_and_pushforward(
     f, ::AutoZeroForward, x, tx::Tangents{B}, ::NoPushforwardExtras
 ) where {B}
     y = f(x)
@@ -25,7 +25,7 @@ function DI.value_and_pushforward(
     return y, Tangents(dys)
 end
 
-function DI.value_and_pushforward(
+function value_and_pushforward(
     f!, y, ::AutoZeroForward, x, tx::Tangents{B}, ::NoPushforwardExtras
 ) where {B}
     f!(y, x)
@@ -33,7 +33,7 @@ function DI.value_and_pushforward(
     return y, Tangents(dys)
 end
 
-function DI.value_and_pushforward!(
+function value_and_pushforward!(
     f, ty::Tangents, ::AutoZeroForward, x, tx::Tangents, ::NoPushforwardExtras
 )
     y = f(x)
@@ -43,7 +43,7 @@ function DI.value_and_pushforward!(
     return y, ty
 end
 
-function DI.value_and_pushforward!(
+function value_and_pushforward!(
     f!, y, ty::Tangents, ::AutoZeroForward, x, tx::Tangents, ::NoPushforwardExtras
 )
     f!(y, x)
@@ -64,13 +64,13 @@ Used in testing and benchmarking.
 struct AutoZeroReverse <: AbstractADType end
 
 ADTypes.mode(::AutoZeroReverse) = ReverseMode()
-DI.check_available(::AutoZeroReverse) = true
-DI.twoarg_support(::AutoZeroReverse) = DI.TwoArgSupported()
+check_available(::AutoZeroReverse) = true
+twoarg_support(::AutoZeroReverse) = TwoArgSupported()
 
-DI.prepare_pullback(f, ::AutoZeroReverse, x, ty::Tangents) = NoPullbackExtras()
-DI.prepare_pullback(f!, y, ::AutoZeroReverse, x, ty::Tangents) = NoPullbackExtras()
+prepare_pullback(f, ::AutoZeroReverse, x, ty::Tangents) = NoPullbackExtras()
+prepare_pullback(f!, y, ::AutoZeroReverse, x, ty::Tangents) = NoPullbackExtras()
 
-function DI.value_and_pullback(
+function value_and_pullback(
     f, ::AutoZeroReverse, x, ty::Tangents{B}, ::NoPullbackExtras
 ) where {B}
     y = f(x)
@@ -78,7 +78,7 @@ function DI.value_and_pullback(
     return y, Tangents(dxs)
 end
 
-function DI.value_and_pullback(
+function value_and_pullback(
     f!, y, ::AutoZeroReverse, x, ty::Tangents{B}, ::NoPullbackExtras
 ) where {B}
     f!(y, x)
@@ -86,7 +86,7 @@ function DI.value_and_pullback(
     return y, Tangents(dxs)
 end
 
-function DI.value_and_pullback!(
+function value_and_pullback!(
     f, tx::Tangents, ::AutoZeroReverse, x, ty::Tangents, ::NoPullbackExtras
 )
     y = f(x)
@@ -96,7 +96,7 @@ function DI.value_and_pullback!(
     return y, tx
 end
 
-function DI.value_and_pullback!(
+function value_and_pullback!(
     f!, y, tx::Tangents, ::AutoZeroReverse, x, ty::Tangents, ::NoPullbackExtras
 )
     f!(y, x)

--- a/DifferentiationInterface/src/misc/zero_backends.jl
+++ b/DifferentiationInterface/src/misc/zero_backends.jl
@@ -42,7 +42,6 @@ end
 function value_and_pushforward!(
     f, ty::Tangents, ::AutoZeroForward, x, tx::Tangents, ::NoPushforwardExtras
 )
-    error()
     y = f(x)
     for b in eachindex(ty.d)
         _zero!(ty.d[b])
@@ -53,7 +52,6 @@ end
 function value_and_pushforward!(
     f!, y, ty::Tangents, ::AutoZeroForward, x, tx::Tangents, ::NoPushforwardExtras
 )
-    error()
     f!(y, x)
     for b in eachindex(ty.d)
         _zero!(ty.d[b])

--- a/DifferentiationInterface/test/Internals/from_primitive.jl
+++ b/DifferentiationInterface/test/Internals/from_primitive.jl
@@ -17,15 +17,4 @@ for backend in vcat(fromprimitive_backends)
     @test DifferentiationInterface.pick_batchsize(backend, 100) == 5
 end
 
-## Dense backends
-
 test_differentiation(fromprimitive_backends, default_scenarios(); logging=LOGGING);
-
-test_differentiation(
-    fromprimitive_backends[1],
-    default_scenarios();
-    correctness=false,
-    type_stability=true,
-    second_order=false,
-    logging=LOGGING,
-);

--- a/DifferentiationInterface/test/Internals/zero_backends.jl
+++ b/DifferentiationInterface/test/Internals/zero_backends.jl
@@ -1,6 +1,9 @@
 using DifferentiationInterface
 using DifferentiationInterface: AutoZeroForward, AutoZeroReverse
 using DifferentiationInterfaceTest
+using ComponentArrays: ComponentArrays
+using JLArrays: JLArrays
+using StaticArrays: StaticArrays
 using Test
 
 LOGGING = get(ENV, "CI", "false") == "false"
@@ -16,8 +19,8 @@ end
 
 test_differentiation(
     zero_backends,
-    default_scenarios();
-    correctness=false,
+    zero.(default_scenarios());
+    correctness=true,
     type_stability=true,
     excluded=[:second_derivative],
     logging=LOGGING,
@@ -28,9 +31,27 @@ test_differentiation(
         SecondOrder(AutoZeroForward(), AutoZeroReverse()),
         SecondOrder(AutoZeroReverse(), AutoZeroForward()),
     ],
-    default_scenarios(; linalg=false);
+    default_scenarios();
     correctness=false,
     type_stability=true,
     first_order=false,
     logging=LOGGING,
 )
+
+## Weird arrays
+
+test_differentiation(
+    [AutoZeroForward(), AutoZeroReverse()],
+    zero.(vcat(component_scenarios(), static_scenarios()));
+    correctness=true,
+    logging=LOGGING,
+)
+
+if VERSION >= v"1.10"
+    test_differentiation(
+        [AutoZeroForward(), AutoZeroReverse()],
+        zero.(gpu_scenarios());
+        correctness=true,
+        logging=LOGGING,
+    )
+end

--- a/DifferentiationInterface/test/Internals/zero_backends.jl
+++ b/DifferentiationInterface/test/Internals/zero_backends.jl
@@ -19,6 +19,7 @@ test_differentiation(
     default_scenarios();
     correctness=false,
     type_stability=true,
+    excluded=[:second_derivative],
     logging=LOGGING,
 )
 

--- a/DifferentiationInterface/test/Internals/zero_backends.jl
+++ b/DifferentiationInterface/test/Internals/zero_backends.jl
@@ -19,7 +19,6 @@ test_differentiation(
     default_scenarios();
     correctness=false,
     type_stability=true,
-    excluded=[:second_derivative],
     logging=LOGGING,
 )
 

--- a/DifferentiationInterface/test/Internals/zero_backends.jl
+++ b/DifferentiationInterface/test/Internals/zero_backends.jl
@@ -1,0 +1,36 @@
+using DifferentiationInterface
+using DifferentiationInterface: AutoZeroForward, AutoZeroReverse
+using DifferentiationInterfaceTest
+using Test
+
+LOGGING = get(ENV, "CI", "false") == "false"
+
+zero_backends = [AutoZeroForward(), AutoZeroReverse()]
+
+for backend in zero_backends
+    @test check_available(backend)
+    @test check_twoarg(backend)
+end
+
+## Type stability
+
+test_differentiation(
+    zero_backends,
+    default_scenarios();
+    correctness=false,
+    type_stability=true,
+    excluded=[:second_derivative],
+    logging=LOGGING,
+)
+
+test_differentiation(
+    [
+        SecondOrder(AutoZeroForward(), AutoZeroReverse()),
+        SecondOrder(AutoZeroReverse(), AutoZeroForward()),
+    ],
+    default_scenarios(; linalg=false);
+    correctness=false,
+    type_stability=true,
+    first_order=false,
+    logging=LOGGING,
+)

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -60,7 +60,6 @@ include("scenarios/sparse.jl")
 include("scenarios/allocfree.jl")
 include("scenarios/extensions.jl")
 
-include("utils/zero_backends.jl")
 include("utils/misc.jl")
 include("utils/filter.jl")
 

--- a/DifferentiationInterfaceTest/src/scenarios/modify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/modify.jl
@@ -9,7 +9,7 @@ maybe_zero(x::AbstractArray) = zero(x)
 maybe_zero(x::Tangents) = Tangents(map(maybe_zero, x.d))
 maybe_zero(::Nothing) = nothing
 
-function scenario_to_zero(scen::Scenario{op,args,pl}) where {op,args,pl}
+function Base.zero(scen::Scenario{op,args,pl}) where {op,args,pl}
     return Scenario{op,args,pl}(
         scen.f;
         x=scen.x,

--- a/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -168,19 +168,19 @@ function run_benchmark!(
         # benchmark
         extras = prepare_pushforward(f, ba, x, seed)
         bench0 = @be prepare_pushforward(f, ba, x, seed) samples = 1 evals = 1
-        bench1 = @be (dy=mysimilar(y), ext=deepcopy(extras)) value_and_pushforward!(
+        bench1 = @be (dy=mysimilar(scen.res1), ext=deepcopy(extras)) value_and_pushforward!(
             f, _.dy, ba, x, seed, _.ext
         ) evals = 1
-        bench2 = @be (dy=mysimilar(y), ext=deepcopy(extras)) pushforward!(
+        bench2 = @be (dy=mysimilar(scen.res1), ext=deepcopy(extras)) pushforward!(
             f, _.dy, ba, x, seed, _.ext
         ) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_pushforward(cc, ba, x, seed)
         calls0 = reset_count!(cc)
-        value_and_pushforward!(cc, mysimilar(y), ba, x, seed, extras)
+        value_and_pushforward!(cc, mysimilar(scen.res1), ba, x, seed, extras)
         calls1 = reset_count!(cc)
-        pushforward!(cc, mysimilar(y), ba, x, seed, extras)
+        pushforward!(cc, mysimilar(scen.res1), ba, x, seed, extras)
         calls2 = reset_count!(cc)
         (; bench0, bench1, bench2, calls0, calls1, calls2)
     catch e
@@ -250,19 +250,19 @@ function run_benchmark!(
         extras = prepare_pushforward(f!, y, ba, x, seed)
         bench0 = @be mysimilar(y) prepare_pushforward(f!, _, ba, x, seed) evals = 1 samples =
             1
-        bench1 = @be (y=mysimilar(y), dy=mysimilar(y), ext=deepcopy(extras)) value_and_pushforward!(
+        bench1 = @be (y=mysimilar(y), dy=mysimilar(scen.res1), ext=deepcopy(extras)) value_and_pushforward!(
             f!, _.y, _.dy, ba, x, seed, _.ext
         ) evals = 1
-        bench2 = @be (y=mysimilar(y), dy=mysimilar(y), ext=deepcopy(extras)) pushforward!(
+        bench2 = @be (y=mysimilar(y), dy=mysimilar(scen.res1), ext=deepcopy(extras)) pushforward!(
             f!, _.y, _.dy, ba, x, seed, _.ext
         ) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_pushforward(cc!, mysimilar(y), ba, x, seed)
         calls0 = reset_count!(cc!)
-        value_and_pushforward!(cc!, mysimilar(y), mysimilar(y), ba, x, seed, extras)
+        value_and_pushforward!(cc!, mysimilar(y), mysimilar(scen.res1), ba, x, seed, extras)
         calls1 = reset_count!(cc!)
-        pushforward!(cc!, mysimilar(y), mysimilar(y), ba, x, seed, extras)
+        pushforward!(cc!, mysimilar(y), mysimilar(scen.res1), ba, x, seed, extras)
         calls2 = reset_count!(cc!)
         (; bench0, bench1, bench2, calls0, calls1, calls2)
     catch e
@@ -326,19 +326,19 @@ function run_benchmark!(
         # benchmark
         extras = prepare_pullback(f, ba, x, seed)
         bench0 = @be prepare_pullback(f, ba, x, seed) samples = 1 evals = 1
-        bench1 = @be (dx=mysimilar(x), ext=deepcopy(extras)) value_and_pullback!(
+        bench1 = @be (dx=mysimilar(scen.res1), ext=deepcopy(extras)) value_and_pullback!(
             f, _.dx, ba, x, seed, _.ext
         ) evals = 1
-        bench2 = @be (dx=mysimilar(x), ext=deepcopy(extras)) pullback!(
+        bench2 = @be (dx=mysimilar(scen.res1), ext=deepcopy(extras)) pullback!(
             f, _.dx, ba, x, seed, _.ext
         ) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_pullback(cc, ba, x, seed)
         calls0 = reset_count!(cc)
-        value_and_pullback!(cc, mysimilar(x), ba, x, seed, extras)
+        value_and_pullback!(cc, mysimilar(scen.res1), ba, x, seed, extras)
         calls1 = reset_count!(cc)
-        pullback!(cc, mysimilar(x), ba, x, seed, extras)
+        pullback!(cc, mysimilar(scen.res1), ba, x, seed, extras)
         calls2 = reset_count!(cc)
         (; bench0, bench1, bench2, calls0, calls1, calls2)
     catch e
@@ -408,19 +408,19 @@ function run_benchmark!(
         extras = prepare_pullback(f!, mysimilar(y), ba, x, seed)
         bench0 = @be mysimilar(y) prepare_pullback(f!, _, ba, x, seed) samples = 1 evals =
             1
-        bench1 = @be (y=mysimilar(y), dx=mysimilar(x), ext=deepcopy(extras)) value_and_pullback!(
+        bench1 = @be (y=mysimilar(y), dx=mysimilar(scen.res1), ext=deepcopy(extras)) value_and_pullback!(
             f!, _.y, _.dx, ba, x, seed, _.ext
         ) evals = 1
-        bench2 = @be (y=mysimilar(y), dx=mysimilar(x), ext=deepcopy(extras)) pullback!(
+        bench2 = @be (y=mysimilar(y), dx=mysimilar(scen.res1), ext=deepcopy(extras)) pullback!(
             f!, _.y, _.dx, ba, x, seed, _.ext
         ) evals = 1
         # count
         cc! = CallCounter(f!)
         extras = prepare_pullback(cc!, mysimilar(y), ba, x, seed)
         calls0 = reset_count!(cc!)
-        value_and_pullback!(cc!, mysimilar(y), mysimilar(x), ba, x, seed, extras)
+        value_and_pullback!(cc!, mysimilar(y), mysimilar(scen.res1), ba, x, seed, extras)
         calls1 = reset_count!(cc!)
-        pullback!(cc!, mysimilar(y), mysimilar(x), ba, x, seed, extras)
+        pullback!(cc!, mysimilar(y), mysimilar(scen.res1), ba, x, seed, extras)
         calls2 = reset_count!(cc!)
         (; bench0, bench1, bench2, calls0, calls1, calls2)
     catch e
@@ -946,14 +946,14 @@ function run_benchmark!(
         # benchmark
         extras = prepare_hvp(f, ba, x, seed)
         bench0 = @be prepare_hvp(f, ba, x, seed) samples = 1 evals = 1
-        bench1 = @be (dg=mysimilar(x), ext=deepcopy(extras)) hvp!(
+        bench1 = @be (dg=mysimilar(scen.res2), ext=deepcopy(extras)) hvp!(
             f, _.dg, ba, x, seed, _.ext
         ) evals = 1
         # count
         cc = CallCounter(f)
         extras = prepare_hvp(cc, ba, x, seed)
         calls0 = reset_count!(cc)
-        hvp!(cc, mysimilar(x), ba, x, seed, extras)
+        hvp!(cc, mysimilar(scen.res2), ba, x, seed, extras)
         calls1 = reset_count!(cc)
         (; bench0, bench1, calls0, calls1)
     catch e

--- a/DifferentiationInterfaceTest/src/tests/type_stability.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability.jl
@@ -1,25 +1,21 @@
 ## Pushforward
 
 function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,1,:outofplace})
-    @compat (; f, x, y, seed) = deepcopy(scen)
+    @compat (; f, x, y, seed, res1) = deepcopy(scen)
     extras = prepare_pushforward(f, ba, x, seed)
 
-    if Bool(pushforward_performance(ba))
-        JET.@test_opt value_and_pushforward(f, ba, x, seed, extras)
-        JET.@test_opt pushforward(f, ba, x, seed, extras)
-    end
+    JET.@test_opt value_and_pushforward(f, ba, x, seed, extras)
+    JET.@test_opt pushforward(f, ba, x, seed, extras)
     return nothing
 end
 
 function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,1,:inplace})
     @compat (; f, x, y, seed) = deepcopy(scen)
     extras = prepare_pushforward(f, ba, x, seed)
-    dy_in = mysimilar(y)
+    res1 = mysimilar(scen.res1)
 
-    if Bool(pushforward_performance(ba))
-        JET.@test_opt value_and_pushforward!(f, dy_in, ba, x, seed, extras)
-        JET.@test_opt pushforward!(f, dy_in, ba, x, seed, extras)
-    end
+    JET.@test_opt value_and_pushforward!(f, res1, ba, x, seed, extras)
+    JET.@test_opt pushforward!(f, res1, ba, x, seed, extras)
     return nothing
 end
 
@@ -29,10 +25,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,2,:outofplace}
     extras = prepare_pushforward(f!, mysimilar(y), ba, x, seed)
     y_in = mysimilar(y)
 
-    if Bool(pushforward_performance(ba))
-        JET.@test_opt value_and_pushforward(f!, y_in, ba, x, seed, extras)
-        JET.@test_opt pushforward(f!, y_in, ba, x, seed, extras)
-    end
+    JET.@test_opt value_and_pushforward(f!, y_in, ba, x, seed, extras)
+    JET.@test_opt pushforward(f!, y_in, ba, x, seed, extras)
     return nothing
 end
 
@@ -40,12 +34,10 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pushforward,2,:inplace})
     @compat (; f, x, y, seed) = deepcopy(scen)
     f! = f
     extras = prepare_pushforward(f!, mysimilar(y), ba, x, seed)
-    y_in, dy_in = mysimilar(y), mysimilar(y)
+    y_in, res1 = mysimilar(y), mysimilar(scen.res1)
 
-    if Bool(pushforward_performance(ba))
-        JET.@test_opt value_and_pushforward!(f!, y_in, dy_in, ba, x, seed, extras)
-        JET.@test_opt pushforward!(f!, y_in, dy_in, ba, x, seed, extras)
-    end
+    JET.@test_opt value_and_pushforward!(f!, y_in, res1, ba, x, seed, extras)
+    JET.@test_opt pushforward!(f!, y_in, res1, ba, x, seed, extras)
     return nothing
 end
 
@@ -55,22 +47,18 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pullback,1,:outofplace})
     @compat (; f, x, seed) = deepcopy(scen)
     extras = prepare_pullback(f, ba, x, seed)
 
-    if Bool(pullback_performance(ba))
-        JET.@test_opt value_and_pullback(f, ba, x, seed, extras)
-        JET.@test_opt pullback(f, ba, x, seed, extras)
-    end
+    JET.@test_opt value_and_pullback(f, ba, x, seed, extras)
+    JET.@test_opt pullback(f, ba, x, seed, extras)
     return nothing
 end
 
 function test_jet(ba::AbstractADType, scen::Scenario{:pullback,1,:inplace})
     @compat (; f, x, seed) = deepcopy(scen)
     extras = prepare_pullback(f, ba, x, seed)
-    dx_in = mysimilar(x)
+    res1 = mysimilar(scen.res1)
 
-    if Bool(pullback_performance(ba))
-        JET.@test_opt value_and_pullback!(f, dx_in, ba, x, seed, extras)
-        JET.@test_opt pullback!(f, dx_in, ba, x, seed, extras)
-    end
+    JET.@test_opt value_and_pullback!(f, res1, ba, x, seed, extras)
+    JET.@test_opt pullback!(f, res1, ba, x, seed, extras)
     return nothing
 end
 
@@ -80,10 +68,8 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pullback,2,:outofplace})
     extras = prepare_pullback(f!, mysimilar(y), ba, x, seed)
     y_in = mysimilar(y)
 
-    if Bool(pullback_performance(ba))
-        JET.@test_opt value_and_pullback(f!, y_in, ba, x, seed, extras)
-        JET.@test_opt pullback(f!, y_in, ba, x, seed, extras)
-    end
+    JET.@test_opt value_and_pullback(f!, y_in, ba, x, seed, extras)
+    JET.@test_opt pullback(f!, y_in, ba, x, seed, extras)
     return nothing
 end
 
@@ -91,12 +77,10 @@ function test_jet(ba::AbstractADType, scen::Scenario{:pullback,2,:inplace})
     @compat (; f, x, y, seed) = deepcopy(scen)
     f! = f
     extras = prepare_pullback(f!, mysimilar(y), ba, x, seed)
-    y_in, dx_in = mysimilar(y), mysimilar(x)
+    y_in, res1 = mysimilar(y), mysimilar(scen.res1)
 
-    if Bool(pullback_performance(ba))
-        JET.@test_opt value_and_pullback!(f!, y_in, dx_in, ba, x, seed, extras)
-        JET.@test_opt pullback!(f!, y_in, dx_in, ba, x, seed, extras)
-    end
+    JET.@test_opt value_and_pullback!(f!, y_in, res1, ba, x, seed, extras)
+    JET.@test_opt pullback!(f!, y_in, res1, ba, x, seed, extras)
     return nothing
 end
 
@@ -244,9 +228,9 @@ end
 function test_jet(ba::AbstractADType, scen::Scenario{:hvp,1,:inplace})
     @compat (; f, x, seed) = deepcopy(scen)
     extras = prepare_hvp(f, ba, x, seed)
-    p_in = mysimilar(x)
+    res2 = mysimilar(scen.res2)
 
-    JET.@test_opt hvp!(f, p_in, ba, x, seed, extras)
+    JET.@test_opt hvp!(f, res2, ba, x, seed, extras)
     return nothing
 end
 

--- a/DifferentiationInterfaceTest/test/runtests.jl
+++ b/DifferentiationInterfaceTest/test/runtests.jl
@@ -18,7 +18,7 @@ GROUP = get(ENV, "JULIA_DIT_TEST_GROUP", "All")
 
     if GROUP == "Zero" || GROUP == "All"
         @testset verbose = false "Zero" begin
-            include("zero.jl")
+            include("zero_backends.jl")
         end
     end
 

--- a/DifferentiationInterfaceTest/test/weird.jl
+++ b/DifferentiationInterfaceTest/test/weird.jl
@@ -21,12 +21,15 @@ using Zygote: Zygote
 
 LOGGING = get(ENV, "CI", "false") == "false"
 
+## Weird arrays
+
 test_differentiation(
-    AutoForwardDiff(),
-    vcat(component_scenarios(), static_scenarios());
-    correctness=true,
-    logging=LOGGING,
+    AutoForwardDiff(), vcat(component_scenarios(), static_scenarios()); logging=LOGGING
 )
+
+test_differentiation(AutoZygote(), gpu_scenarios(); second_order=false, logging=LOGGING)
+
+## Closures
 
 test_differentiation(
     AutoFiniteDiff(),
@@ -35,9 +38,7 @@ test_differentiation(
     logging=LOGGING,
 );
 
-test_differentiation(
-    AutoZygote(), gpu_scenarios(); correctness=true, second_order=false, logging=LOGGING
-)
+## Neural nets
 
 Random.seed!(0)
 

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -1,12 +1,8 @@
 using DifferentiationInterface
+using DifferentiationInterface: AutoZeroForward, AutoZeroReverse
 using DifferentiationInterfaceTest
 using DifferentiationInterfaceTest:
-    AutoZeroForward,
-    AutoZeroReverse,
-    scenario_to_zero,
-    test_allocfree,
-    allocfree_scenarios,
-    remove_batched
+    scenario_to_zero, test_allocfree, allocfree_scenarios, remove_batched
 using ComponentArrays: ComponentArrays
 using JLArrays: JLArrays
 using StaticArrays: StaticArrays
@@ -15,18 +11,14 @@ using Test
 
 LOGGING = get(ENV, "CI", "false") == "false"
 
-@test check_available(AutoZeroForward())
-@test check_available(AutoZeroReverse())
-@test check_twoarg(AutoZeroForward())
-@test check_twoarg(AutoZeroReverse())
-
 ## Correctness + type stability
 
 test_differentiation(
     [AutoZeroForward(), AutoZeroReverse()],
-    scenario_to_zero.(default_scenarios());
-    correctness=true,
-    type_stability=false,  # TODO: switch back
+    default_scenarios();
+    correctness=false,
+    type_stability=true,
+    excluded=[:second_derivative],
     logging=LOGGING,
 )
 
@@ -35,9 +27,9 @@ test_differentiation(
         SecondOrder(AutoZeroForward(), AutoZeroReverse()),
         SecondOrder(AutoZeroReverse(), AutoZeroForward()),
     ],
-    scenario_to_zero.(default_scenarios(; linalg=false));
-    correctness=true,
-    type_stability=false,  # TODO: switch back
+    default_scenarios(; linalg=false);
+    correctness=false,
+    type_stability=true,
     first_order=false,
     logging=LOGGING,
 )


### PR DESCRIPTION
Idea

- In DI, we test correctness and performance of the differentiation mechanism
  - correctness for backends from primitive
  - type stability and weird arrays for zero backends
- In DIT, we test correctness of the tests themselves
  - correctness for ForwardDiff
  - weird arrays for appropriate backends
  - type stability for zero backends

---

**DI source**

- Add zero backends (`AutoZeroForward` and `AutoZeroReverse`) alongside backends from primitive (`AutoForwardFromPrimitive` and `AutoReverseFromPrimitive`)
- Replace `Returns(y)` with a custom `ReturnZero(y)` to generate a new output every time

**DI tests**

- Add type stability tests and weird array tests for zero backends
- Remove type stability tests for backends from primitive

**DIT source**

- Remove zero backends
- Rename `scenario_to_zero` into `Base.zero`
- Remove conditionals in type stability tests: `pushforward` activated even if `Bool(pushforward_performance)` is `false` and same for `pullback`
- Adjust type stability tests and benchmarks so that they work on scenarios with `Tangents` 

**DIT tests**

- Remove some correctness tests for zero backends