### PR TITLE
Add constant contexts for Enzyme

### DIFF
--- a/DifferentiationInterface/docs/src/explanation/advanced.md
+++ b/DifferentiationInterface/docs/src/explanation/advanced.md
@@ -12,7 +12,7 @@ Another option would be creating a closure, but that is sometimes undesirable.
 
 !!! warning
     This feature is still experimental, and will likely not be supported by all backends.
-    At the moment, it only works with ForwardDiff.
+    At the moment, it only works with ForwardDiff, Zygote and Enzyme.
 
 ### Types of contexts
 

--- a/DifferentiationInterface/docs/src/tutorials/advanced.md
+++ b/DifferentiationInterface/docs/src/tutorials/advanced.md
@@ -49,10 +49,6 @@ extras_other_constant = prepare_gradient(f_multiarg, backend, x, Constant(-1))
 gradient(f_multiarg, extras_other_constant, backend, x, Constant(10))
 ```
 
-!!! warning
-    At the moment, contexts only work with ForwardDiff, but we will add compatibility with other backends soon.
-    This trick will be especially important to leverage Enzyme's annotations for increased performance. 
-
 ## Sparsity
 
 Sparse AD is very useful when Jacobian or Hessian matrices have a lot of zeros.

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -4,6 +4,7 @@ using ADTypes: ADTypes, AutoEnzyme
 using Base: Fix1
 import DifferentiationInterface as DI
 using DifferentiationInterface:
+    Context,
     DerivativeExtras,
     GradientExtras,
     JacobianExtras,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -1,41 +1,62 @@
 ## Pushforward
 
 function DI.prepare_pushforward(
-    f!, y, ::AutoEnzyme{<:Union{ForwardMode,Nothing}}, x, tx::Tangents
-)
+    f!::F,
+    y,
+    ::AutoEnzyme{<:Union{ForwardMode,Nothing}},
+    x,
+    tx::Tangents,
+    contexts::Vararg{Context,C},
+) where {F,C}
     return NoPushforwardExtras()
 end
 
 function DI.value_and_pushforward(
-    f!,
+    f!::F,
     y,
     ::NoPushforwardExtras,
     backend::AutoEnzyme{<:Union{ForwardMode,Nothing}},
     x,
     tx::Tangents{1},
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     f!_and_df! = get_f_and_df(f!, backend)
     dx_sametype = convert(typeof(x), only(tx))
     dy_sametype = make_zero(y)
     x_and_dx = Duplicated(x, dx_sametype)
     y_and_dy = Duplicated(y, dy_sametype)
-    autodiff(forward_mode_noprimal(backend), f!_and_df!, Const, y_and_dy, x_and_dx)
+    autodiff(
+        forward_mode_noprimal(backend),
+        f!_and_df!,
+        Const,
+        y_and_dy,
+        x_and_dx,
+        map(translate, contexts)...,
+    )
     return y, Tangents(dy_sametype)
 end
 
 function DI.value_and_pushforward(
-    f!,
+    f!::F,
     y,
     ::NoPushforwardExtras,
     backend::AutoEnzyme{<:Union{ForwardMode,Nothing}},
     x,
     tx::Tangents{B},
-) where {B}
+    contexts::Vararg{Context,C},
+) where {F,B,C}
     f!_and_df! = get_f_and_df(f!, backend, Val(B))
     dxs_sametype = map(Fix1(convert, typeof(x)), tx.d)
     dys_sametype = ntuple(_ -> make_zero(y), Val(B))
     x_and_dxs = BatchDuplicated(x, dxs_sametype)
     y_and_dys = BatchDuplicated(y, dys_sametype)
-    autodiff(forward_mode_noprimal(backend), f!_and_df!, Const, y_and_dys, x_and_dxs)
+    autodiff(
+        forward_mode_noprimal(backend),
+        f!_and_df!,
+        Const,
+        y_and_dys,
+        x_and_dxs,
+        map(translate, contexts)...,
+    )
     return y, Tangents(dys_sametype...)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -203,14 +203,14 @@ end
 function DI.gradient!(
     f::F,
     grad,
-    extras::NoGradientExtras,
+    ::NoGradientExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing},<:Union{Nothing,Const}},
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
     dx_righttype = convert(typeof(x), grad)
     make_zero!(dx_righttype)
-    _, y = autodiff(
+    autodiff(
         reverse_mode_noprimal(backend),
         f,
         Active,
@@ -218,7 +218,7 @@ function DI.gradient!(
         map(translate, contexts)...,
     )
     dx_righttype === grad || copyto!(grad, dx_righttype)
-    return y, grad
+    return grad
 end
 
 function DI.value_and_gradient(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -23,21 +23,28 @@ end
 
 ## Pullback
 
-function DI.prepare_pullback(f, ::AutoEnzyme{<:Union{ReverseMode,Nothing}}, x, ty::Tangents)
+function DI.prepare_pullback(
+    f::F,
+    ::AutoEnzyme{<:Union{ReverseMode,Nothing}},
+    x,
+    ty::Tangents,
+    contexts::Vararg{Context,C},
+) where {F,C}
     return NoPullbackExtras()
 end
 
 ### Out-of-place
 
 function DI.value_and_pullback(
-    f,
+    f::F,
     extras::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::Tangents,
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     ys_and_dxs = map(ty.d) do dy
-        y, tx = DI.value_and_pullback(f, extras, backend, x, Tangents(dy))
+        y, tx = DI.value_and_pullback(f, extras, backend, x, Tangents(dy), contexts...)
         y, only(tx)
     end
     y = first(ys_and_dxs[1])
@@ -47,56 +54,66 @@ function DI.value_and_pullback(
 end
 
 function DI.value_and_pullback(
-    f,
+    f::F,
     ::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     ty::Tangents{1},
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_mode_split_withprimal(backend)
     RA = eltype(ty) <: Number ? Active : Duplicated
-    dinputs, result = seeded_autodiff_thunk(mode, only(ty), f_and_df, RA, Active(x))
-    return result, Tangents(only(dinputs))
+    dinputs, result = seeded_autodiff_thunk(
+        mode, only(ty), f_and_df, RA, Active(x), map(translate, contexts)...
+    )
+    return result, Tangents(first(dinputs))
 end
 
 function DI.value_and_pullback(
-    f,
+    f::F,
     ::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::Tangents{1},
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_mode_split_withprimal(backend)
     RA = eltype(ty) <: Number ? Active : Duplicated
     dx = make_zero(x)
-    _, result = seeded_autodiff_thunk(mode, only(ty), f_and_df, RA, Duplicated(x, dx))
+    _, result = seeded_autodiff_thunk(
+        mode, only(ty), f_and_df, RA, Duplicated(x, dx), map(translate, contexts)...
+    )
     return result, Tangents(dx)
 end
 
 function DI.pullback(
-    f,
+    f::F,
     extras::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     ty::Tangents{1},
-)
-    return last(DI.value_and_pullback(f, extras, backend, x, ty))
+    contexts::Vararg{Context,C},
+) where {F,C}
+    return last(DI.value_and_pullback(f, extras, backend, x, ty, contexts...))
 end
 
 ### In-place
 
 function DI.value_and_pullback!(
-    f,
+    f::F,
     tx::Tangents,
     extras::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::Tangents,
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     ys = map(tx.d, ty.d) do dx, dy
-        y, _ = DI.value_and_pullback!(f, Tangents(dx), extras, backend, x, Tangents(dy))
+        y, _ = DI.value_and_pullback!(
+            f, Tangents(dx), extras, backend, x, Tangents(dy), contexts...
+        )
         y
     end
     y = first(ys)
@@ -104,101 +121,134 @@ function DI.value_and_pullback!(
 end
 
 function DI.pullback!(
-    f,
+    f::F,
     tx::Tangents,
     extras::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::Tangents,
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     for b in eachindex(tx.d, ty.d)
-        DI.pullback!(f, Tangents(tx.d[b]), extras, backend, x, Tangents(ty.d[b]))
+        DI.pullback!(
+            f, Tangents(tx.d[b]), extras, backend, x, Tangents(ty.d[b]), contexts...
+        )
     end
     return tx
 end
 
 function DI.value_and_pullback!(
-    f,
+    f::F,
     tx::Tangents{1},
     ::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::Tangents{1},
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_mode_split_withprimal(backend)
     RA = eltype(ty) <: Number ? Active : Duplicated
     dx_righttype = convert(typeof(x), only(tx))
     make_zero!(dx_righttype)
     _, result = seeded_autodiff_thunk(
-        mode, only(ty), f_and_df, RA, Duplicated(x, dx_righttype)
+        mode,
+        only(ty),
+        f_and_df,
+        RA,
+        Duplicated(x, dx_righttype),
+        map(translate, contexts)...,
     )
     only(tx) === dx_righttype || copyto!(only(tx), dx_righttype)
     return result, tx
 end
 
 function DI.pullback!(
-    f,
+    f::F,
     tx::Tangents{1},
     extras::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::Tangents{1},
-)
-    return last(DI.value_and_pullback!(f, tx, extras, backend, x, ty))
+    contexts::Vararg{Context,C},
+) where {F,C}
+    return last(DI.value_and_pullback!(f, tx, extras, backend, x, ty, contexts...))
 end
 
 ## Gradient
 
 function DI.prepare_gradient(
-    f, ::AutoEnzyme{<:Union{ReverseMode,Nothing},<:Union{Nothing,Const}}, x
-)
+    f::F,
+    ::AutoEnzyme{<:Union{ReverseMode,Nothing},<:Union{Nothing,Const}},
+    x,
+    contexts::Vararg{Context,C},
+) where {F,C}
     return NoGradientExtras()
 end
 
 function DI.gradient(
-    f,
+    f::F,
     ::NoGradientExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing},<:Union{Nothing,Const}},
     x,
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     f_and_df = get_f_and_df(f, backend)
-    derivs = gradient(reverse_mode_noprimal(backend), f_and_df, x)
-    return only(derivs)
+    derivs = gradient(
+        reverse_mode_noprimal(backend), f_and_df, x, map(translate, contexts)...
+    )
+    return first(derivs)
 end
 
 function DI.gradient!(
-    f,
+    f::F,
     grad,
     extras::NoGradientExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing},<:Union{Nothing,Const}},
     x,
-)
-    return copyto!(grad, DI.gradient(f, extras, backend, x))
+    contexts::Vararg{Context,C},
+) where {F,C}
+    dx_righttype = convert(typeof(x), grad)
+    make_zero!(dx_righttype)
+    _, y = autodiff(
+        reverse_mode_noprimal(backend),
+        f,
+        Active,
+        Duplicated(x, dx_righttype),
+        map(translate, contexts)...,
+    )
+    dx_righttype === grad || copyto!(grad, dx_righttype)
+    return y, grad
 end
 
 function DI.value_and_gradient(
-    f,
+    f::F,
     ::NoGradientExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing},<:Union{Nothing,Const}},
     x,
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     f_and_df = get_f_and_df(f, backend)
     (; derivs, val) = gradient(reverse_mode_withprimal(backend), f_and_df, x)
-    return val, only(derivs)
+    return val, first(derivs)
 end
 
 function DI.value_and_gradient!(
-    f,
+    f::F,
     grad,
     ::NoGradientExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing},<:Union{Nothing,Const}},
     x,
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     dx_righttype = convert(typeof(x), grad)
     make_zero!(dx_righttype)
     _, y = autodiff(
-        reverse_mode_withprimal(backend), f, Active, Duplicated(x, dx_righttype)
+        reverse_mode_withprimal(backend),
+        f,
+        Active,
+        Duplicated(x, dx_righttype),
+        map(translate, contexts)...,
     )
     dx_righttype === grad || copyto!(grad, dx_righttype)
     return y, grad
@@ -208,7 +258,7 @@ end
 
 struct EnzymeReverseOneArgJacobianExtras{M,B} <: JacobianExtras end
 
-function DI.prepare_jacobian(f, backend::AutoEnzyme{<:ReverseMode,Nothing}, x)
+function DI.prepare_jacobian(f::F, backend::AutoEnzyme{<:ReverseMode,Nothing}, x) where {F}
     y = f(x)
     M = length(y)
     B = pick_batchsize(backend, M)
@@ -216,22 +266,22 @@ function DI.prepare_jacobian(f, backend::AutoEnzyme{<:ReverseMode,Nothing}, x)
 end
 
 function DI.jacobian(
-    f,
+    f::F,
     ::EnzymeReverseOneArgJacobianExtras{M,B},
     backend::AutoEnzyme{<:ReverseMode,Nothing},
     x,
-) where {M,B}
+) where {F,M,B}
     derivs = jacobian(reverse_mode_noprimal(backend), f, x; n_outs=Val((M,)), chunk=Val(B))
     jac_tensor = only(derivs)
     return maybe_reshape(jac_tensor, M, length(x))
 end
 
 function DI.value_and_jacobian(
-    f,
+    f::F,
     extras::EnzymeReverseOneArgJacobianExtras{M,B},
     backend::AutoEnzyme{<:ReverseMode,Nothing},
     x,
-) where {M,B}
+) where {F,M,B}
     (; derivs, val) = jacobian(
         reverse_mode_withprimal(backend), f, x; n_outs=Val((M,)), chunk=Val(B)
     )
@@ -240,22 +290,22 @@ function DI.value_and_jacobian(
 end
 
 function DI.jacobian!(
-    f,
+    f::F,
     jac,
     extras::EnzymeReverseOneArgJacobianExtras,
     backend::AutoEnzyme{<:ReverseMode,Nothing},
     x,
-)
+) where {F}
     return copyto!(jac, DI.jacobian(f, extras, backend, x))
 end
 
 function DI.value_and_jacobian!(
-    f,
+    f::F,
     jac,
     extras::EnzymeReverseOneArgJacobianExtras,
     backend::AutoEnzyme{<:ReverseMode,Nothing},
     x,
-)
+) where {F}
     y, new_jac = DI.value_and_jacobian(f, extras, backend, x)
     return y, copyto!(jac, new_jac)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -208,11 +208,12 @@ function DI.gradient!(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
+    f_and_df = get_f_and_df(f, backend)
     dx_righttype = convert(typeof(x), grad)
     make_zero!(dx_righttype)
     autodiff(
         reverse_mode_noprimal(backend),
-        f,
+        f_and_df,
         Active,
         Duplicated(x, dx_righttype),
         map(translate, contexts)...,
@@ -243,11 +244,12 @@ function DI.value_and_gradient!(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
+    f_and_df = get_f_and_df(f, backend)
     dx_righttype = convert(typeof(x), grad)
     make_zero!(dx_righttype)
     _, y = autodiff(
         reverse_mode_withprimal(backend),
-        f,
+        f_and_df,
         Active,
         Duplicated(x, dx_righttype),
         map(translate, contexts)...,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -229,7 +229,9 @@ function DI.value_and_gradient(
     contexts::Vararg{Context,C},
 ) where {F,C}
     f_and_df = get_f_and_df(f, backend)
-    (; derivs, val) = gradient(reverse_mode_withprimal(backend), f_and_df, x)
+    (; derivs, val) = gradient(
+        reverse_mode_withprimal(backend), f_and_df, x, map(translate, contexts)...
+    )
     return val, first(derivs)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -1,75 +1,114 @@
 ## Pullback
 
 function DI.prepare_pullback(
-    f!, y, ::AutoEnzyme{<:Union{ReverseMode,Nothing}}, x, ty::Tangents
-)
+    f!::F,
+    y,
+    ::AutoEnzyme{<:Union{ReverseMode,Nothing}},
+    x,
+    ty::Tangents,
+    contexts::Vararg{Context,C},
+) where {F,C}
     return NoPullbackExtras()
 end
 
 function DI.value_and_pullback(
-    f!,
+    f!::F,
     y,
     ::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     ty::Tangents{1},
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     f!_and_df! = get_f_and_df(f!, backend)
     dy_sametype = convert(typeof(y), copy(only(ty)))
     y_and_dy = Duplicated(y, dy_sametype)
-    _, dx = only(
-        autodiff(reverse_mode_noprimal(backend), f!_and_df!, Const, y_and_dy, Active(x))
+    dinputs = only(
+        autodiff(
+            reverse_mode_noprimal(backend),
+            f!_and_df!,
+            Const,
+            y_and_dy,
+            Active(x),
+            map(translate, contexts)...,
+        ),
     )
+    dx = dinputs[2]
     return y, Tangents(dx)
 end
 
 function DI.value_and_pullback(
-    f!,
+    f!::F,
     y,
     ::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     ty::Tangents{B},
-) where {B}
+    contexts::Vararg{Context,C},
+) where {F,B,C}
     f!_and_df! = get_f_and_df(f!, backend, Val(B))
     dys_sametype = map(Fix1(convert, typeof(y)), copy.(ty.d))
     y_and_dys = BatchDuplicated(y, dys_sametype)
-    _, dxs = only(
-        autodiff(reverse_mode_noprimal(backend), f!_and_df!, Const, y_and_dys, Active(x))
+    dinputs = only(
+        autodiff(
+            reverse_mode_noprimal(backend),
+            f!_and_df!,
+            Const,
+            y_and_dys,
+            Active(x),
+            map(translate, contexts)...,
+        ),
     )
+    dxs = dinputs[2]
     return y, Tangents(dxs...)
 end
 
 function DI.value_and_pullback(
-    f!,
+    f!::F,
     y,
     ::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::Tangents{1},
-)
+    contexts::Vararg{Context,C},
+) where {F,C}
     f!_and_df! = get_f_and_df(f!, backend)
     dx_sametype = make_zero(x)
     dy_sametype = convert(typeof(y), copy(only(ty)))
     x_and_dx = Duplicated(x, dx_sametype)
     y_and_dy = Duplicated(y, dy_sametype)
-    autodiff(reverse_mode_noprimal(backend), f!_and_df!, Const, y_and_dy, x_and_dx)
+    autodiff(
+        reverse_mode_noprimal(backend),
+        f!_and_df!,
+        Const,
+        y_and_dy,
+        x_and_dx,
+        map(translate, contexts)...,
+    )
     return y, Tangents(dx_sametype)
 end
 
 function DI.value_and_pullback(
-    f!,
+    f!::F,
     y,
     ::NoPullbackExtras,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::Tangents{B},
-) where {B}
+    contexts::Vararg{Context,C},
+) where {F,B,C}
     f!_and_df! = get_f_and_df(f!, backend, Val(B))
     dxs_sametype = ntuple(_ -> make_zero(x), Val(B))
     dys_sametype = map(Fix1(convert, typeof(y)), copy.(ty.d))
     x_and_dxs = BatchDuplicated(x, dxs_sametype)
     y_and_dys = BatchDuplicated(y, dys_sametype)
-    autodiff(reverse_mode_noprimal(backend), f!_and_df!, Const, y_and_dys, x_and_dxs)
+    autodiff(
+        reverse_mode_noprimal(backend),
+        f!_and_df!,
+        Const,
+        y_and_dys,
+        x_and_dxs,
+        map(translate, contexts)...,
+    )
     return y, Tangents(dxs_sametype...)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -36,7 +36,7 @@ end
 force_annotation(f::F) where {F<:Annotation} = f
 force_annotation(f::F) where {F} = Const(f)
 
-translate(c::DI.Constant) = Const(unwrap(c))
+translate(c::DI.Constant) = Const(DI.unwrap(c))
 
 ## Modes
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -1,16 +1,18 @@
 # until https://github.com/EnzymeAD/Enzyme.jl/pull/1545 is merged
 DI.pick_batchsize(::AutoEnzyme, dimension::Integer) = min(dimension, 16)
 
-function get_f_and_df(f, ::AutoEnzyme{M,Nothing}, ::Val{B}=Val(1)) where {M,B}
+## Annotations
+
+function get_f_and_df(f::F, ::AutoEnzyme{M,Nothing}, ::Val{B}=Val(1)) where {F,M,B}
     return f
 end
 
-function get_f_and_df(f, ::AutoEnzyme{M,<:Const}, ::Val{B}=Val(1)) where {M,B}
+function get_f_and_df(f::F, ::AutoEnzyme{M,<:Const}, ::Val{B}=Val(1)) where {F,M,B}
     return Const(f)
 end
 
 function get_f_and_df(
-    f,
+    f::F,
     ::AutoEnzyme{
         M,
         <:Union{
@@ -22,7 +24,7 @@ function get_f_and_df(
         },
     },
     ::Val{B}=Val(1),
-) where {M,B}
+) where {F,M,B}
     # TODO: needs more sophistication for mixed activities
     if B == 1
         return Duplicated(f, make_zero(f))
@@ -31,8 +33,12 @@ function get_f_and_df(
     end
 end
 
-force_annotation(f::Annotation) = f
-force_annotation(f) = Const(f)
+force_annotation(f::F) where {F<:Annotation} = f
+force_annotation(f::F) where {F} = Const(f)
+
+translate(c::DI.Constant) = Const(unwrap(c))
+
+## Modes
 
 function mode_noprimal(
     ::Type{ForwardMode{ReturnPrimal,ABI,ErrIfFuncWritten,RuntimeActivity}}

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -12,10 +12,10 @@ LOGGING = get(ENV, "CI", "false") == "false"
 
 dense_backends = [
     AutoEnzyme(; mode=nothing),
-    AutoEnzyme(; mode=nothing, function_annotation=Enzyme.Const),
     AutoEnzyme(; mode=Enzyme.Forward),
-    AutoEnzyme(; mode=Enzyme.Forward, function_annotation=Enzyme.Const),
     AutoEnzyme(; mode=Enzyme.Reverse),
+    AutoEnzyme(; mode=nothing, function_annotation=Enzyme.Const),
+    AutoEnzyme(; mode=Enzyme.Forward, function_annotation=Enzyme.Const),
     AutoEnzyme(; mode=Enzyme.Reverse, function_annotation=Enzyme.Const),
 ]
 
@@ -43,6 +43,13 @@ end;
 
 test_differentiation(
     dense_backends, default_scenarios(); second_order=false, logging=LOGGING
+);
+
+test_differentiation(
+    dense_backends[1:3],
+    default_scenarios(; include_normal=false, include_constantified=true);
+    second_order=false,
+    logging=LOGGING,
 );
 
 test_differentiation(


### PR DESCRIPTION
**DI extensions**

- Enzyme: Support `Constant` contexts by translating them into `Enzyme.Const`.
- Zygote: Type-annotate `Vararg{Context,C}` to specialize on the number of arguments.

**DI docs**

- Specify that contexts now work with ForwardDiff, Zygote and Enzyme.

**DI tests**

- Enzyme: Add tests with constantified scenarios