### PR TITLE
Make `DifferentiateWith` compatible with ForwardDiff, clarify docs

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -7,6 +7,7 @@ import DifferentiationInterface as DI
 using DifferentiationInterface:
     Context,
     DerivativeExtras,
+    DifferentiateWith,
     GradientExtras,
     HessianExtras,
     HVPExtras,
@@ -59,5 +60,6 @@ include("utils.jl")
 include("onearg.jl")
 include("twoarg.jl")
 include("secondorder.jl")
+include("differentiate_with.jl")
 
 end # module

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/differentiate_with.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/differentiate_with.jl
@@ -1,0 +1,15 @@
+function (dw::DifferentiateWith)(x::Dual{T,V,N}) where {T,V,N}
+    @compat (; f, backend) = dw
+    xval = myvalue(T, x)
+    tx = mypartials(T, Val(N), x)
+    y, ty = DI.value_and_pushforward(f, backend, xval, tx)
+    return make_dual(T, y, ty)
+end
+
+function (dw::DifferentiateWith)(x::AbstractArray{Dual{T,V,N}}) where {T,V,N}
+    @compat (; f, backend) = dw
+    xval = myvalue(T, x)
+    tx = mypartials(T, Val(N), x)
+    y, ty = DI.value_and_pushforward(f, backend, xval, tx)
+    return make_dual(T, y, ty)
+end

--- a/DifferentiationInterface/src/misc/differentiate_with.jl
+++ b/DifferentiationInterface/src/misc/differentiate_with.jl
@@ -1,18 +1,23 @@
 """
     DifferentiateWith
 
-Callable function wrapper that enforces differentiation with a specified (inner) backend.
+Function wrapper that enforces differentiation with a substitute AD backend, different from the true AD backend that the user intends to call.
 
-This works by defining new rules overriding the behavior of the outer backend that would normally be used.
+For instance, suppose `f` is not differentiable with Zygote because it involves mutation, but you know that it is differentiable with Enzyme.
+Then `g = DifferentiateWith(f, AutoEnzyme())` is differentiable with Zygote thanks to a chain rule which calls Enzyme under the hood.
+Moreover, any composition involving `g` will also be differentiable.
 
 !!! warning
-    This is an experimental functionality, whose API cannot yet be considered stable.
-    It only supports out-of-place functions, and rules are only defined for [ChainRules.jl](https://github.com/JuliaDiff/ChainRules.jl)-compatible outer backends.
+    `DifferentiateWith` only supports out-of-place functions `y = f(x)` without additional context arguments.
+    It only makes these functions differentiable if the true backend is either [ForwardDiff](https://github.com/JuliaDiff/ForwardDiff.jl) or anything [ChainRules](https://github.com/JuliaDiff/ChainRules.jl)-compatible.
 
 # Fields
 
-- `f`: the function in question
-- `backend::AbstractADType`: the inner backend to use for differentiation
+- `f`: the function in question, with signature `f(x)`
+- `backend::AbstractADType`: the substitute backend to use for differentiation
+
+!!! note
+    For the substitute AD backend to be called under the hood, its package needs to be loaded in addition to the package of the true AD backend.
 
 # Constructor
 
@@ -21,23 +26,29 @@ This works by defining new rules overriding the behavior of the outer backend th
 # Example
 
 ```jldoctest
-using DifferentiationInterface
-import ForwardDiff, Zygote
+julia> using DifferentiationInterface
 
-function f(x)
-    a = Vector{eltype(x)}(undef, 1)
-    a[1] = sum(x)  # mutation that breaks Zygote
-    return a[1]
-end
+julia> import Enzyme, ForwardDiff, Zygote
 
-dw = DifferentiateWith(f, AutoForwardDiff());
+julia> function f(x::Vector{Float64})
+           a = Vector{Float64}(undef, 1)  # type constraint breaks ForwardDiff
+           a[1] = sum(abs2, x)  # mutation breaks Zygote
+           return a[1]
+       end;
 
-gradient(dw, AutoZygote(), [2.0])  # calls ForwardDiff instead
+julia> g = DifferentiateWith(f, AutoEnzyme());
 
-# output
+julia> h(x) = 7 * g(x);
 
-1-element Vector{Float64}:
- 1.0
+julia> ForwardDiff.gradient(h, [3.0, 5.0])
+2-element Vector{Float64}:
+ 42.0
+ 70.0
+
+julia> Zygote.gradient(h, [3.0, 5.0])[1]
+2-element Vector{Float64}:
+ 42.0
+ 70.0
 ```
 """
 struct DifferentiateWith{F,B<:AbstractADType}
