### PR TITLE
Improve type stability tests

### DIFF
--- a/DifferentiationInterfaceTest/src/tests/type_stability_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability_eval.jl
@@ -30,7 +30,9 @@ for op in [
             @compat (; f, x) = deepcopy(scen)
             ex = $prep_op(f, ba, x)
             JET.@test_opt $op(f, ba, x, ex)
+            JET.@test_call $op(f, ba, x, ex)
             JET.@test_opt $val_and_op(f, ba, x, ex)
+            JET.@test_call $val_and_op(f, ba, x, ex)
         end
 
         @eval function test_jet(ba::AbstractADType, scen::$S1in)
@@ -38,7 +40,9 @@ for op in [
             ex = $prep_op(f, ba, x)
             res1_in = mysimilar(res1)
             JET.@test_opt $op!(f, res1_in, ba, x, ex)
+            JET.@test_call $op!(f, res1_in, ba, x, ex)
             JET.@test_opt $val_and_op!(f, res1_in, ba, x, ex)
+            JET.@test_call $val_and_op!(f, res1_in, ba, x, ex)
         end
 
         op == :gradient && continue
@@ -48,7 +52,9 @@ for op in [
             y_in = mysimilar(y)
             ex = $prep_op(f, y_in, ba, x)
             JET.@test_opt $op(f, y_in, ba, x, ex)
+            JET.@test_call $op(f, y_in, ba, x, ex)
             JET.@test_opt $val_and_op(f, y_in, ba, x, ex)
+            JET.@test_call $val_and_op(f, y_in, ba, x, ex)
         end
 
         @eval function test_jet(ba::AbstractADType, scen::$S2in)
@@ -56,7 +62,9 @@ for op in [
             y_in, res1_in = mysimilar(y), mysimilar(res1)
             ex = $prep_op(f, y_in, ba, x)
             JET.@test_opt $op!(f, y_in, res1_in, ba, x, ex)
+            JET.@test_call $op!(f, y_in, res1_in, ba, x, ex)
             JET.@test_opt $val_and_op!(f, y_in, res1_in, ba, x, ex)
+            JET.@test_call $val_and_op!(f, y_in, res1_in, ba, x, ex)
         end
 
     elseif op in [:second_derivative, :hessian]
@@ -64,7 +72,9 @@ for op in [
             @compat (; f, x) = deepcopy(scen)
             ex = $prep_op(f, ba, x)
             JET.@test_opt $op(f, ba, x, ex)
+            JET.@test_call $op(f, ba, x, ex)
             JET.@test_opt $val_and_op(f, ba, x, ex)
+            JET.@test_call $val_and_op(f, ba, x, ex)
         end
 
         @eval function test_jet(ba::AbstractADType, scen::$S1in)
@@ -72,7 +82,9 @@ for op in [
             ex = $prep_op(f, ba, x)
             res1_in, res2_in = mysimilar(res1), mysimilar(res2)
             JET.@test_opt $op!(f, res2_in, ba, x, ex)
+            JET.@test_call $op!(f, res2_in, ba, x, ex)
             JET.@test_opt $val_and_op!(f, res1_in, res2_in, ba, x, ex)
+            JET.@test_call $val_and_op!(f, res1_in, res2_in, ba, x, ex)
         end
 
     elseif op in [:pushforward, :pullback]
@@ -80,7 +92,9 @@ for op in [
             @compat (; f, x, seed) = deepcopy(scen)
             ex = $prep_op(f, ba, x, seed)
             JET.@test_opt $op(f, ba, x, seed, ex)
+            JET.@test_call $op(f, ba, x, seed, ex)
             JET.@test_opt $val_and_op(f, ba, x, seed, ex)
+            JET.@test_call $val_and_op(f, ba, x, seed, ex)
         end
 
         @eval function test_jet(ba::AbstractADType, scen::$S1in)
@@ -88,7 +102,9 @@ for op in [
             ex = $prep_op(f, ba, x, seed)
             res1_in = mysimilar(res1)
             JET.@test_opt $op!(f, res1_in, ba, x, seed, ex)
+            JET.@test_call $op!(f, res1_in, ba, x, seed, ex)
             JET.@test_opt $val_and_op!(f, res1_in, ba, x, seed, ex)
+            JET.@test_call $val_and_op!(f, res1_in, ba, x, seed, ex)
         end
 
         @eval function test_jet(ba::AbstractADType, scen::$S2out)
@@ -96,7 +112,9 @@ for op in [
             y_in = mysimilar(y)
             ex = $prep_op(f, y_in, ba, x, seed)
             JET.@test_opt $op(f, y_in, ba, x, seed, ex)
+            JET.@test_call $op(f, y_in, ba, x, seed, ex)
             JET.@test_opt $val_and_op(f, y_in, ba, x, seed, ex)
+            JET.@test_call $val_and_op(f, y_in, ba, x, seed, ex)
         end
 
         @eval function test_jet(ba::AbstractADType, scen::$S2in)
@@ -104,7 +122,9 @@ for op in [
             y_in, res1_in = mysimilar(y), mysimilar(res1)
             ex = $prep_op(f, y_in, ba, x, seed)
             JET.@test_opt $op!(f, y_in, res1_in, ba, x, seed, ex)
+            JET.@test_call $op!(f, y_in, res1_in, ba, x, seed, ex)
             JET.@test_opt $val_and_op!(f, y_in, res1_in, ba, x, seed, ex)
+            JET.@test_call $val_and_op!(f, y_in, res1_in, ba, x, seed, ex)
         end
 
     elseif op in [:hvp]
@@ -112,13 +132,15 @@ for op in [
             @compat (; f, x, seed) = deepcopy(scen)
             ex = $prep_op(f, ba, x, seed)
             JET.@test_opt $op(f, ba, x, seed, ex)
+            JET.@test_call $op(f, ba, x, seed, ex)
         end
 
         @eval function test_jet(ba::AbstractADType, scen::$S1in)
             @compat (; f, x, seed, res1, res2) = deepcopy(scen)
             ex = $prep_op(f, ba, x, seed)
             res2_in = mysimilar(res2)
-            JET.@test_opt $op!(f, res2_in, ba, x, ex)
+            JET.@test_opt $op!(f, res2_in, ba, x, seed, ex)
+            JET.@test_call $op!(f, res2_in, ba, x, seed, ex)
         end
     end
 end


### PR DESCRIPTION
**DIT source**

- Fix typo in `hvp` type stability test
- Add `JET.@test_call` following `JET.@test_opt` to check that the code doesn't error