### PR TITLE
Fix ForwardDiff tags & improve StaticArrays support

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -558,7 +558,7 @@ function DI.hessian!(
 end
 
 function DI.hessian(
-    f::F, ::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+    f::F, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
 ) where {F,C,chunksize,T}
     if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
@@ -570,7 +570,7 @@ function DI.hessian(
 end
 
 function DI.value_gradient_and_hessian!(
-    f::F, grad, hess, ::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+    f::F, grad, hess, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
 ) where {F,C,chunksize,T}
     if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
@@ -587,7 +587,7 @@ function DI.value_gradient_and_hessian!(
 end
 
 function DI.value_gradient_and_hessian(
-    f::F, ::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+    f::F, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
 ) where {F,C,chunksize,T}
     if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -272,7 +272,7 @@ function DI.prepare_gradient(
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     chunk = choose_chunk(backend, x)
-    tag = get_tag(f, backend, x)
+    tag = get_tag(fc, backend, x)
     config = GradientConfig(fc, x, chunk, tag)
     return ForwardDiffGradientPrep(config)
 end
@@ -389,7 +389,7 @@ function DI.prepare_jacobian(
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     chunk = choose_chunk(backend, x)
-    tag = get_tag(f, backend, x)
+    tag = get_tag(fc, backend, x)
     config = JacobianConfig(fc, x, chunk, tag)
     return ForwardDiffOneArgJacobianPrep(config)
 end
@@ -612,7 +612,7 @@ function DI.prepare_hessian(
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     chunk = choose_chunk(backend, x)
-    tag = get_tag(f, backend, x)
+    tag = get_tag(fc, backend, x)
     result = HessianResult(x)
     array_config = HessianConfig(fc, x, chunk, tag)
     result_config = HessianConfig(fc, result, x, chunk, tag)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -1,5 +1,51 @@
 ## Pushforward
 
+### Unprepared (avoid working on `similar(x)`)
+
+function DI.value_and_pushforward(
+    f::F, backend::AutoForwardDiff, x, tx::NTuple{B}, contexts::Vararg{Context,C}
+) where {F,B,C}
+    T = tag_type(f, backend, x)
+    xdual_tmp = make_dual(T, x, tx)
+    ydual = f(xdual_tmp, map(unwrap, contexts)...)
+    y = myvalue(T, ydual)
+    ty = mypartials(T, Val(B), ydual)
+    return y, ty
+end
+
+function DI.value_and_pushforward!(
+    f::F, ty::NTuple, backend::AutoForwardDiff, x, tx::NTuple, contexts::Vararg{Context,C}
+) where {F,C}
+    T = tag_type(f, backend, x)
+    xdual_tmp = make_dual(T, x, tx)
+    ydual = f(xdual_tmp, map(unwrap, contexts)...)
+    y = myvalue(T, ydual)
+    mypartials!(T, ty, ydual)
+    return y, ty
+end
+
+function DI.pushforward(
+    f::F, backend::AutoForwardDiff, x, tx::NTuple{B}, contexts::Vararg{Context,C}
+) where {F,B,C}
+    T = tag_type(f, backend, x)
+    xdual_tmp = make_dual(T, x, tx)
+    ydual = f(xdual_tmp, map(unwrap, contexts)...)
+    ty = mypartials(T, Val(B), ydual)
+    return ty
+end
+
+function DI.pushforward!(
+    f::F, ty::NTuple, backend::AutoForwardDiff, x, tx::NTuple, contexts::Vararg{Context,C}
+) where {F,C}
+    T = tag_type(f, backend, x)
+    xdual_tmp = make_dual(T, x, tx)
+    ydual = f(xdual_tmp, map(unwrap, contexts)...)
+    mypartials!(T, ty, ydual)
+    return ty
+end
+
+### Prepared
+
 struct ForwardDiffOneArgPushforwardPrep{T,X} <: PushforwardPrep
     xdual_tmp::X
 end
@@ -159,12 +205,12 @@ end
 
 ## Gradient
 
-### Unprepared, only when chunk size not specified
+### Unprepared, only when chunk size and tag are not specified
 
 function DI.value_and_gradient!(
-    f::F, grad, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
-) where {F,C,chunksize}
-    if isnothing(chunksize)
+    f::F, grad, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
         result = DiffResult(zero(eltype(x)), (grad,))
         result = gradient!(result, fc, x)
@@ -178,9 +224,9 @@ function DI.value_and_gradient!(
 end
 
 function DI.value_and_gradient(
-    f::F, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
-) where {F,C,chunksize}
-    if isnothing(chunksize)
+    f::F, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
         result = GradientResult(x)
         result = gradient!(result, fc, x)
@@ -192,9 +238,9 @@ function DI.value_and_gradient(
 end
 
 function DI.gradient!(
-    f::F, grad, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
-) where {F,C,chunksize}
-    if isnothing(chunksize)
+    f::F, grad, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
         return gradient!(grad, fc, x)
     else
@@ -204,9 +250,9 @@ function DI.gradient!(
 end
 
 function DI.gradient(
-    f::F, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
-) where {F,C,chunksize}
-    if isnothing(chunksize)
+    f::F, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
         return gradient(fc, x)
     else
@@ -225,7 +271,10 @@ function DI.prepare_gradient(
     f::F, backend::AutoForwardDiff, x::AbstractArray, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
-    return ForwardDiffGradientPrep(GradientConfig(fc, x, choose_chunk(backend, x)))
+    chunk = choose_chunk(backend, x)
+    tag = get_tag(f, backend, x)
+    config = GradientConfig(fc, x, chunk, tag)
+    return ForwardDiffGradientPrep(config)
 end
 
 function DI.value_and_gradient!(
@@ -274,12 +323,12 @@ end
 
 ## Jacobian
 
-### Unprepared, only when chunk size not specified
+### Unprepared, only when chunk size and tag are not specified
 
 function DI.value_and_jacobian!(
-    f::F, jac, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
-) where {F,C,chunksize}
-    if isnothing(chunksize)
+    f::F, jac, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
         y = fc(x)
         result = DiffResult(y, (jac,))
@@ -294,9 +343,9 @@ function DI.value_and_jacobian!(
 end
 
 function DI.value_and_jacobian(
-    f::F, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
-) where {F,C,chunksize}
-    if isnothing(chunksize)
+    f::F, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
         return fc(x), jacobian(fc, x)
     else
@@ -306,9 +355,9 @@ function DI.value_and_jacobian(
 end
 
 function DI.jacobian!(
-    f::F, jac, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
-) where {F,C,chunksize}
-    if isnothing(chunksize)
+    f::F, jac, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
         return jacobian!(jac, fc, x)
     else
@@ -318,9 +367,9 @@ function DI.jacobian!(
 end
 
 function DI.jacobian(
-    f::F, backend::AutoForwardDiff{chunksize}, x, contexts::Vararg{Context,C}
-) where {F,C,chunksize}
-    if isnothing(chunksize)
+    f::F, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
         fc = with_contexts(f, contexts...)
         return jacobian(fc, x)
     else
@@ -339,7 +388,10 @@ function DI.prepare_jacobian(
     f::F, backend::AutoForwardDiff, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
-    return ForwardDiffOneArgJacobianPrep(JacobianConfig(fc, x, choose_chunk(backend, x)))
+    chunk = choose_chunk(backend, x)
+    tag = get_tag(f, backend, x)
+    config = JacobianConfig(fc, x, chunk, tag)
+    return ForwardDiffOneArgJacobianPrep(config)
 end
 
 function DI.value_and_jacobian!(
@@ -491,62 +543,80 @@ end
 
 ## Hessian
 
-### Unprepared
+### Unprepared, only when chunk size and tag are not specified
 
 function DI.hessian!(
-    f::F, hess, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
-) where {F,C}
-    fc = with_contexts(f, contexts...)
-    return hessian!(hess, fc, x)
+    f::F, hess, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
+        fc = with_contexts(f, contexts...)
+        return hessian!(hess, fc, x)
+    else
+        prep = DI.prepare_hessian(f, backend, x, contexts...)
+        return DI.hessian!(f, hess, prep, backend, x, contexts...)
+    end
 end
 
-function DI.hessian(f::F, ::AutoForwardDiff, x, contexts::Vararg{Context,C}) where {F,C}
-    fc = with_contexts(f, contexts...)
-    return hessian(fc, x)
+function DI.hessian(
+    f::F, ::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
+        fc = with_contexts(f, contexts...)
+        return hessian(fc, x)
+    else
+        prep = DI.prepare_hessian(f, backend, x, contexts...)
+        return DI.hessian(f, prep, backend, x, contexts...)
+    end
 end
 
 function DI.value_gradient_and_hessian!(
-    f::F, grad, hess, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
-) where {F,C}
-    fc = with_contexts(f, contexts...)
-    result = DiffResult(one(eltype(x)), (grad, hess))
-    result = hessian!(result, fc, x)
-    y = DR.value(result)
-    grad === DR.gradient(result) || copyto!(grad, DR.gradient(result))
-    hess === DR.hessian(result) || copyto!(hess, DR.hessian(result))
-    return (y, grad, hess)
+    f::F, grad, hess, ::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
+        fc = with_contexts(f, contexts...)
+        result = DiffResult(one(eltype(x)), (grad, hess))
+        result = hessian!(result, fc, x)
+        y = DR.value(result)
+        grad === DR.gradient(result) || copyto!(grad, DR.gradient(result))
+        hess === DR.hessian(result) || copyto!(hess, DR.hessian(result))
+        return (y, grad, hess)
+    else
+        prep = DI.prepare_hessian(f, backend, x, contexts...)
+        return DI.value_gradient_and_hessian!(f, grad, hess, prep, backend, x, contexts...)
+    end
 end
 
 function DI.value_gradient_and_hessian(
-    f::F, ::AutoForwardDiff, x, contexts::Vararg{Context,C}
-) where {F,C}
-    fc = with_contexts(f, contexts...)
-    result = HessianResult(x)
-    result = hessian!(result, fc, x)
-    return (DR.value(result), DR.gradient(result), DR.hessian(result))
+    f::F, ::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{Context,C}
+) where {F,C,chunksize,T}
+    if isnothing(chunksize) && T === Nothing
+        fc = with_contexts(f, contexts...)
+        result = HessianResult(x)
+        result = hessian!(result, fc, x)
+        return (DR.value(result), DR.gradient(result), DR.hessian(result))
+    else
+        prep = DI.prepare_hessian(f, backend, x, contexts...)
+        return DI.value_gradient_and_hessian(f, prep, backend, x, contexts...)
+    end
 end
 
 ### Prepared
 
-struct ForwardDiffHessianPrep{C1,C2,C3} <: HessianPrep
+struct ForwardDiffHessianPrep{C1,C2} <: HessianPrep
     array_config::C1
-    manual_result_config::C2
-    auto_result_config::C3
+    result_config::C2
 end
 
 function DI.prepare_hessian(
     f::F, backend::AutoForwardDiff, x, contexts::Vararg{Context,C}
 ) where {F,C}
     fc = with_contexts(f, contexts...)
-    manual_result = MutableDiffResult(
-        one(eltype(x)), (similar(x), similar(x, length(x), length(x)))
-    )
-    auto_result = HessianResult(x)
     chunk = choose_chunk(backend, x)
-    array_config = HessianConfig(fc, x, chunk)
-    manual_result_config = HessianConfig(fc, manual_result, x, chunk)
-    auto_result_config = HessianConfig(fc, auto_result, x, chunk)
-    return ForwardDiffHessianPrep(array_config, manual_result_config, auto_result_config)
+    tag = get_tag(f, backend, x)
+    result = HessianResult(x)
+    array_config = HessianConfig(fc, x, chunk, tag)
+    result_config = HessianConfig(fc, result, x, chunk, tag)
+    return ForwardDiffHessianPrep(array_config, result_config)
 end
 
 function DI.hessian!(
@@ -579,7 +649,7 @@ function DI.value_gradient_and_hessian!(
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     result = DiffResult(one(eltype(x)), (grad, hess))
-    result = hessian!(result, fc, x, prep.manual_result_config)
+    result = hessian!(result, fc, x, prep.result_config)
     y = DR.value(result)
     grad === DR.gradient(result) || copyto!(grad, DR.gradient(result))
     hess === DR.hessian(result) || copyto!(hess, DR.hessian(result))
@@ -591,6 +661,6 @@ function DI.value_gradient_and_hessian(
 ) where {F,C}
     fc = with_contexts(f, contexts...)
     result = HessianResult(x)
-    result = hessian!(result, fc, x, prep.auto_result_config)
+    result = hessian!(result, fc, x, prep.result_config)
     return (DR.value(result), DR.gradient(result), DR.hessian(result))
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/secondorder.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/secondorder.jl
@@ -7,15 +7,11 @@ end
 
 Return a new `AutoForwardDiff` backend with a fixed tag linked to `f`, so that we know how to prepare the inner gradient of the HVP without depending on what that gradient closure looks like.
 """
-function tag_backend_hvp(f::F, ::AutoForwardDiff{chunksize,Nothing}, x) where {F,chunksize}
-    return AutoForwardDiff(;
-        chunksize=chunksize,
-        tag=ForwardDiff.Tag(ForwardDiffOverSomethingHVPWrapper(f), eltype(x)),
-    )
-end
+tag_backend_hvp(f, backend::AutoForwardDiff, x) = backend
 
-function tag_backend_hvp(f, backend::AutoForwardDiff, x)
-    return backend
+function tag_backend_hvp(f::F, ::AutoForwardDiff{chunksize,Nothing}, x) where {F,chunksize}
+    tag = ForwardDiff.Tag(ForwardDiffOverSomethingHVPWrapper(f), eltype(x))
+    return AutoForwardDiff{chunksize,typeof(tag)}(tag)
 end
 
 struct ForwardDiffOverSomethingHVPPrep{B<:AutoForwardDiff,G,E<:PushforwardPrep} <: HVPPrep

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -1,11 +1,13 @@
 choose_chunk(::AutoForwardDiff{nothing}, x) = Chunk(x)
 choose_chunk(::AutoForwardDiff{chunksize}, x) where {chunksize} = Chunk{chunksize}()
 
-tag_type(f, ::AutoForwardDiff{chunksize,T}, x) where {chunksize,T} = T
+get_tag(f, backend::AutoForwardDiff, x) = backend.tag
 
-function tag_type(f, ::AutoForwardDiff{chunksize,Nothing}, x) where {chunksize}
-    return typeof(Tag(f, eltype(x)))
+function get_tag(f::F, ::AutoForwardDiff{chunksize,Nothing}, x) where {F,chunksize}
+    return Tag(f, eltype(x))
 end
+
+tag_type(f::F, backend::AutoForwardDiff, x) where {F} = typeof(get_tag(f, backend, x))
 
 function make_dual_similar(::Type{T}, x::Number, tx::NTuple{B}) where {T,B}
     return Dual{T}(x, tx...)

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -9,7 +9,9 @@ using Test
 
 LOGGING = get(ENV, "CI", "false") == "false"
 
-backends = [AutoForwardDiff(; tag=:hello), AutoForwardDiff(; chunksize=5)]
+backends = [
+    AutoForwardDiff(), AutoForwardDiff(; tag=:hello), AutoForwardDiff(; chunksize=5)
+]
 
 for backend in backends
     @test check_available(backend)
@@ -51,3 +53,7 @@ test_differentiation(
     sparsity=true,
     logging=LOGGING,
 );
+
+## Static
+
+test_differentiation(AutoForwardDiff(), static_scenarios(); logging=LOGGING)

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -52,7 +52,8 @@ For `type_stability` and `benchmark`, the possible values are `:none`, `:prepare
 
 **Benchmark options:**
 
-- `count_calls::Bool`: whether to also count function calls during benchmarking
+- `count_calls=true`: whether to also count function calls during benchmarking
+- `benchmark_test=true`: whether to include tests which succeed iff benchmark doesn't error
 """
 function test_differentiation(
     backends::Vector{<:AbstractADType},
@@ -80,6 +81,7 @@ function test_differentiation(
     end,
     # benchmark options
     count_calls::Bool=true,
+    benchmark_test::Bool=true,
 )
     @assert type_stability in (:none, :prepared, :full)
     @assert benchmark in (:none, :prepared, :full)
@@ -155,6 +157,7 @@ function test_differentiation(
                             logging,
                             subset=benchmark,
                             count_calls,
+                            benchmark_test,
                         )
                     end
                     yield()
@@ -192,6 +195,7 @@ function benchmark_differentiation(
     excluded::Vector{Symbol}=Symbol[],
     logging::Bool=false,
     count_calls::Bool=true,
+    benchmark_test::Bool=true,
 )
     return test_differentiation(
         backends,
@@ -202,5 +206,6 @@ function benchmark_differentiation(
         logging,
         excluded,
         count_calls,
+        benchmark_test,
     )
 end

--- a/DifferentiationInterfaceTest/src/tests/benchmark_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark_eval.jl
@@ -39,6 +39,7 @@ for op in ALL_OPS
         logging::Bool,
         subset::Symbol,
         count_calls::Bool,
+        benchmark_test::Bool,
     )
         @assert subset in (:full, :prepared)
 
@@ -50,7 +51,7 @@ for op in ALL_OPS
             logging && @warn "Error during benchmarking" backend scenario exception
             BenchmarkResult()
         end
-        @test bench_success
+        benchmark_test && @test bench_success
 
         if count_calls
             count_success = true
@@ -61,7 +62,7 @@ for op in ALL_OPS
                 logging && @warn "Error during call counting" backend scenario exception
                 CallsResult()
             end
-            @test count_success
+            benchmark_test && @test count_success
         else
             calls_result = CallsResult()
         end

--- a/DifferentiationInterfaceTest/src/tests/benchmark_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark_eval.jl
@@ -42,20 +42,26 @@ for op in ALL_OPS
     )
         @assert subset in (:full, :prepared)
 
+        bench_success = true
         bench_result = try
             benchmark_aux(backend, scenario; subset)
         catch exception
+            bench_success = false
             logging && @warn "Error during benchmarking" backend scenario exception
             BenchmarkResult()
         end
+        @test bench_success
 
         if count_calls
+            count_success = true
             calls_result = try
                 calls_aux(backend, scenario; subset)
             catch exception
+                count_success = false
                 logging && @warn "Error during call counting" backend scenario exception
                 CallsResult()
             end
+            @test count_success
         else
             calls_result = CallsResult()
         end
@@ -162,14 +168,18 @@ for op in ALL_OPS
         @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
             (; f, x, res1, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, contexts...)
-            prepared_valop = @be (res1, prep) $val_and_op!(
+            prepared_valop = @be (mysimilar(res1), prep) $val_and_op!(
                 f, _[1], _[2], ba, x, contexts...
             )
-            prepared_op = @be (res1, prep) $op!(f, _[1], _[2], ba, x, contexts...)
+            prepared_op = @be (mysimilar(res1), prep) $op!(
+                f, _[1], _[2], ba, x, contexts...
+            )
             if subset == :full
                 preparation = @be $prep_op(f, ba, x, contexts...)
-                unprepared_valop = @be res1 $val_and_op!(f, _, ba, x, contexts...)
-                unprepared_op = @be res1 $op!(f, _, ba, x, contexts...)
+                unprepared_valop = @be mysimilar(res1) $val_and_op!(
+                    f, _, ba, x, contexts...
+                )
+                unprepared_op = @be mysimilar(res1) $op!(f, _, ba, x, contexts...)
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -187,13 +197,13 @@ for op in ALL_OPS
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, contexts...)
             preparation = reset_count!(cc)
-            $val_and_op!(cc, res1, prep, ba, x, contexts...)
+            $val_and_op!(cc, mysimilar(res1), prep, ba, x, contexts...)
             prepared_valop = reset_count!(cc)
-            $op!(cc, res1, prep, ba, x, contexts...)
+            $op!(cc, mysimilar(res1), prep, ba, x, contexts...)
             prepared_op = reset_count!(cc)
-            $val_and_op!(cc, res1, ba, x, contexts...)
+            $val_and_op!(cc, mysimilar(res1), ba, x, contexts...)
             unprepared_valop = reset_count!(cc)
-            $op!(cc, res1, ba, x, contexts...)
+            $op!(cc, mysimilar(res1), ba, x, contexts...)
             unprepared_op = reset_count!(cc)
             return CallsResult(;
                 prepared_valop, prepared_op, preparation, unprepared_valop, unprepared_op
@@ -244,16 +254,20 @@ for op in ALL_OPS
         @eval function benchmark_aux(ba::AbstractADType, scen::$S2in; subset::Symbol)
             (; f, x, y, res1, contexts) = deepcopy(scen)
             prep = $prep_op(f, y, ba, x, contexts...)
-            prepared_valop = @be (y, res1, prep) $val_and_op!(
+            prepared_valop = @be (y, mysimilar(res1), prep) $val_and_op!(
                 f, _[1], _[2], _[3], ba, x, contexts...
             )
-            prepared_op = @be (y, res1, prep) $op!(f, _[1], _[2], _[3], ba, x, contexts...)
+            prepared_op = @be (y, mysimilar(res1), prep) $op!(
+                f, _[1], _[2], _[3], ba, x, contexts...
+            )
             if subset == :full
                 preparation = @be $prep_op(f, y, ba, x, contexts...)
-                unprepared_valop = @be (y, res1) $val_and_op!(
+                unprepared_valop = @be (y, mysimilar(res1)) $val_and_op!(
                     f, _[1], _[2], ba, x, contexts...
                 )
-                unprepared_op = @be (y, res1) $op!(f, _[1], _[2], ba, x, contexts...)
+                unprepared_op = @be (y, mysimilar(res1)) $op!(
+                    f, _[1], _[2], ba, x, contexts...
+                )
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -271,13 +285,13 @@ for op in ALL_OPS
             cc = CallCounter(f)
             prep = $prep_op(cc, y, ba, x, contexts...)
             preparation = reset_count!(cc)
-            $val_and_op!(cc, y, res1, prep, ba, x, contexts...)
+            $val_and_op!(cc, y, mysimilar(res1), prep, ba, x, contexts...)
             prepared_valop = reset_count!(cc)
-            $op!(cc, y, res1, prep, ba, x, contexts...)
+            $op!(cc, y, mysimilar(res1), prep, ba, x, contexts...)
             prepared_op = reset_count!(cc)
-            $val_and_op!(cc, y, res1, ba, x, contexts...)
+            $val_and_op!(cc, y, mysimilar(res1), ba, x, contexts...)
             unprepared_valop = reset_count!(cc)
-            $op!(cc, y, res1, ba, x, contexts...)
+            $op!(cc, y, mysimilar(res1), ba, x, contexts...)
             unprepared_op = reset_count!(cc)
             return CallsResult(;
                 prepared_valop, prepared_op, preparation, unprepared_valop, unprepared_op
@@ -328,16 +342,18 @@ for op in ALL_OPS
             (; f, x, res1, res2, contexts) = deepcopy(scen)
 
             prep = $prep_op(f, ba, x, contexts...)
-            prepared_valop = @be (res1, res2, prep) $val_and_op!(
+            prepared_valop = @be (mysimilar(res1), mysimilar(res2), prep) $val_and_op!(
                 f, _[1], _[2], _[3], ba, x, contexts...
             )
-            prepared_op = @be (res2, prep) $op!(f, _[1], _[2], ba, x, contexts...)
+            prepared_op = @be (mysimilar(res2), prep) $op!(
+                f, _[1], _[2], ba, x, contexts...
+            )
             if subset == :full
                 preparation = @be $prep_op(f, ba, x, contexts...)
-                unprepared_valop = @be (res1, res2) $val_and_op!(
+                unprepared_valop = @be (mysimilar(res1), mysimilar(res2)) $val_and_op!(
                     f, _[1], _[2], ba, x, contexts...
                 )
-                unprepared_op = @be res2 $op!(f, _, ba, x, contexts...)
+                unprepared_op = @be mysimilar(res2) $op!(f, _, ba, x, contexts...)
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -355,13 +371,13 @@ for op in ALL_OPS
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, contexts...)
             preparation = reset_count!(cc)
-            $val_and_op!(cc, res1, res2, prep, ba, x, contexts...)
+            $val_and_op!(cc, mysimilar(res1), mysimilar(res2), prep, ba, x, contexts...)
             prepared_valop = reset_count!(cc)
-            $op!(cc, res2, prep, ba, x, contexts...)
+            $op!(cc, mysimilar(res2), prep, ba, x, contexts...)
             prepared_op = reset_count!(cc)
-            $val_and_op!(cc, res1, res2, ba, x, contexts...)
+            $val_and_op!(cc, mysimilar(res1), mysimilar(res2), ba, x, contexts...)
             unprepared_valop = reset_count!(cc)
-            $op!(cc, res2, ba, x, contexts...)
+            $op!(cc, mysimilar(res2), ba, x, contexts...)
             unprepared_op = reset_count!(cc)
             return CallsResult(;
                 prepared_valop, prepared_op, preparation, unprepared_valop, unprepared_op
@@ -410,14 +426,18 @@ for op in ALL_OPS
         @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
             (; f, x, tang, res1, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, tang, contexts...)
-            prepared_valop = @be (res1, prep) $val_and_op!(
+            prepared_valop = @be (mysimilar(res1), prep) $val_and_op!(
                 f, _[1], _[2], ba, x, tang, contexts...
             )
-            prepared_op = @be (res1, prep) $op!(f, _[1], _[2], ba, x, tang, contexts...)
+            prepared_op = @be (mysimilar(res1), prep) $op!(
+                f, _[1], _[2], ba, x, tang, contexts...
+            )
             if subset == :full
                 preparation = @be $prep_op(f, ba, x, tang, contexts...)
-                unprepared_valop = @be res1 $val_and_op!(f, _, ba, x, tang, contexts...)
-                unprepared_op = @be res1 $op!(f, _, ba, x, tang, contexts...)
+                unprepared_valop = @be mysimilar(res1) $val_and_op!(
+                    f, _, ba, x, tang, contexts...
+                )
+                unprepared_op = @be mysimilar(res1) $op!(f, _, ba, x, tang, contexts...)
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -435,13 +455,13 @@ for op in ALL_OPS
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, tang, contexts...)
             preparation = reset_count!(cc)
-            $val_and_op!(cc, res1, prep, ba, x, tang, contexts...)
+            $val_and_op!(cc, mysimilar(res1), prep, ba, x, tang, contexts...)
             prepared_valop = reset_count!(cc)
-            $op!(cc, res1, prep, ba, x, tang, contexts...)
+            $op!(cc, mysimilar(res1), prep, ba, x, tang, contexts...)
             prepared_op = reset_count!(cc)
-            $val_and_op!(cc, res1, ba, x, tang, contexts...)
+            $val_and_op!(cc, mysimilar(res1), ba, x, tang, contexts...)
             unprepared_valop = reset_count!(cc)
-            $op!(cc, res1, ba, x, tang, contexts...)
+            $op!(cc, mysimilar(res1), ba, x, tang, contexts...)
             unprepared_op = reset_count!(cc)
             return CallsResult(;
                 prepared_valop, prepared_op, preparation, unprepared_valop, unprepared_op
@@ -492,18 +512,20 @@ for op in ALL_OPS
         @eval function benchmark_aux(ba::AbstractADType, scen::$S2in; subset::Symbol)
             (; f, x, y, tang, res1, contexts) = deepcopy(scen)
             prep = $prep_op(f, y, ba, x, tang, contexts...)
-            prepared_valop = @be (y, res1, prep) $val_and_op!(
+            prepared_valop = @be (y, mysimilar(res1), prep) $val_and_op!(
                 f, _[1], _[2], _[3], ba, x, tang, contexts...
             )
-            prepared_op = @be (y, res1, prep) $op!(
+            prepared_op = @be (y, mysimilar(res1), prep) $op!(
                 f, _[1], _[2], _[3], ba, x, tang, contexts...
             )
             if subset == :full
                 preparation = @be $prep_op(f, y, ba, x, tang, contexts...)
-                unprepared_valop = @be (y, res1) $val_and_op!(
+                unprepared_valop = @be (y, mysimilar(res1)) $val_and_op!(
                     f, _[1], _[2], ba, x, tang, contexts...
                 )
-                unprepared_op = @be (y, res1) $op!(f, _[1], _[2], ba, x, tang, contexts...)
+                unprepared_op = @be (y, mysimilar(res1)) $op!(
+                    f, _[1], _[2], ba, x, tang, contexts...
+                )
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -521,13 +543,13 @@ for op in ALL_OPS
             cc = CallCounter(f)
             prep = $prep_op(cc, y, ba, x, tang, contexts...)
             preparation = reset_count!(cc)
-            $val_and_op!(cc, y, res1, prep, ba, x, tang, contexts...)
+            $val_and_op!(cc, y, mysimilar(res1), prep, ba, x, tang, contexts...)
             prepared_valop = reset_count!(cc)
-            $op!(cc, y, res1, prep, ba, x, tang, contexts...)
+            $op!(cc, y, mysimilar(res1), prep, ba, x, tang, contexts...)
             prepared_op = reset_count!(cc)
-            $val_and_op!(cc, y, res1, ba, x, tang, contexts...)
+            $val_and_op!(cc, y, mysimilar(res1), ba, x, tang, contexts...)
             unprepared_valop = reset_count!(cc)
-            $op!(cc, y, res1, ba, x, tang, contexts...)
+            $op!(cc, y, mysimilar(res1), ba, x, tang, contexts...)
             unprepared_op = reset_count!(cc)
             return CallsResult(;
                 prepared_valop, prepared_op, preparation, unprepared_valop, unprepared_op
@@ -576,11 +598,13 @@ for op in ALL_OPS
             (; f, x, tang, res2, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, tang, contexts...)
             prepared_valop = @be +(1, 1)   # TODO: fix
-            prepared_op = @be (res2, prep) $op!(f, _[1], _[2], ba, x, tang, contexts...)
+            prepared_op = @be (mysimilar(res2), prep) $op!(
+                f, _[1], _[2], ba, x, tang, contexts...
+            )
             if subset == :full
                 preparation = @be $prep_op(f, ba, x, tang, contexts...)
                 unprepared_valop = @be +(1, 1)   # TODO: fix
-                unprepared_op = @be res2 $op!(f, _, ba, x, tang, contexts...)
+                unprepared_op = @be mysimilar(res2) $op!(f, _, ba, x, tang, contexts...)
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -599,10 +623,10 @@ for op in ALL_OPS
             prep = $prep_op(cc, ba, x, tang, contexts...)
             preparation = reset_count!(cc)
             prepared_valop = -1  # TODO: fix
-            $op!(cc, res2, prep, ba, x, tang, contexts...)
+            $op!(cc, mysimilar(res2), prep, ba, x, tang, contexts...)
             prepared_op = reset_count!(cc)
             unprepared_valop = -1  # TODO: fix
-            $op!(cc, res2, ba, x, tang, contexts...)
+            $op!(cc, mysimilar(res2), ba, x, tang, contexts...)
             unprepared_op = reset_count!(cc)
             return CallsResult(;
                 prepared_valop, prepared_op, preparation, unprepared_valop, unprepared_op

--- a/DifferentiationInterfaceTest/src/tests/type_stability_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/type_stability_eval.jl
@@ -58,16 +58,18 @@ for op in ALL_OPS
                     function_filter $prep_op(f, ba, x, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, res1, ba, x, contexts...)
+                    function_filter $op!(f, mysimilar(res1), ba, x, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, res1, ba, x, contexts...)
+                    function_filter $val_and_op!(f, mysimilar(res1), ba, x, contexts...)
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, res1, prep, ba, x, contexts...)
+                    function_filter $op!(f, mysimilar(res1), prep, ba, x, contexts...)
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, res1, prep, ba, x, contexts...)
+                    function_filter $val_and_op!(
+                    f, mysimilar(res1), prep, ba, x, contexts...
+                )
             return nothing
         end
 
@@ -114,16 +116,18 @@ for op in ALL_OPS
                     function_filter $prep_op(f, y, ba, x, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, y, res1, ba, x, contexts...)
+                    function_filter $op!(f, y, mysimilar(res1), ba, x, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, y, res1, ba, x, contexts...)
+                    function_filter $val_and_op!(f, y, mysimilar(res1), ba, x, contexts...)
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, y, res1, prep, ba, x, contexts...)
+                    function_filter $op!(f, y, mysimilar(res1), prep, ba, x, contexts...)
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, y, res1, prep, ba, x, contexts...)
+                    function_filter $val_and_op!(
+                    f, y, mysimilar(res1), prep, ba, x, contexts...
+                )
             return nothing
         end
 
@@ -169,16 +173,20 @@ for op in ALL_OPS
                     function_filter $prep_op(f, ba, x, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, res2, ba, x, contexts...)
+                    function_filter $op!(f, mysimilar(res2), ba, x, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, res1, res2, ba, x, contexts...)
+                    function_filter $val_and_op!(
+                    f, mysimilar(res1), mysimilar(res2), ba, x, contexts...
+                )
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, res2, prep, ba, x, contexts...)
+                    function_filter $op!(f, mysimilar(res2), prep, ba, x, contexts...)
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, res1, res2, prep, ba, x, contexts...)
+                    function_filter $val_and_op!(
+                    f, mysimilar(res1), mysimilar(res2), prep, ba, x, contexts...
+                )
             return nothing
         end
 
@@ -224,16 +232,20 @@ for op in ALL_OPS
                     function_filter $prep_op(f, ba, x, tang, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, res1, ba, x, tang, contexts...)
+                    function_filter $op!(f, mysimilar(res1), ba, x, tang, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, res1, ba, x, tang, contexts...)
+                    function_filter $val_and_op!(
+                    f, mysimilar(res1), ba, x, tang, contexts...
+                )
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, res1, prep, ba, x, tang, contexts...)
+                    function_filter $op!(f, mysimilar(res1), prep, ba, x, tang, contexts...)
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, res1, prep, ba, x, tang, contexts...)
+                    function_filter $val_and_op!(
+                    f, mysimilar(res1), prep, ba, x, tang, contexts...
+                )
             return nothing
         end
 
@@ -278,16 +290,22 @@ for op in ALL_OPS
                     function_filter $prep_op(f, y, ba, x, tang, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, y, res1, ba, x, tang, contexts...)
+                    function_filter $op!(f, y, mysimilar(res1), ba, x, tang, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, y, res1, ba, x, tang, contexts...)
+                    function_filter $val_and_op!(
+                    f, y, mysimilar(res1), ba, x, tang, contexts...
+                )
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, y, res1, prep, ba, x, tang, contexts...)
+                    function_filter $op!(
+                    f, y, mysimilar(res1), prep, ba, x, tang, contexts...
+                )
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $val_and_op!(f, y, res1, prep, ba, x, tang, contexts...)
+                    function_filter $val_and_op!(
+                    f, y, mysimilar(res1), prep, ba, x, tang, contexts...
+                )
             return nothing
         end
 
@@ -327,10 +345,10 @@ for op in ALL_OPS
                     function_filter $prep_op(f, ba, x, tang, contexts...)
             (subset == :full) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, res2, ba, x, tang, contexts...)
+                    function_filter $op!(f, mysimilar(res2), ba, x, tang, contexts...)
             (subset in (:prepared, :full)) &&
                 @test_opt ignored_modules = ignored_modules function_filter =
-                    function_filter $op!(f, res2, prep, ba, x, tang, contexts...)
+                    function_filter $op!(f, mysimilar(res2), prep, ba, x, tang, contexts...)
             return nothing
         end
     end

--- a/DifferentiationInterfaceTest/test/weird.jl
+++ b/DifferentiationInterfaceTest/test/weird.jl
@@ -32,7 +32,9 @@ static_scenarios(;
 
 ## Weird arrays
 
-test_differentiation(AutoForwardDiff(), static_scenarios(); logging=LOGGING)
+test_differentiation(
+    AutoForwardDiff(), static_scenarios(); benchmark=:full, logging=LOGGING
+)
 
 test_differentiation(AutoForwardDiff(), component_scenarios(); logging=LOGGING)
 

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -3,7 +3,6 @@ using DifferentiationInterface
 using DifferentiationInterface: AutoZeroForward, AutoZeroReverse
 using DifferentiationInterfaceTest
 using DifferentiationInterfaceTest: allocfree_scenarios
-
 using Test
 
 LOGGING = get(ENV, "CI", "false") == "false"
@@ -47,8 +46,8 @@ ADTypes.mode(::FakeBackend) = ADTypes.ForwardMode()
 data2 = benchmark_differentiation(
     FakeBackend(),
     default_scenarios(; include_batchified=false);
-    count_calls=false,
     logging=false,
+    benchmark_test=false,
 );
 
 @testset "Benchmarking DataFrame" begin


### PR DESCRIPTION
**Versions**

- Bump DI to v0.6.11

**DI extensions**

ForwardDiff:

- Add unprepared `pushforward` to avoid allocating `similar(xdual)` in the preparation object. This should make `pushforward(f, backend, x, tx)` alloc-free on `SArray`.
- Pass custom tag to `DerivativeConfig`, `JacobianConfig`, `GradientConfig` and `HessianConfig` (this is an internal, like so much else).
- Restrict unprepared shortcuts to the situation where we have both no chunksize and no tag (otherwise we need to put this stuff in the config anyway).
- Fix unprepared `hessian` and clean up the preparation

**DI tests**

ForwardDiff:
- Add tests for `AutoForwardDiff()`
- Add tests on `static_scenarios()`.

**DIT source**

- Modify benchmarks and type stability to make them work with `SArray`s (take `mysimilar(res)` instead of `res`, as in correctness tests).
- Add `@test`s in the benchmark suite so that we can know where failures occurred.
- Add an option `benchmark_test=true/false` to `test_differentiation` which controls the inclusion of these tests.

**DIT tests**

- Test benchmarks on `static_scenarios()` (used to fail)