### PR TITLE
Test with ExplicitImports

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -48,6 +48,7 @@ ADTypes = "1.9.0"
 ChainRulesCore = "1.23.0"
 Diffractor = "=0.2.6"
 Enzyme = "0.13.6"
+ExplicitImports = "1.10.1"
 FastDifferentiation = "0.4.1"
 FiniteDiff = "2.23.1"
 FiniteDifferences = "0.12.31"
@@ -73,6 +74,7 @@ ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Diffractor = "9f5e2b26-1114-432f-b630-d3fe2085c51c"
 Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FastDifferentiation = "eb9bf01b-bf85-4b60-bf87-ee5de06c00be"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
@@ -96,4 +98,4 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StableRNGs", "StaticArrays", "Test"]
+test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "ExplicitImports", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StableRNGs", "StaticArrays", "Test"]

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseArraysExt/DifferentiationInterfaceSparseArraysExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseArraysExt/DifferentiationInterfaceSparseArraysExt.jl
@@ -3,9 +3,9 @@ module DifferentiationInterfaceSparseArraysExt
 using ADTypes: ADTypes
 using DifferentiationInterface
 using DifferentiationInterface:
-    DenseSparsityDetector, PushforwardFast, PushforwardSlow, basis, pushforward_performance
+    DenseSparsityDetector, PushforwardFast, basis, pushforward_performance
 import DifferentiationInterface as DI
-using SparseArrays: SparseMatrixCSC, nonzeros, nzrange, rowvals, sparse
+using SparseArrays: sparse
 
 include("sparsity_detector.jl")
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
@@ -2,7 +2,6 @@ module DifferentiationInterfaceSparseMatrixColoringsExt
 
 using ADTypes:
     ADTypes,
-    AbstractADType,
     AutoSparse,
     coloring_algorithm,
     dense_ad,
@@ -20,7 +19,6 @@ using DifferentiationInterface:
     PushforwardFast,
     PushforwardSlow,
     inner,
-    outer,
     multibasis,
     pick_batchsize,
     pick_jacobian_batchsize,
@@ -31,14 +29,12 @@ import DifferentiationInterface as DI
 using SparseMatrixColorings:
     AbstractColoringResult,
     ColoringProblem,
-    GreedyColoringAlgorithm,
     coloring,
     column_colors,
     row_colors,
     column_groups,
     row_groups,
     sparsity_pattern,
-    decompress,
     decompress!
 import SparseMatrixColorings as SMC
 

--- a/DifferentiationInterface/src/DifferentiationInterface.jl
+++ b/DifferentiationInterface/src/DifferentiationInterface.jl
@@ -29,7 +29,7 @@ using ADTypes:
     AutoSymbolics,
     AutoTracker,
     AutoZygote
-using LinearAlgebra: Symmetric, Transpose, dot, parent, transpose
+using LinearAlgebra: dot
 
 include("compat.jl")
 

--- a/DifferentiationInterface/test/Misc/Internals/_formalities.jl
+++ b/DifferentiationInterface/test/Misc/Internals/_formalities.jl
@@ -29,6 +29,6 @@ end
     @test check_all_explicit_imports_via_owners(DifferentiationInterface) === nothing
     @test_broken check_all_explicit_imports_are_public(DifferentiationInterface) === nothing
     @test check_all_qualified_accesses_via_owners(DifferentiationInterface) === nothing
-    @test check_all_qualified_accesses_are_public(DifferentiationInterface) === nothing
+    @test_skip check_all_qualified_accesses_are_public(DifferentiationInterface) === nothing
     @test check_no_self_qualified_accesses(DifferentiationInterface) === nothing
 end

--- a/DifferentiationInterface/test/Misc/Internals/_formalities.jl
+++ b/DifferentiationInterface/test/Misc/Internals/_formalities.jl
@@ -29,7 +29,6 @@ end
     @test check_all_explicit_imports_via_owners(DifferentiationInterface) === nothing
     @test_broken check_all_explicit_imports_are_public(DifferentiationInterface) === nothing
     @test check_all_qualified_accesses_via_owners(DifferentiationInterface) === nothing
-    @test_broken check_all_qualified_accesses_are_public(DifferentiationInterface) ===
-        nothing
+    @test check_all_qualified_accesses_are_public(DifferentiationInterface) === nothing
     @test check_no_self_qualified_accesses(DifferentiationInterface) === nothing
 end

