### PR TITLE
Remove fallback `backend -> SecondOrder(backend, backend)`

### DIFF
--- a/DifferentiationInterface/src/second_order/second_derivative.jl
+++ b/DifferentiationInterface/src/second_order/second_derivative.jl
@@ -65,45 +65,27 @@ struct ClosureSecondDerivativeExtras{ID<:InnerDerivative,E<:DerivativeExtras} <:
 end
 
 function prepare_second_derivative(f::F, backend::AbstractADType, x) where {F}
-    return prepare_second_derivative(f, SecondOrder(backend, backend), x)
-end
-
-function prepare_second_derivative(f::F, backend::SecondOrder, x) where {F}
-    inner_derivative = InnerDerivative(f, nested(inner(backend)))
-    outer_derivative_extras = prepare_derivative(inner_derivative, outer(backend), x)
+    inner_derivative = InnerDerivative(f, nested(maybe_inner(backend)))
+    outer_derivative_extras = prepare_derivative(inner_derivative, maybe_outer(backend), x)
     return ClosureSecondDerivativeExtras(inner_derivative, outer_derivative_extras)
 end
 
 ## One argument
 
 function second_derivative(
-    f::F, extras::SecondDerivativeExtras, backend::AbstractADType, x
-) where {F}
-    return second_derivative(f, extras, SecondOrder(backend, backend), x)
-end
-
-function second_derivative(
-    f::F, extras::ClosureSecondDerivativeExtras, backend::SecondOrder, x
+    f::F, extras::ClosureSecondDerivativeExtras, backend::AbstractADType, x
 ) where {F}
     @compat (; inner_derivative, outer_derivative_extras) = extras
-    return derivative(inner_derivative, outer_derivative_extras, outer(backend), x)
+    return derivative(inner_derivative, outer_derivative_extras, maybe_outer(backend), x)
 end
 
 function value_derivative_and_second_derivative(
-    f::F, extras::SecondDerivativeExtras, backend::AbstractADType, x
-) where {F}
-    return value_derivative_and_second_derivative(
-        f, extras, SecondOrder(backend, backend), x
-    )
-end
-
-function value_derivative_and_second_derivative(
-    f::F, extras::ClosureSecondDerivativeExtras, backend::SecondOrder, x
+    f::F, extras::ClosureSecondDerivativeExtras, backend::AbstractADType, x
 ) where {F}
     @compat (; inner_derivative, outer_derivative_extras) = extras
     y = f(x)
     der, der2 = value_and_derivative(
-        inner_derivative, outer_derivative_extras, outer(backend), x
+        inner_derivative, outer_derivative_extras, maybe_outer(backend), x
     )
     return y, der, der2
 end
@@ -111,31 +93,19 @@ end
 function second_derivative!(
     f::F, der2, extras::SecondDerivativeExtras, backend::AbstractADType, x
 ) where {F}
-    return second_derivative!(f, der2, extras, SecondOrder(backend, backend), x)
-end
-
-function second_derivative!(
-    f::F, der2, extras::SecondDerivativeExtras, backend::SecondOrder, x
-) where {F}
     @compat (; inner_derivative, outer_derivative_extras) = extras
-    return derivative!(inner_derivative, der2, outer_derivative_extras, outer(backend), x)
+    return derivative!(
+        inner_derivative, der2, outer_derivative_extras, maybe_outer(backend), x
+    )
 end
 
 function value_derivative_and_second_derivative!(
     f::F, der, der2, extras::SecondDerivativeExtras, backend::AbstractADType, x
 ) where {F}
-    return value_derivative_and_second_derivative!(
-        f, der, der2, extras, SecondOrder(backend, backend), x
-    )
-end
-
-function value_derivative_and_second_derivative!(
-    f::F, der, der2, extras::SecondDerivativeExtras, backend::SecondOrder, x
-) where {F}
     @compat (; inner_derivative, outer_derivative_extras) = extras
     y = f(x)
     new_der, _ = value_and_derivative!(
-        inner_derivative, der2, outer_derivative_extras, outer(backend), x
+        inner_derivative, der2, outer_derivative_extras, maybe_outer(backend), x
     )
     return y, copyto!(der, new_der), der2
 end

--- a/DifferentiationInterface/src/utils/traits.jl
+++ b/DifferentiationInterface/src/utils/traits.jl
@@ -125,6 +125,8 @@ Traits identifying second-order backends that compute HVPs in forward over forwa
 """
 struct ForwardOverForward <: HVPMode end
 
+hvp_mode(backend::AbstractADType) = hvp_mode(SecondOrder(backend, backend))
+
 function hvp_mode(ba::SecondOrder)
     if Bool(pushforward_performance(outer(ba))) && Bool(pullback_performance(inner(ba)))
         return ForwardOverReverse()


### PR DESCRIPTION
**DI source**

- Use `maybe_inner` and `maybe_outer` to make the code for `hvp` and `second_derivative` work with standard backends too
- Remove unnecessary fallback from `backend` to `SecondOrder(backend, backend)`