### PR TITLE
Fix package name printing

### DIFF
--- a/DifferentiationInterface/src/utils/printing.jl
+++ b/DifferentiationInterface/src/utils/printing.jl
@@ -1,8 +1,10 @@
 function package_name(b::AbstractADType)
     s = string(b)
+    s = chopprefix(s, "ADTypes.")
+    s = chopprefix(s, "Auto")
     k = findfirst('(', s)
     isnothing(k) && throw(ArgumentError("Cannot parse backend into package"))
-    return s[5:(k - 1)]
+    return s[begin:(k - 1)]
 end
 
 function package_name(b::SecondOrder)


### PR DESCRIPTION
**DI source**

- Fix package name parsing from `ADTypes` backend string

```julia
julia> import DifferentiationInterface

julia> DifferentiationInterface.package_name(DifferentiationInterface.AutoForwardDiff())
"ForwardDiff"

julia> using DifferentiationInterface

julia> DifferentiationInterface.package_name(DifferentiationInterface.AutoForwardDiff())
"ForwardDiff"
```