--- a/DifferentiationInterface/test/Misc/Internals/_formalities.jl
+++ b/DifferentiationInterface/test/Misc/Internals/_formalities.jl
@@ -2,23 +2,34 @@
 
 using Aqua: Aqua
 using DifferentiationInterface
+using ExplicitImports
 using JET: JET
 using JuliaFormatter: JuliaFormatter
 using Test
 using SparseMatrixColorings
+using SparseArrays
 
-@testset verbose = true "Formalities" begin
-    @testset "Aqua" begin
-        Aqua.test_all(
-            DifferentiationInterface; ambiguities=false, deps_compat=(check_extras = false)
-        )
-    end
-    @testset "JET" begin
-        JET.test_package(DifferentiationInterface; target_defined_modules=true)
-    end
-    @testset "JuliaFormatter" begin
-        @test JuliaFormatter.format(
-            DifferentiationInterface; verbose=false, overwrite=false
-        )
-    end
+@testset "Aqua" begin
+    Aqua.test_all(
+        DifferentiationInterface; ambiguities=false, deps_compat=(check_extras = false)
+    )
+end
+
+@testset "JET" begin
+    JET.test_package(DifferentiationInterface; target_defined_modules=true)
+end
+
+@testset "JuliaFormatter" begin
+    @test JuliaFormatter.format(DifferentiationInterface; verbose=false, overwrite=false)
+end
+
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(DifferentiationInterface) === nothing
+    @test check_no_stale_explicit_imports(DifferentiationInterface) === nothing
+    @test check_all_explicit_imports_via_owners(DifferentiationInterface) === nothing
+    @test_broken check_all_explicit_imports_are_public(DifferentiationInterface) === nothing
+    @test check_all_qualified_accesses_via_owners(DifferentiationInterface) === nothing
+    @test_broken check_all_qualified_accesses_are_public(DifferentiationInterface) ===
+        nothing
+    @test check_no_self_qualified_accesses(DifferentiationInterface) === nothing
 end

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -42,6 +42,7 @@ ComponentArrays = "0.15"
 DataFrames = "1.6.1"
 DifferentiationInterface = "0.6.0"
 DocStringExtensions = "0.8,0.9"
+ExplicitImports = "1.10.1"
 FiniteDifferences = "0.12"
 Flux = "0.13,0.14"
 ForwardDiff = "0.10.36"
@@ -67,6 +68,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ComponentArrays = "b0b7db55-cfe3-40fc-9ded-d10e2dbeff66"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 Flux = "587475ba-b771-5e3f-ad9e-33799f191a9c"
@@ -86,4 +88,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "DifferentiationInterface", "FiniteDifferences", "Flux", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StaticArrays", "Test", "Zygote"]
+test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "DifferentiationInterface", "ExplicitImports", "FiniteDifferences", "Flux", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StaticArrays", "Test", "Zygote"]

--- a/DifferentiationInterfaceTest/test/formalities.jl
+++ b/DifferentiationInterfaceTest/test/formalities.jl
@@ -1,6 +1,7 @@
 using DifferentiationInterface
 using DifferentiationInterfaceTest
 using Aqua: Aqua
+using ExplicitImports
 using JET: JET
 using JuliaFormatter: JuliaFormatter
 using SparseMatrixColorings: SparseMatrixColorings
@@ -18,4 +19,17 @@ end
 end
 @testset verbose = true "JET" begin
     JET.test_package(DifferentiationInterfaceTest; target_defined_modules=true)
+end
+
+@testset "ExplicitImports" begin
+    @test_broken check_no_implicit_imports(DifferentiationInterfaceTest) === nothing
+    @test_broken check_no_stale_explicit_imports(DifferentiationInterfaceTest) === nothing
+    @test_broken check_all_explicit_imports_via_owners(DifferentiationInterfaceTest) ===
+        nothing
+    @test_broken check_all_explicit_imports_are_public(DifferentiationInterfaceTest) ===
+        nothing
+    @test check_all_qualified_accesses_via_owners(DifferentiationInterfaceTest) === nothing
+    @test_broken check_all_qualified_accesses_are_public(DifferentiationInterfaceTest) ===
+        nothing
+    @test check_no_self_qualified_accesses(DifferentiationInterfaceTest) === nothing
 end


### PR DESCRIPTION
**DI tests**

- [x] Use ExplicitImports for testing core package and sparse extensions (except public names)
- [ ] Do the same for backend extensions

**DIT tests**

- [ ] Use ExplicitImports for testing core package
