### PR TITLE
Disable default sparsity check in DIT

### DIFF
--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterfaceTest"
 uuid = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -43,7 +43,7 @@ For `type_stability` and `benchmark`, the possible values are `:none`, `:prepare
 - `atol=0`: absolute precision for correctness testing (when comparing to the reference outputs)
 - `rtol=1e-3`: relative precision for correctness testing (when comparing to the reference outputs)
 - `scenario_intact=true`: whether to check that the scenario remains unchanged after the operators are applied
-- `sparsity`: whether to check sparsity patterns for Jacobians / Hessians
+- `sparsity=false`: whether to check sparsity patterns for Jacobians / Hessians
 
 **Type stability options:**
 
@@ -69,7 +69,7 @@ function test_differentiation(
     atol::Real=0,
     rtol::Real=1e-3,
     scenario_intact::Bool=true,
-    sparsity::Bool=true,
+    sparsity::Bool=false,
     # type stability options
     ignored_modules=nothing,
     # benchmark options


### PR DESCRIPTION
**Version**

- Bump DIT to v0.8.1

**DIT source**

- Set `sparsity=false` in `test_differentiation` by default. Counting nonzeros exactly fails for finite differences!