### PR TITLE
More batch mode for Enzyme

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -135,7 +135,7 @@ function DI.pullback(
     f::F,
     prep::NoPullbackPrep,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
-    x::Number,
+    x,
     ty::Tangents,
     contexts::Vararg{Context,C},
 ) where {F,C}

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -42,14 +42,6 @@ end;
 ## Dense backends
 
 test_differentiation(
-    AutoEnzyme(),
-    default_scenarios();
-    second_order=false,
-    excluded=[:pushforward, :derivative, :gradient, :jacobian],
-    logging=LOGGING,
-);
-
-test_differentiation(
     dense_backends, default_scenarios(); second_order=false, logging=LOGGING
 );
 

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -42,6 +42,14 @@ end;
 ## Dense backends
 
 test_differentiation(
+    AutoEnzyme(),
+    default_scenarios();
+    second_order=false,
+    excluded=[:pushforward, :derivative, :gradient, :jacobian],
+    logging=LOGGING,
+);
+
+test_differentiation(
     dense_backends, default_scenarios(); second_order=false, logging=LOGGING
 );
 

--- a/DifferentiationInterface/test/Internals/tangents.jl
+++ b/DifferentiationInterface/test/Internals/tangents.jl
@@ -4,12 +4,14 @@ using Test
 @test_throws ArgumentError Tangents()
 
 t = Tangents([2.0])
+@test NTuple(t) == ([2.0],)
 @test length(t) == 1
 @test eltype(t) == Vector{Float64}
 @test only(t) == [2.0]
 @test copyto!(map(zero, t), t) ≈ t
 
 t = Tangents(2.0, 4.0, 6.0)
+@test NTuple(t) == (2.0, 4.0, 6.0)
 @test length(t) == 3
 @test eltype(t) == Float64
 @test t[begin] == first(t) == 2.0


### PR DESCRIPTION
**DI extensions**

- Enzyme: Implement batch mode pullback for out-of-place functions, except for scalar inputs (see https://github.com/EnzymeAD/Enzyme.jl/issues/1883)

**DI source**

- Implement `NTuple` converter for `Tangents` and make it part of the API 