### PR TITLE
Type-stable jacobian & gradient for unprepared ForwardDiff

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -159,10 +159,10 @@ end
 
 ## Gradient
 
-### Unprepared
+### Unprepared, only when chunk size not specified
 
 function DI.value_and_gradient!(
-    f::F, grad, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f::F, grad, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     result = DiffResult(zero(eltype(x)), (grad,))
@@ -173,7 +173,7 @@ function DI.value_and_gradient!(
 end
 
 function DI.value_and_gradient(
-    f::F, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f::F, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     result = GradientResult(x)
@@ -182,13 +182,15 @@ function DI.value_and_gradient(
 end
 
 function DI.gradient!(
-    f::F, grad, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f::F, grad, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     return gradient!(grad, fc, x)
 end
 
-function DI.gradient(f::F, ::AutoForwardDiff, x, contexts::Vararg{Context,C}) where {F,C}
+function DI.gradient(
+    f::F, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
+) where {F,C}
     fc = with_contexts(f, contexts...)
     return gradient(fc, x)
 end
@@ -252,10 +254,10 @@ end
 
 ## Jacobian
 
-### Unprepared
+### Unprepared, only when chunk size not specified
 
 function DI.value_and_jacobian!(
-    f::F, jac, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f::F, jac, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     y = fc(x)
@@ -267,20 +269,22 @@ function DI.value_and_jacobian!(
 end
 
 function DI.value_and_jacobian(
-    f::F, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f::F, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     return fc(x), jacobian(fc, x)
 end
 
 function DI.jacobian!(
-    f::F, jac, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f::F, jac, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     return jacobian!(jac, fc, x)
 end
 
-function DI.jacobian(f::F, ::AutoForwardDiff, x, contexts::Vararg{Context,C}) where {F,C}
+function DI.jacobian(
+    f::F, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
+) where {F,C}
     fc = with_contexts(f, contexts...)
     return jacobian(fc, x)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -212,36 +212,56 @@ end
 ### Unprepared, only when chunk size is not specified
 
 function DI.value_and_jacobian(
-    f!::F, y, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
-) where {F,C}
-    fc! = with_contexts(f!, contexts...)
-    jac = similar(y, length(y), length(x))
-    result = MutableDiffResult(y, (jac,))
-    result = jacobian!(result, fc!, y, x)
-    return DiffResults.value(result), DiffResults.jacobian(result)
+    f!::F, y, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize}
+    if isnothing(chunksize)
+        fc! = with_contexts(f!, contexts...)
+        jac = similar(y, length(y), length(x))
+        result = MutableDiffResult(y, (jac,))
+        result = jacobian!(result, fc!, y, x)
+        return DiffResults.value(result), DiffResults.jacobian(result)
+    else
+        prep = DI.prepare_jacobian(f!, y, backend, x, contexts...)
+        return DI.value_and_jacobian(f!, y, prep, backend, x, contexts...)
+    end
 end
 
 function DI.value_and_jacobian!(
-    f!::F, y, jac, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
-) where {F,C}
-    fc! = with_contexts(f!, contexts...)
-    result = MutableDiffResult(y, (jac,))
-    result = jacobian!(result, fc!, y, x)
-    return DiffResults.value(result), DiffResults.jacobian(result)
+    f!::F, y, jac, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize}
+    if isnothing(chunksize)
+        fc! = with_contexts(f!, contexts...)
+        result = MutableDiffResult(y, (jac,))
+        result = jacobian!(result, fc!, y, x)
+        return DiffResults.value(result), DiffResults.jacobian(result)
+    else
+        prep = DI.prepare_jacobian(f!, y, backend, x, contexts...)
+        return DI.value_and_jacobian!(f!, y, jac, prep, backend, x, contexts...)
+    end
 end
 
 function DI.jacobian(
-    f!::F, y, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
-) where {F,C}
-    fc! = with_contexts(f!, contexts...)
-    return jacobian(fc!, y, x)
+    f!::F, y, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize}
+    if isnothing(chunksize)
+        fc! = with_contexts(f!, contexts...)
+        return jacobian(fc!, y, x)
+    else
+        prep = DI.prepare_jacobian(f!, y, backend, x, contexts...)
+        return DI.jacobian(f!, y, prep, backend, x, contexts...)
+    end
 end
 
 function DI.jacobian!(
-    f!::F, y, jac, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
-) where {F,C}
-    fc! = with_contexts(f!, contexts...)
-    return jacobian!(jac, fc!, y, x)
+    f!::F, y, jac, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize}
+    if isnothing(chunksize)
+        fc! = with_contexts(f!, contexts...)
+        return jacobian!(jac, fc!, y, x)
+    else
+        prep = DI.prepare_jacobian(f!, y, backend, x, contexts...)
+        return DI.jacobian!(f!, y, jac, prep, backend, x, contexts...)
+    end
 end
 
 ### Prepared

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -209,10 +209,10 @@ end
 
 ## Jacobian
 
-### Unprepared
+### Unprepared, only when chunk size is not specified
 
 function DI.value_and_jacobian(
-    f!::F, y, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f!::F, y, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc! = with_contexts(f!, contexts...)
     jac = similar(y, length(y), length(x))
@@ -222,7 +222,7 @@ function DI.value_and_jacobian(
 end
 
 function DI.value_and_jacobian!(
-    f!::F, y, jac, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f!::F, y, jac, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc! = with_contexts(f!, contexts...)
     result = MutableDiffResult(y, (jac,))
@@ -231,14 +231,14 @@ function DI.value_and_jacobian!(
 end
 
 function DI.jacobian(
-    f!::F, y, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f!::F, y, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc! = with_contexts(f!, contexts...)
     return jacobian(fc!, y, x)
 end
 
 function DI.jacobian!(
-    f!::F, y, jac, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
+    f!::F, y, jac, ::AutoForwardDiff{nothing}, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc! = with_contexts(f!, contexts...)
     return jacobian!(jac, fc!, y, x)


### PR DESCRIPTION
- Bump DI to v0.6.6

**DI extensions**

- ForwardDiff: restrict the unprepared fallbacks of `gradient` and `jacobian` to `AutoForwardDiff{nothing}`. When the chunk size is specified in `AutoForwardDiff{C}`, we want to manually pass it to avoid type-instabilities, and that requires creating a `config`, which is equivalent to preparation. In those cases, the fallback unprepared => prepared will happen automatically. Note that we need to distinguish manually `chunksize = nothing`, otherwise we run into method ambiguities with the mutating function implems.

I have opened #540 to add a generic way to test this.