@@ -45,16 +56,17 @@ struct DifferentiateWith{F,B<:AbstractADType}
     backend::B
 end
 
-"""
-    (dw::DifferentiateWith)(x)
-
-Call the underlying function `dw.f` of a [`DifferentiateWith`](@ref) wrapper.
-"""
 (dw::DifferentiateWith)(x) = dw.f(x)
 
 function Base.show(io::IO, dw::DifferentiateWith)
     @compat (; f, backend) = dw
     return print(
-        io, DifferentiateWith, "(", repr(f; context=io), ",", repr(backend; context=io), ")"
+        io,
+        DifferentiateWith,
+        "(",
+        repr(f; context=io),
+        ", ",
+        repr(backend; context=io),
+        ")",
     )
 end

--- a/DifferentiationInterface/src/misc/differentiate_with.jl
+++ b/DifferentiationInterface/src/misc/differentiate_with.jl
@@ -1,15 +1,20 @@
 """
     DifferentiateWith
 
-Function wrapper that enforces differentiation with a substitute AD backend, different from the true AD backend that the user intends to call.
+Function wrapper that enforces differentiation with a "substitute" AD backend, possible different from the "true" AD backend that is called.
 
-For instance, suppose `f` is not differentiable with Zygote because it involves mutation, but you know that it is differentiable with Enzyme.
-Then `g = DifferentiateWith(f, AutoEnzyme())` is differentiable with Zygote thanks to a chain rule which calls Enzyme under the hood.
-Moreover, any composition involving `g` will also be differentiable.
+For instance, suppose a function `f` is not differentiable with Zygote because it involves mutation, but you know that it is differentiable with Enzyme.
+Then `f2 = DifferentiateWith(f, AutoEnzyme())` is a new function that behaves like `f`, except that `f2` is differentiable with Zygote (thanks to a chain rule which calls Enzyme under the hood).
+Moreover, any larger algorithm `alg` that calls `f2` instead of `f` will also be differentiable with Zygote (as long as `f` was the only Zygote blocker).
+
+!!! tip
+    This is mainly relevant for package developers who want to produce differentiable code at low cost, without writing the differentiation rules themselves.
+    If you sprinkle a few `DifferentiateWith` in places where some AD backends may struggle, end users can pick from a wider variety of packages to differentiate your algorithms.
 
 !!! warning
     `DifferentiateWith` only supports out-of-place functions `y = f(x)` without additional context arguments.
-    It only makes these functions differentiable if the true backend is either [ForwardDiff](https://github.com/JuliaDiff/ForwardDiff.jl) or anything [ChainRules](https://github.com/JuliaDiff/ChainRules.jl)-compatible.
+    It only makes these functions differentiable if the true backend is either [ForwardDiff](https://github.com/JuliaDiff/ForwardDiff.jl) or compatible with [ChainRules](https://github.com/JuliaDiff/ChainRules.jl).
+    For any other true backend, the differentiation behavior is not altered by `DifferentiateWith` (it becomes a transparent wrapper).
 
 # Fields
 
@@ -36,16 +41,19 @@ julia> function f(x::Vector{Float64})
            return a[1]
        end;
 
-julia> g = DifferentiateWith(f, AutoEnzyme());
+julia> f2 = DifferentiateWith(f, AutoEnzyme());
 
-julia> h(x) = 7 * g(x);
+julia> f([3.0, 5.0]) == f2([3.0, 5.0])
+true
 
-julia> ForwardDiff.gradient(h, [3.0, 5.0])
+julia> alg(x) = 7 * f2(x);
+
+julia> ForwardDiff.gradient(alg, [3.0, 5.0])
 2-element Vector{Float64}:
  42.0
  70.0
 
-julia> Zygote.gradient(h, [3.0, 5.0])[1]
+julia> Zygote.gradient(alg, [3.0, 5.0])[1]
 2-element Vector{Float64}:
  42.0
  70.0


### PR DESCRIPTION
**DIT source**

- Clarify documentation of `DifferentiateWith`, mention compositions.

**DIT extensions**

- Make `DifferentiateWith` compatible with ForwardDiff through `Dual` and `AbstractArray{<:Dual}` overloads

**DI tests**

- Test `DifferentiateWith` for Zygote and ForwardDiff on the closurified backends, using FiniteDiff as substitute