### PR TITLE
Replace closures with argument shuffling in second order

### DIFF
--- a/DifferentiationInterface/docs/src/explanation/backends.md
+++ b/DifferentiationInterface/docs/src/explanation/backends.md
@@ -48,7 +48,7 @@ In practice, many AD backends have custom implementations for high-level operato
     | `AutoMooncake`             | ❌    | ✅    | ❌     | ❌      | ❌     | ❌      | ❌     | ❌      |
     | `AutoPolyesterForwardDiff` | 🔀    | ❌    | 🔀     | ✅      | ✅     | 🔀      | 🔀     | 🔀      |
     | `AutoReverseDiff`          | ❌    | 🔀    | ❌     | ✅      | ✅     | ✅      | ❌     | ❌      |
-    | `AutoSymbolics`            | ✅    | ❌    | ✅     | ✅      | ✅     | ✅      | ❌     | ❌      |
+    | `AutoSymbolics`            | ✅    | ❌    | ✅     | ✅      | ✅     | ✅      | ✅     | ✅      |
     | `AutoTracker`              | ❌    | ✅    | ❌     | ✅      | ❌     | ❌      | ❌     | ❌      |
     | `AutoZygote`               | ❌    | ✅    | ❌     | ✅      | ✅     | ✅      | 🔀     | ❌      |
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSymbolicsExt/onearg.jl
@@ -275,3 +275,96 @@ function DI.value_gradient_and_hessian!(
     DI.hessian!(f, hess, prep, backend, x)
     return y, grad, hess
 end
+
+## HVP
+
+struct SymbolicsOneArgHVPPrep{G,E2,E2!} <: HVPPrep
+    gradient_prep::G
+    hvp_exe::E2
+    hvp_exe!::E2!
+end
+
+function DI.prepare_hvp(f, backend::AutoSymbolics, x, tx::NTuple)
+    x_var = variables(:x, axes(x)...)
+    dx_var = variables(:dx, axes(x)...)
+    # Symbolic.hessian only accepts vectors
+    hess_var = hessian(f(x_var), vec(x_var))
+    hvp_vec_var = hess_var * vec(dx_var)
+
+    res = build_function(hvp_vec_var, vcat(vec(x_var), vec(dx_var)); expression=Val(false))
+    (hvp_exe, hvp_exe!) = res
+
+    gradient_prep = DI.prepare_gradient(f, backend, x)
+    return SymbolicsOneArgHVPPrep(gradient_prep, hvp_exe, hvp_exe!)
+end
+
+function DI.hvp(f, prep::SymbolicsOneArgHVPPrep, ::AutoSymbolics, x, tx::NTuple)
+    return map(tx) do dx
+        v_vec = vcat(vec(x), vec(dx))
+        dg_vec = prep.hvp_exe(v_vec)
+        reshape(dg_vec, size(x))
+    end
+end
+
+function DI.hvp!(
+    f, tg::NTuple, prep::SymbolicsOneArgHVPPrep, ::AutoSymbolics, x, tx::NTuple
+)
+    for b in eachindex(tx, tg)
+        dx, dg = tx[b], tg[b]
+        v_vec = vcat(vec(x), vec(dx))
+        prep.hvp_exe!(vec(dg), v_vec)
+    end
+    return tg
+end
+
+## Second derivative
+
+struct SymbolicsOneArgSecondDerivativePrep{D,E1,E1!} <: SecondDerivativePrep
+    derivative_prep::D
+    der2_exe::E1
+    der2_exe!::E1!
+end
+
+function DI.prepare_second_derivative(f, backend::AutoSymbolics, x)
+    x_var = variable(:x)
+    der_var = derivative(f(x_var), x_var)
+    der2_var = derivative(der_var, x_var)
+
+    res = build_function(der2_var, x_var; expression=Val(false))
+    (der2_exe, der2_exe!) = if res isa Tuple
+        res
+    elseif res isa RuntimeGeneratedFunction
+        res, nothing
+    end
+    derivative_prep = DI.prepare_derivative(f, backend, x)
+    return SymbolicsOneArgSecondDerivativePrep(derivative_prep, der2_exe, der2_exe!)
+end
+
+function DI.second_derivative(
+    f, prep::SymbolicsOneArgSecondDerivativePrep, ::AutoSymbolics, x
+)
+    return prep.der2_exe(x)
+end
+
+function DI.second_derivative!(
+    f, der2, prep::SymbolicsOneArgSecondDerivativePrep, ::AutoSymbolics, x
+)
+    prep.der2_exe!(der2, x)
+    return der2
+end
+
+function DI.value_derivative_and_second_derivative(
+    f, prep::SymbolicsOneArgSecondDerivativePrep, backend::AutoSymbolics, x
+)
+    y, der = DI.value_and_derivative(f, prep.derivative_prep, backend, x)
+    der2 = DI.second_derivative(f, prep, backend, x)
+    return y, der, der2
+end
+
+function DI.value_derivative_and_second_derivative!(
+    f, der, der2, prep::SymbolicsOneArgSecondDerivativePrep, backend::AutoSymbolics, x
+)
+    y, _ = DI.value_and_derivative!(f, der, prep.derivative_prep, backend, x)
+    DI.second_derivative!(f, der2, prep, backend, x)
+    return y, der, der2
+end

--- a/DifferentiationInterface/src/first_order/derivative.jl
+++ b/DifferentiationInterface/src/first_order/derivative.jl
@@ -200,14 +200,3 @@ function shuffled_derivative(
 ) where {F,C}
     return derivative(f, backend, x, rewrap(unannotated_contexts...)...)
 end
-
-function shuffled_derivative!(
-    der,
-    x,
-    f::F,
-    backend::AbstractADType,
-    rewrap::Rewrap{C},
-    unannotated_contexts::Vararg{Any,C},
-) where {F,C}
-    return derivative!(f, der, backend, x, rewrap(unannotated_contexts...)...)
-end

--- a/DifferentiationInterface/src/first_order/derivative.jl
+++ b/DifferentiationInterface/src/first_order/derivative.jl
@@ -192,3 +192,22 @@ function derivative!(
     pushforward!(f!, y, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...)
     return der
 end
+
+## Shuffled
+
+function shuffled_derivative(
+    x, f::F, backend::AbstractADType, rewrap::Rewrap{C}, unannotated_contexts::Vararg{Any,C}
+) where {F,C}
+    return derivative(f, backend, x, rewrap(unannotated_contexts...)...)
+end
+
+function shuffled_derivative!(
+    der,
+    x,
+    f::F,
+    backend::AbstractADType,
+    rewrap::Rewrap{C},
+    unannotated_contexts::Vararg{Any,C},
+) where {F,C}
+    return derivative!(f, der, backend, x, rewrap(unannotated_contexts...)...)
+end

--- a/DifferentiationInterface/src/first_order/gradient.jl
+++ b/DifferentiationInterface/src/first_order/gradient.jl
@@ -120,3 +120,22 @@ function gradient!(
     pullback!(f, (grad,), prep.pullback_prep, backend, x, (true,), contexts...)
     return grad
 end
+
+## Shuffled
+
+function shuffled_gradient(
+    x, f::F, backend::AbstractADType, rewrap::Rewrap{C}, unannotated_contexts::Vararg{Any,C}
+) where {F,C}
+    return gradient(f, backend, x, rewrap(unannotated_contexts...)...)
+end
+
+function shuffled_gradient!(
+    grad,
+    x,
+    f::F,
+    backend::AbstractADType,
+    rewrap::Rewrap{C},
+    unannotated_contexts::Vararg{Any,C},
+) where {F,C}
+    return gradient!(f, grad, backend, x, rewrap(unannotated_contexts...)...)
+end

--- a/DifferentiationInterface/src/first_order/gradient.jl
+++ b/DifferentiationInterface/src/first_order/gradient.jl
@@ -128,14 +128,3 @@ function shuffled_gradient(
 ) where {F,C}
     return gradient(f, backend, x, rewrap(unannotated_contexts...)...)
 end
-
-function shuffled_gradient!(
-    grad,
-    x,
-    f::F,
-    backend::AbstractADType,
-    rewrap::Rewrap{C},
-    unannotated_contexts::Vararg{Any,C},
-) where {F,C}
-    return gradient!(f, grad, backend, x, rewrap(unannotated_contexts...)...)
-end

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -340,16 +340,3 @@ function shuffled_single_pushforward(
     ty = pushforward(f, backend, x, (dx,), rewrap(unannotated_contexts...)...)
     return only(ty)
 end
-
-function shuffled_single_pushforward!(
-    dy,
-    x,
-    f::F,
-    backend::AbstractADType,
-    dx,
-    rewrap::Rewrap{C},
-    unannotated_contexts::Vararg{Any,C},
-) where {F,C}
-    pushforward!(f, (dy,), backend, x, (dx,), rewrap(unannotated_contexts...)...)
-    return dy
-end

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -326,3 +326,30 @@ function pushforward!(
 ) where {F,C}
     return value_and_pushforward!(f!, y, ty, prep, backend, x, tx, contexts...)[2]
 end
+
+## Shuffled
+
+function shuffled_single_pushforward(
+    x,
+    f::F,
+    backend::AbstractADType,
+    dx,
+    rewrap::Rewrap{C},
+    unannotated_contexts::Vararg{Any,C},
+) where {F,C}
+    ty = pushforward(f, backend, x, (dx,), rewrap(unannotated_contexts...)...)
+    return only(ty)
+end
+
+function shuffled_single_pushforward!(
+    dy,
+    x,
+    f::F,
+    backend::AbstractADType,
+    dx,
+    rewrap::Rewrap{C},
+    unannotated_contexts::Vararg{Any,C},
+) where {F,C}
+    pushforward!(f, (dy,), backend, x, (dx,), rewrap(unannotated_contexts...)...)
+    return dy
+end

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -52,23 +52,23 @@ function hvp! end
 
 ## Preparation
 
-struct ForwardOverForwardHVPPrep{G,E<:PushforwardPrep} <: HVPPrep
-    inner_gradient::G
+struct ForwardOverForwardHVPPrep{E<:PushforwardPrep} <: HVPPrep
+    # pushforward of many pushforwards in theory, but pushforward of gradient in practice
     outer_pushforward_prep::E
 end
 
-struct ForwardOverReverseHVPPrep{G,E<:PushforwardPrep} <: HVPPrep
-    inner_gradient::G
+struct ForwardOverReverseHVPPrep{E<:PushforwardPrep} <: HVPPrep
+    # pushforward of gradient
     outer_pushforward_prep::E
 end
 
-struct ReverseOverForwardHVPPrep{P,E} <: HVPPrep
-    inner_pushforward::P
+struct ReverseOverForwardHVPPrep{E<:GradientPrep} <: HVPPrep
+    # gradient of pushforward
     outer_gradient_prep::E
 end
 
-struct ReverseOverReverseHVPPrep{G,E<:PullbackPrep} <: HVPPrep
-    inner_gradient::G
+struct ReverseOverReverseHVPPrep{E<:PullbackPrep} <: HVPPrep
+    # pullback of gradient
     outer_pullback_prep::E
 end
 
@@ -87,15 +87,11 @@ function _prepare_hvp_aux(
     contexts::Vararg{Context,C},
 ) where {F,C}
     rewrap = Rewrap(contexts...)
-    # pushforward of many pushforwards in theory, but pushforward of gradient in practice
-    function inner_gradient(_x, unannotated_contexts...)
-        annotated_contexts = rewrap(unannotated_contexts...)
-        return gradient(f, nested(inner(backend)), _x, annotated_contexts...)
-    end
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     outer_pushforward_prep = prepare_pushforward(
-        inner_gradient, outer(backend), x, tx, contexts...
+        shuffled_gradient, outer(backend), x, tx, new_contexts...
     )
-    return ForwardOverForwardHVPPrep(inner_gradient, outer_pushforward_prep)
+    return ForwardOverForwardHVPPrep(outer_pushforward_prep)
 end
 
 function _prepare_hvp_aux(
@@ -107,15 +103,11 @@ function _prepare_hvp_aux(
     contexts::Vararg{Context,C},
 ) where {F,C}
     rewrap = Rewrap(contexts...)
-    # pushforward of gradient
-    function inner_gradient(_x, unannotated_contexts...)
-        annotated_contexts = rewrap(unannotated_contexts...)
-        return gradient(f, nested(inner(backend)), _x, annotated_contexts...)
-    end
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     outer_pushforward_prep = prepare_pushforward(
-        inner_gradient, outer(backend), x, tx, contexts...
+        shuffled_gradient, outer(backend), x, tx, new_contexts...
     )
-    return ForwardOverReverseHVPPrep(inner_gradient, outer_pushforward_prep)
+    return ForwardOverReverseHVPPrep(outer_pushforward_prep)
 end
 
 function _prepare_hvp_aux(
@@ -127,16 +119,17 @@ function _prepare_hvp_aux(
     contexts::Vararg{Context,C},
 ) where {F,C}
     rewrap = Rewrap(contexts...)
-    # gradient of pushforward
-    function inner_pushforward(_x, _dx, unannotated_contexts...)
-        annotated_contexts = rewrap(unannotated_contexts...)
-        ty = pushforward(f, nested(inner(backend)), _x, (_dx,), annotated_contexts...)
-        return only(ty)
-    end
-    outer_gradient_prep = prepare_gradient(
-        inner_pushforward, outer(backend), x, contexts...
+    new_contexts = (
+        Constant(f),
+        Constant(inner(backend)),
+        Constant(first(tx)),
+        Constant(rewrap),
+        contexts...,
     )
-    return ReverseOverForwardHVPPrep(inner_pushforward, outer_gradient_prep)
+    outer_gradient_prep = prepare_gradient(
+        shuffled_single_pushforward, outer(backend), x, new_contexts...
+    )
+    return ReverseOverForwardHVPPrep(outer_gradient_prep)
 end
 
 function _prepare_hvp_aux(
@@ -148,15 +141,11 @@ function _prepare_hvp_aux(
     contexts::Vararg{Context,C},
 ) where {F,C}
     rewrap = Rewrap(contexts...)
-    # pullback of gradient
-    function inner_gradient(_x, unannotated_contexts...)
-        annotated_contexts = rewrap(unannotated_contexts...)
-        return gradient(f, nested(inner(backend)), _x, annotated_contexts...)
-    end
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     outer_pullback_prep = prepare_pullback(
-        inner_gradient, outer(backend), x, tx, contexts...
+        shuffled_gradient, outer(backend), x, tx, new_contexts...
     )
-    return ReverseOverReverseHVPPrep(inner_gradient, outer_pullback_prep)
+    return ReverseOverReverseHVPPrep(outer_pullback_prep)
 end
 
 ## One argument
@@ -169,9 +158,11 @@ function hvp(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_gradient, outer_pushforward_prep) = prep
+    (; outer_pushforward_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     return pushforward(
-        inner_gradient, outer_pushforward_prep, outer(backend), x, tx, contexts...
+        shuffled_gradient, outer_pushforward_prep, outer(backend), x, tx, new_contexts...
     )
 end
 
@@ -183,9 +174,11 @@ function hvp(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_gradient, outer_pushforward_prep) = prep
+    (; outer_pushforward_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     return pushforward(
-        inner_gradient, outer_pushforward_prep, outer(backend), x, tx, contexts...
+        shuffled_gradient, outer_pushforward_prep, outer(backend), x, tx, new_contexts...
     )
 end
 
@@ -197,9 +190,20 @@ function hvp(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_pushforward, outer_gradient_prep) = prep
+    (; outer_gradient_prep) = prep
+    rewrap = Rewrap(contexts...)
     tg = map(tx) do dx
-        gradient(inner_pushforward, outer(backend), x, Constant(dx), contexts...)
+        gradient(
+            shuffled_single_pushforward,
+            outer_gradient_prep,
+            outer(backend),
+            x,
+            Constant(f),
+            Constant(inner(backend)),
+            Constant(dx),
+            Constant(rewrap),
+            contexts...,
+        )
     end
     return tg
 end
@@ -212,8 +216,12 @@ function hvp(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_gradient, outer_pullback_prep) = prep
-    return pullback(inner_gradient, outer_pullback_prep, outer(backend), x, tx, contexts...)
+    (; outer_pullback_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
+    return pullback(
+        shuffled_gradient, outer_pullback_prep, outer(backend), x, tx, new_contexts...
+    )
 end
 
 function hvp!(
@@ -225,9 +233,17 @@ function hvp!(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_gradient, outer_pushforward_prep) = prep
+    (; outer_pushforward_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     return pushforward!(
-        inner_gradient, tg, outer_pushforward_prep, outer(backend), x, tx, contexts...
+        shuffled_gradient,
+        tg,
+        outer_pushforward_prep,
+        outer(backend),
+        x,
+        tx,
+        new_contexts...,
     )
 end
 
@@ -240,9 +256,17 @@ function hvp!(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_gradient, outer_pushforward_prep) = prep
+    (; outer_pushforward_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     return pushforward!(
-        inner_gradient, tg, outer_pushforward_prep, outer(backend), x, tx, contexts...
+        shuffled_gradient,
+        tg,
+        outer_pushforward_prep,
+        outer(backend),
+        x,
+        tx,
+        new_contexts...,
     )
 end
 
@@ -255,15 +279,19 @@ function hvp!(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_pushforward, outer_gradient_prep) = prep
+    (; outer_gradient_prep) = prep
+    rewrap = Rewrap(contexts...)
     for b in eachindex(tx, tg)
         gradient!(
-            inner_pushforward,
+            shuffled_single_pushforward,
             tg[b],
             outer_gradient_prep,
             outer(backend),
             x,
+            Constant(f),
+            Constant(inner(backend)),
             Constant(tx[b]),
+            Constant(rewrap),
             contexts...,
         )
     end
@@ -279,8 +307,10 @@ function hvp!(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_gradient, outer_pullback_prep) = prep
+    (; outer_pullback_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     return pullback!(
-        inner_gradient, tg, outer_pullback_prep, outer(backend), x, tx, contexts...
+        shuffled_gradient, tg, outer_pullback_prep, outer(backend), x, tx, new_contexts...
     )
 end

--- a/DifferentiationInterface/src/second_order/second_derivative.jl
+++ b/DifferentiationInterface/src/second_order/second_derivative.jl
@@ -48,8 +48,7 @@ function value_derivative_and_second_derivative! end
 
 ## Preparation
 
-struct ClosureSecondDerivativePrep{ID,E<:DerivativePrep} <: SecondDerivativePrep
-    inner_derivative::ID
+struct DerivativeSecondDerivativePrep{E<:DerivativePrep} <: SecondDerivativePrep
     outer_derivative_prep::E
 end
 
@@ -57,42 +56,43 @@ function prepare_second_derivative(
     f::F, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
     rewrap = Rewrap(contexts...)
-    function inner_derivative(_x, unannotated_contexts...)
-        annotated_contexts = rewrap(unannotated_contexts...)
-        return derivative(f, nested(inner(backend)), _x, annotated_contexts...)
-    end
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     outer_derivative_prep = prepare_derivative(
-        inner_derivative, outer(backend), x, contexts...
+        shuffled_derivative, outer(backend), x, new_contexts...
     )
-    return ClosureSecondDerivativePrep(inner_derivative, outer_derivative_prep)
+    return DerivativeSecondDerivativePrep(outer_derivative_prep)
 end
 
 ## One argument
 
 function second_derivative(
     f::F,
-    prep::ClosureSecondDerivativePrep,
+    prep::DerivativeSecondDerivativePrep,
     backend::AbstractADType,
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_derivative, outer_derivative_prep) = prep
+    (; outer_derivative_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     return derivative(
-        inner_derivative, outer_derivative_prep, outer(backend), x, contexts...
+        shuffled_derivative, outer_derivative_prep, outer(backend), x, new_contexts...
     )
 end
 
 function value_derivative_and_second_derivative(
     f::F,
-    prep::ClosureSecondDerivativePrep,
+    prep::DerivativeSecondDerivativePrep,
     backend::AbstractADType,
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_derivative, outer_derivative_prep) = prep
+    (; outer_derivative_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     y = f(x, map(unwrap, contexts)...)
     der, der2 = value_and_derivative(
-        inner_derivative, outer_derivative_prep, outer(backend), x, contexts...
+        shuffled_derivative, outer_derivative_prep, outer(backend), x, new_contexts...
     )
     return y, der, der2
 end
@@ -105,9 +105,11 @@ function second_derivative!(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_derivative, outer_derivative_prep) = prep
+    (; outer_derivative_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     return derivative!(
-        inner_derivative, der2, outer_derivative_prep, outer(backend), x, contexts...
+        shuffled_derivative, der2, outer_derivative_prep, outer(backend), x, new_contexts...
     )
 end
 
@@ -120,10 +122,12 @@ function value_derivative_and_second_derivative!(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; inner_derivative, outer_derivative_prep) = prep
+    (; outer_derivative_prep) = prep
+    rewrap = Rewrap(contexts...)
+    new_contexts = (Constant(f), Constant(inner(backend)), Constant(rewrap), contexts...)
     y = f(x, map(unwrap, contexts)...)
     new_der, _ = value_and_derivative!(
-        inner_derivative, der2, outer_derivative_prep, outer(backend), x, contexts...
+        shuffled_derivative, der2, outer_derivative_prep, outer(backend), x, new_contexts...
     )
     return y, copyto!(der, new_der), der2
 end

--- a/DifferentiationInterface/src/second_order/second_order.jl
+++ b/DifferentiationInterface/src/second_order/second_order.jl
@@ -60,12 +60,3 @@ outer(backend::AbstractADType) = backend
 Return the _outer_ mode of the second-order backend.
 """
 ADTypes.mode(backend::SecondOrder) = mode(outer(backend))
-
-"""
-    nested(backend)
-
-Return a possibly modified `backend` that can work while nested inside another differentiation procedure.
-
-At the moment this function is pretty much useless.
-"""
-nested(backend::AbstractADType) = backend

--- a/DifferentiationInterface/src/utils/context.jl
+++ b/DifferentiationInterface/src/utils/context.jl
@@ -59,12 +59,13 @@ end
 Base.convert(::Type{Constant{T}}, x) where {T} = Constant(convert(T, x))
 
 struct Rewrap{C,T}
-    contexts::T
     function Rewrap(contexts::Vararg{Context,C}) where {C}
         T = typeof(contexts)
-        return new{C,T}(contexts)
+        return new{C,T}()
     end
 end
+
+(::Rewrap{0})() = ()
 
 function (r::Rewrap{C,T})(unannotated_contexts::Vararg{Any,C}) where {C,T}
     return T(unannotated_contexts)

--- a/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
+++ b/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
@@ -8,17 +8,17 @@ LOGGING = get(ENV, "CI", "false") == "false"
 
 backends = [ #
     AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
-    AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
+    AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=4)),
 ]
 
 second_order_backends = [ #
     SecondOrder(
-        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
+        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=4)),
         AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
     ),
     SecondOrder(
         AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
-        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
+        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=4)),
     ),
 ]
 

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterfaceTest"
 uuid = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"


### PR DESCRIPTION
**Versions**

- Bump DIT to v0.8.2 (forgot to do it in #571)

**DI source**

- [x] In `second_derivative` and `hvp`, remove `inner_derivative/gradient/pushforward` and replace them with shuffled versions that use additional contexts to pass `f` and `backend`.
- [x] Remove the private `DI.nested`

**DI extensions**

- [ ] Zygote, Tracker: Move to a closure-based handling of constants? The idea is to avoid computing pullbacks of function and backend objects if possible.
- [x] Symbolics: Code manual `second_derivative` and `hvp` because passing constants is not supported.