### PR TITLE
Better HVP in reverse over forward

### DIFF
--- a/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
+++ b/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
@@ -11,6 +11,17 @@ fromprimitive_backends = [ #
     AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
 ]
 
+fromprimitive_secondorder_backends = [ #
+    SecondOrder(
+        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
+        AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
+    ),
+    SecondOrder(
+        AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
+        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
+    ),
+]
+
 for backend in vcat(fromprimitive_backends)
     @test check_available(backend)
     @test check_inplace(backend)
@@ -18,4 +29,11 @@ end
 
 test_differentiation(
     fromprimitive_backends, default_scenarios(; include_constantified=true); logging=LOGGING
+);
+
+test_differentiation(
+    fromprimitive_secondorder_backends,
+    default_scenarios(; include_constantified=true);
+    first_order=false,
+    logging=LOGGING,
 );


### PR DESCRIPTION
**DI source**

- Improve HVP for reverse-over-forward by putting the tangent in a `Constant` context

**DI tests**

- Add `FromPrimitive` tests for heterogeneous `SecondOrder` backends