### PR TITLE
Pick correct batch size for hessian

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
@@ -20,7 +20,7 @@ using DifferentiationInterface:
     PushforwardSlow,
     inner,
     multibasis,
-    pick_batchsize,
+    pick_hessian_batchsize,
     pick_jacobian_batchsize,
     pushforward_performance,
     unwrap,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/hessian.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/hessian.jl
@@ -42,7 +42,7 @@ SMC.column_groups(prep::SparseHessianPrep) = column_groups(prep.coloring_result)
 function DI.prepare_hessian(
     f::F, backend::AutoSparse, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    valB = pick_batchsize(dense_ad(backend), length(x))
+    valB = pick_hessian_batchsize(dense_ad(backend), length(x))
     return _prepare_sparse_hessian_aux(valB, f, backend, x, contexts...)
 end
 

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -72,7 +72,7 @@ end
 function prepare_hessian(
     f::F, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    valB = pick_batchsize(backend, length(x))
+    valB = pick_hessian_batchsize(backend, length(x))
     return _prepare_hessian_aux(valB, f, backend, x, contexts...)
 end
 

--- a/DifferentiationInterface/src/utils/batchsize.jl
+++ b/DifferentiationInterface/src/utils/batchsize.jl
@@ -23,4 +23,8 @@ function pick_jacobian_batchsize(
     return pick_batchsize(backend, M)
 end
 
+function pick_hessian_batchsize(backend::AbstractADType, N::Integer)
+    return pick_batchsize(outer(backend), N)
+end
+
 threshold_batchsize(backend::AbstractADType, ::Integer) = backend


### PR DESCRIPTION
**Versions**

- Bump DI to v0.6.12

**DI source**

- Implement `pick_hessian_batchsize(backend, N) = pick_batchsize(outer(backend), N)`
- Use it in dense and sparse `hessian`. Before that, Hessians with `SecondOrder` would have had batch size 1 by default.