### PR TITLE
Bump version of DI to 0.6.2

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -19,6 +19,7 @@ jobs:
   docs:
     name: ${{ matrix.pkg.shortcut }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.name, "Bump version of DI") }}
     permissions:
       contents: write
       statuses: write

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -19,7 +19,7 @@ jobs:
   docs:
     name: ${{ matrix.pkg.shortcut }}
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.name, "Bump version of DI") }}
+    if: ${{ !contains(github.event.pull_request.name, 'Bump version of DI') }}
     permissions:
       contents: write
       statuses: write

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -19,7 +19,7 @@ jobs:
   docs:
     name: ${{ matrix.pkg.shortcut }}
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.name, 'Bump version of DI') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'bump') }}
     permissions:
       contents: write
       statuses: write

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -19,6 +19,7 @@ jobs:
   test-DI:
     name: ${{ matrix.version }} - DI (${{ matrix.group }})
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.name, "Bump version of DI") }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
@@ -131,6 +132,7 @@ jobs:
   test-DIT:
     name: ${{ matrix.version }} - DIT (${{ matrix.group }})
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.name, "Bump version of DI") }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -19,7 +19,7 @@ jobs:
   test-DI:
     name: ${{ matrix.version }} - DI (${{ matrix.group }})
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.name, "Bump version of DI") }}
+    if: ${{ !contains(github.event.pull_request.name, 'Bump version of DI') }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
@@ -132,7 +132,7 @@ jobs:
   test-DIT:
     name: ${{ matrix.version }} - DIT (${{ matrix.group }})
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.name, "Bump version of DI") }}
+    if: ${{ !contains(github.event.pull_request.name, 'Bump version of DI') }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -19,7 +19,7 @@ jobs:
   test-DI:
     name: ${{ matrix.version }} - DI (${{ matrix.group }})
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.name, 'Bump version of DI') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'bump') }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
@@ -132,7 +132,7 @@ jobs:
   test-DIT:
     name: ${{ matrix.version }} - DIT (${{ matrix.group }})
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.name, 'Bump version of DI') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'bump') }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
**Versions**

- Bump DI to v0.6.2

**CI**

- Avoid running CI on PRs labeled `bump`