### PR TITLE
Fix and test ForwardDiff type stability

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -311,6 +311,24 @@ function DI.value_derivative_and_second_derivative!(
     return y, der, der2
 end
 
+## HVP
+
+function DI.prepare_hvp(f::F, backend::AutoForwardDiff, x, tx::Tangents) where {F}
+    return DI.prepare_hvp(f, SecondOrder(backend, backend), x, tx)
+end
+
+function DI.hvp(
+    f::F, extras::HVPExtras, backend::AutoForwardDiff, x, tx::Tangents
+) where {F}
+    return DI.hvp(f, extras, SecondOrder(backend, backend), x, tx)
+end
+
+function DI.hvp!(
+    f::F, tg::Tangents, extras::HVPExtras, backend::AutoForwardDiff, x, tx::Tangents
+) where {F}
+    return DI.hvp!(f, tg, extras, SecondOrder(backend, backend), x, tx)
+end
+
 ## Hessian
 
 ### Unprepared

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -27,15 +27,12 @@ end
 
 ## Dense backends
 
-test_differentiation(dense_backends, default_scenarios(); logging=LOGGING);
+test_differentiation(
+    dense_backends, default_scenarios(; include_constantified=true); logging=LOGGING
+);
 
 test_differentiation(
-    dense_backends,
-    default_scenarios(; include_constantified=true);
-    correctness=false,
-    type_stability=true,
-    second_order=false,
-    logging=LOGGING,
+    dense_backends; correctness=false, type_stability=true, logging=LOGGING
 );
 
 test_differentiation(


### PR DESCRIPTION
**DI extensions**

- ForwardDiff: Make `hvp` fall back on the `SecondOrder` implementation, which is optimized for correct inner preparation.

**DI tests**

- Test type stability for ForwardDiff across all operators