### PR TITLE
Revamp batch size handling

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.12"
+version = "0.6.13"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/docs/src/explanation/advanced.md
+++ b/DifferentiationInterface/docs/src/explanation/advanced.md
@@ -67,3 +67,26 @@ The complexity of sparse Jacobians or Hessians grows with the number of distinct
 To reduce this number of colors, [`GreedyColoringAlgorithm`](@ref) has two main settings: the order used for vertices and the decompression method.
 Depending on your use case, you may want to modify either of these options to increase performance.
 See the documentation of [SparseMatrixColorings.jl](https://github.com/gdalle/SparseMatrixColorings.jl) for details.
+
+## Batch mode
+
+### Multiple tangents
+
+The [`jacobian`](@ref) and [`hessian`](@ref) operators compute matrices by repeatedly applying lower-level operators ([`pushforward`](@ref), [`pullback`](@ref) or [`hvp`](@ref)) to a set of tangents.
+Each of these tangents corresponds to a basis element of the appropriate vector space.
+We could call the lower-level operator on each tangent separately, but some packages ([ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) and [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl)) have optimized implementations for multiple tangents at once.
+This is often called "vector mode" AD, but we call it "batch mode" to avoid confusion with Julia's `Vector` type.
+As a matter of fact, the optimal batch size (number of simultaneous tangents) is usually very small, so tangents are passed within an `NTuple` and not a `Vector`.
+
+### Picking the batch size
+
+For every backend which does not support batch mode, the batch size is always set to 1.
+But for [`AutoForwardDiff`](@extref ADTypes.AutoForwardDiff) and [`AutoEnzyme`](@extref ADTypes.AutoEnzyme), more complicated rules apply.
+
+Let $N$ denote the dimension of the vector space.
+If the backend object has a fixed batch size $B$, then
+
+- When $N < B$, `jacobian` and `hessian` error.
+- Otherwise, they will process $\lceil N / B_0 \rceil$ batches of $B_0$ elements each.
+
+If the backend has no fixed batch size, then we rely 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -4,7 +4,6 @@ using ADTypes: ADTypes, AutoEnzyme
 using Base: Fix1
 import DifferentiationInterface as DI
 using DifferentiationInterface:
-    BatchSizeSettings,
     Context,
     DerivativePrep,
     GradientPrep,
@@ -17,12 +16,12 @@ using DifferentiationInterface:
     NoHVPPrep,
     NoJacobianPrep,
     NoPullbackPrep,
-    NoPushforwardPrep,
-    pick_batchsize
+    NoPushforwardPrep
 using Enzyme:
     Active,
     Annotation,
     BatchDuplicated,
+    BatchMixedDuplicated,
     Const,
     Duplicated,
     DuplicatedNoNeed,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -4,6 +4,7 @@ using ADTypes: ADTypes, AutoEnzyme
 using Base: Fix1
 import DifferentiationInterface as DI
 using DifferentiationInterface:
+    BatchSizeSettings,
     Context,
     DerivativePrep,
     GradientPrep,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -121,7 +121,7 @@ end
 function DI.prepare_gradient(
     f::F, backend::AutoEnzyme{<:ForwardMode,<:Union{Nothing,Const}}, x
 ) where {F}
-    valB = pick_batchsize(backend, length(x))
+    valB = to_val(pick_batchsize(backend, length(x)))
     shadows = create_shadows(valB, x)
     return EnzymeForwardGradientPrep(valB, shadows)
 end
@@ -190,7 +190,7 @@ function DI.prepare_jacobian(
     f::F, backend::AutoEnzyme{<:Union{ForwardMode,Nothing},<:Union{Nothing,Const}}, x
 ) where {F}
     y = f(x)
-    valB = pick_batchsize(backend, length(x))
+    valB = to_val(pick_batchsize(backend, length(x)))
     shadows = create_shadows(valB, x)
     return EnzymeForwardOneArgJacobianPrep(valB, shadows, length(y))
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -121,7 +121,7 @@ end
 function DI.prepare_gradient(
     f::F, backend::AutoEnzyme{<:ForwardMode,<:Union{Nothing,Const}}, x
 ) where {F}
-    valB = DI.to_val(pick_batchsize(backend, length(x)))
+    valB = to_val(DI.pick_batchsize(backend, x))
     shadows = create_shadows(valB, x)
     return EnzymeForwardGradientPrep(valB, shadows)
 end
@@ -190,7 +190,7 @@ function DI.prepare_jacobian(
     f::F, backend::AutoEnzyme{<:Union{ForwardMode,Nothing},<:Union{Nothing,Const}}, x
 ) where {F}
     y = f(x)
-    valB = DI.to_val(pick_batchsize(backend, length(x)))
+    valB = to_val(DI.pick_batchsize(backend, x))
     shadows = create_shadows(valB, x)
     return EnzymeForwardOneArgJacobianPrep(valB, shadows, length(y))
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -121,7 +121,7 @@ end
 function DI.prepare_gradient(
     f::F, backend::AutoEnzyme{<:ForwardMode,<:Union{Nothing,Const}}, x
 ) where {F}
-    valB = to_val(pick_batchsize(backend, length(x)))
+    valB = DI.to_val(pick_batchsize(backend, length(x)))
     shadows = create_shadows(valB, x)
     return EnzymeForwardGradientPrep(valB, shadows)
 end
@@ -190,7 +190,7 @@ function DI.prepare_jacobian(
     f::F, backend::AutoEnzyme{<:Union{ForwardMode,Nothing},<:Union{Nothing,Const}}, x
 ) where {F}
     y = f(x)
-    valB = to_val(pick_batchsize(backend, length(x)))
+    valB = DI.to_val(pick_batchsize(backend, length(x)))
     shadows = create_shadows(valB, x)
     return EnzymeForwardOneArgJacobianPrep(valB, shadows, length(y))
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -337,7 +337,7 @@ end
 function DI.prepare_jacobian(f::F, backend::AutoEnzyme{<:ReverseMode,Nothing}, x) where {F}
     y = f(x)
     Sy = size(y)
-    valB = to_val(pick_batchsize(backend, prod(Sy)))
+    valB = DI.to_val(pick_batchsize(backend, prod(Sy)))
     return EnzymeReverseOneArgJacobianPrep(Val(Sy), valB)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -71,7 +71,7 @@ function DI.value_and_pullback(
 ) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_split_withprimal(backend)
-    RA = eltype(ty) <: Number ? Active : Duplicated
+    RA = guess_activity(eltype(ty), mode)
     dinputs, result = seeded_autodiff_thunk(
         mode, only(ty), f_and_df, RA, Active(x), map(translate, contexts)...
     )
@@ -88,7 +88,7 @@ function DI.value_and_pullback(
 ) where {F,B,C}
     f_and_df = force_annotation(get_f_and_df(f, backend, Val(B)))
     mode = reverse_split_withprimal(backend)
-    RA = eltype(ty) <: Number ? Active : BatchDuplicated
+    RA = batchify_activity(guess_activity(eltype(ty), mode), Val(B))
     dinputs, result = batch_seeded_autodiff_thunk(
         mode, ty, f_and_df, RA, Active(x), map(translate, contexts)...
     )
@@ -105,7 +105,7 @@ function DI.value_and_pullback(
 ) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_split_withprimal(backend)
-    RA = eltype(ty) <: Number ? Active : Duplicated
+    RA = guess_activity(eltype(ty), mode)
     dx = make_zero(x)
     _, result = seeded_autodiff_thunk(
         mode, only(ty), f_and_df, RA, Duplicated(x, dx), map(translate, contexts)...
@@ -123,7 +123,7 @@ function DI.value_and_pullback(
 ) where {F,B,C}
     f_and_df = force_annotation(get_f_and_df(f, backend, Val(B)))
     mode = reverse_split_withprimal(backend)
-    RA = eltype(ty) <: Number ? Active : BatchDuplicated
+    RA = batchify_activity(guess_activity(eltype(ty), mode), Val(B))
     tx = ntuple(_ -> make_zero(x), Val(B))
     _, result = batch_seeded_autodiff_thunk(
         mode, ty, f_and_df, RA, BatchDuplicated(x, tx), map(translate, contexts)...
@@ -155,7 +155,7 @@ function DI.value_and_pullback!(
 ) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_split_withprimal(backend)
-    RA = eltype(ty) <: Number ? Active : Duplicated
+    RA = guess_activity(eltype(ty), mode)
     dx_righttype = convert(typeof(x), only(tx))
     make_zero!(dx_righttype)
     _, result = seeded_autodiff_thunk(
@@ -181,7 +181,7 @@ function DI.value_and_pullback!(
 ) where {F,B,C}
     f_and_df = force_annotation(get_f_and_df(f, backend, Val(B)))
     mode = reverse_split_withprimal(backend)
-    RA = eltype(ty) <: Number ? Active : BatchDuplicated
+    RA = batchify_activity(guess_activity(eltype(ty), mode), Val(B))
     tx_righttype = map(Fix1(convert, typeof(x)), tx)
     make_zero!(tx_righttype)
     _, result = batch_seeded_autodiff_thunk(
@@ -337,7 +337,7 @@ end
 function DI.prepare_jacobian(f::F, backend::AutoEnzyme{<:ReverseMode,Nothing}, x) where {F}
     y = f(x)
     Sy = size(y)
-    valB = DI.to_val(pick_batchsize(backend, prod(Sy)))
+    valB = to_val(DI.pick_batchsize(backend, y))
     return EnzymeReverseOneArgJacobianPrep(Val(Sy), valB)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -337,7 +337,7 @@ end
 function DI.prepare_jacobian(f::F, backend::AutoEnzyme{<:ReverseMode,Nothing}, x) where {F}
     y = f(x)
     Sy = size(y)
-    valB = pick_batchsize(backend, prod(Sy))
+    valB = to_val(pick_batchsize(backend, prod(Sy)))
     return EnzymeReverseOneArgJacobianPrep(Val(Sy), valB)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -71,7 +71,7 @@ function DI.value_and_pullback(
 ) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_split_withprimal(backend)
-    RA = guess_activity(eltype(ty), mode)
+    RA = eltype(ty) <: Number ? Active : Duplicated
     dinputs, result = seeded_autodiff_thunk(
         mode, only(ty), f_and_df, RA, Active(x), map(translate, contexts)...
     )
@@ -88,7 +88,7 @@ function DI.value_and_pullback(
 ) where {F,B,C}
     f_and_df = force_annotation(get_f_and_df(f, backend, Val(B)))
     mode = reverse_split_withprimal(backend)
-    RA = batchify_activity(guess_activity(eltype(ty), mode), Val(B))
+    RA = eltype(ty) <: Number ? Active : BatchDuplicated
     dinputs, result = batch_seeded_autodiff_thunk(
         mode, ty, f_and_df, RA, Active(x), map(translate, contexts)...
     )
@@ -105,7 +105,7 @@ function DI.value_and_pullback(
 ) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_split_withprimal(backend)
-    RA = guess_activity(eltype(ty), mode)
+    RA = eltype(ty) <: Number ? Active : Duplicated
     dx = make_zero(x)
     _, result = seeded_autodiff_thunk(
         mode, only(ty), f_and_df, RA, Duplicated(x, dx), map(translate, contexts)...
@@ -123,7 +123,7 @@ function DI.value_and_pullback(
 ) where {F,B,C}
     f_and_df = force_annotation(get_f_and_df(f, backend, Val(B)))
     mode = reverse_split_withprimal(backend)
-    RA = batchify_activity(guess_activity(eltype(ty), mode), Val(B))
+    RA = eltype(ty) <: Number ? Active : BatchDuplicated
     tx = ntuple(_ -> make_zero(x), Val(B))
     _, result = batch_seeded_autodiff_thunk(
         mode, ty, f_and_df, RA, BatchDuplicated(x, tx), map(translate, contexts)...
@@ -155,7 +155,7 @@ function DI.value_and_pullback!(
 ) where {F,C}
     f_and_df = force_annotation(get_f_and_df(f, backend))
     mode = reverse_split_withprimal(backend)
-    RA = guess_activity(eltype(ty), mode)
+    RA = eltype(ty) <: Number ? Active : Duplicated
     dx_righttype = convert(typeof(x), only(tx))
     make_zero!(dx_righttype)
     _, result = seeded_autodiff_thunk(
@@ -181,7 +181,7 @@ function DI.value_and_pullback!(
 ) where {F,B,C}
     f_and_df = force_annotation(get_f_and_df(f, backend, Val(B)))
     mode = reverse_split_withprimal(backend)
-    RA = batchify_activity(guess_activity(eltype(ty), mode), Val(B))
+    RA = eltype(ty) <: Number ? Active : BatchDuplicated
     tx_righttype = map(Fix1(convert, typeof(x)), tx)
     make_zero!(tx_righttype)
     _, result = batch_seeded_autodiff_thunk(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -1,5 +1,5 @@
 # until https://github.com/EnzymeAD/Enzyme.jl/pull/1545 is merged
-DI.pick_batchsize(::AutoEnzyme, dimension::Integer) = Val(min(dimension, 16))
+DI.adaptive_batchsize(::AutoEnzyme, a) = Val(min(length(a), 16))
 
 ## Annotations
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -6,7 +6,7 @@ function DI.BatchSizeSettings(::AutoEnzyme, N::Integer)
     return DI.BatchSizeSettings{B,singlebatch,aligned}(N)
 end
 
-to_val(::BatchSizeSettings{B}) where {B} = Val(B)
+to_val(::DI.BatchSizeSettings{B}) where {B} = Val(B)
 
 ## Annotations
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -1,10 +1,12 @@
 # until https://github.com/EnzymeAD/Enzyme.jl/pull/1545 is merged
 function DI.BatchSizeSettings(::AutoEnzyme, N::Integer)
-    B = min(N, 16)  # TODO: balance batches
+    B = DI.reasonable_batchsize(N, 16)
     singlebatch = B == N
     aligned = N % B == 0
     return BatchSizeSettings{B,singlebatch,aligned}(N)
 end
+
+to_val(::BatchSizeSettings{B}) where {B} = Val(B)
 
 ## Annotations
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -1,4 +1,5 @@
 # until https://github.com/EnzymeAD/Enzyme.jl/pull/1545 is merged
+DI.has_fixed_batchsize(::AutoEnzyme) = false
 DI.adaptive_batchsize(::AutoEnzyme, a) = Val(min(length(a), 16))
 
 ## Annotations

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -1,6 +1,10 @@
 # until https://github.com/EnzymeAD/Enzyme.jl/pull/1545 is merged
-DI.has_fixed_batchsize(::AutoEnzyme) = false
-DI.adaptive_batchsize(::AutoEnzyme, a) = Val(min(length(a), 16))
+function DI.BatchSizeSettings(::AutoEnzyme, N::Integer)
+    B = min(N, 16)  # TODO: balance batches
+    singlebatch = B == N
+    aligned = N % B == 0
+    return BatchSizeSettings{B,singlebatch,aligned}(N)
+end
 
 ## Annotations
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -68,14 +68,6 @@ end
 set_err(mode::Mode, ::AutoEnzyme{<:Any,Nothing}) = EnzymeCore.set_err_if_func_written(mode)
 set_err(mode::Mode, ::AutoEnzyme{<:Any,<:Annotation}) = mode
 
-batchify_activity(::Type{Const{T}}, ::Val{B}) where {T,B} = Const{T}
-batchify_activity(::Type{Active{T}}, ::Val{B}) where {T,B} = Active{T}
-batchify_activity(::Type{Duplicated{T}}, ::Val{B}) where {T,B} = BatchDuplicated{T,B}
-
-function batchify_activity(::Type{MixedDuplicated{T}}, ::Val{B}) where {T,B}
-    return BatchMixedDuplicated{T,B}
-end
-
 function maybe_reshape(A::AbstractMatrix, m, n)
     @assert size(A) == (m, n)
     return A

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -4,6 +4,7 @@ using ADTypes: AbstractADType, AutoForwardDiff
 using Base: Fix1, Fix2
 import DifferentiationInterface as DI
 using DifferentiationInterface:
+    BatchSizeSettings,
     Context,
     DerivativePrep,
     DifferentiateWith,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -49,24 +49,6 @@ using LinearAlgebra: dot, mul!
 
 DI.check_available(::AutoForwardDiff) = true
 
-function DI.pick_batchsize(
-    ::AutoForwardDiff{chunksize}, dimension::Integer
-) where {chunksize}
-    return Val{chunksize}()
-end
-
-function DI.pick_batchsize(::AutoForwardDiff{nothing}, dimension::Integer)
-    # type-unstable
-    return Val(ForwardDiff.pickchunksize(dimension))
-end
-
-function DI.threshold_batchsize(
-    backend::AutoForwardDiff{chunksize1}, chunksize2::Integer
-) where {chunksize1}
-    chunksize = (chunksize1 === nothing) ? nothing : min(chunksize1, chunksize2)
-    return AutoForwardDiff(; chunksize, tag=backend.tag)
-end
-
 include("utils.jl")
 include("onearg.jl")
 include("twoarg.jl")

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -1,3 +1,26 @@
+function DI.has_fixed_batchsize(::AutoForwardDiff{chunksize}) where {chunksize}
+    return !isnothing(chunksize)
+end
+
+function DI.fixed_batchsize(::AutoForwardDiff{chunksize}) where {chunksize}
+    @assert !isnothing(chunksize)
+    return Val(chunksize)
+end
+
+chunk_to_val(::Chunk{C}) where {C} = Val(C)
+
+function DI.adaptive_batchsize(::AutoForwardDiff{nothing}, a)
+    chunk = Chunk(a)  # type-unstable
+    return chunk_to_val(chunk)
+end
+
+function DI.threshold_batchsize(
+    backend::AutoForwardDiff{chunksize1}, chunksize2::Integer
+) where {chunksize1}
+    chunksize = isnothing(chunksize1) ? nothing : min(chunksize1, chunksize2)
+    return AutoForwardDiff(; chunksize, tag=backend.tag)
+end
+
 choose_chunk(::AutoForwardDiff{nothing}, x) = Chunk(x)
 choose_chunk(::AutoForwardDiff{chunksize}, x) where {chunksize} = Chunk{chunksize}()
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -10,8 +10,8 @@ function DI.BatchSizeSettings(::AutoForwardDiff{chunksize}, N::Integer) where {c
         throw(ArgumentError("Fixed chunksize $chunksize larger than input size $N"))
     end
     B = chunksize
-    singlebatch = true
-    aligned = true
+    singlebatch = B == N
+    aligned = N % B == 0
     return BatchSizeSettings{B,singlebatch,aligned}(N)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
@@ -28,12 +28,8 @@ end
 
 DI.check_available(::AutoPolyesterForwardDiff) = true
 
-function DI.fixed_batchsize(backend::AutoPolyesterForwardDiff)
-    return DI.fixed_batchsize(single_threaded(backend))
-end
-
-function DI.adaptive_batchsize(backend::AutoPolyesterForwardDiff, a)
-    return DI.adaptive_batchsize(single_threaded(backend), a)
+function DI.BatchSizeSettings(backend::AutoPolyesterForwardDiff, x_or_N)
+    return DI.BatchSizeSettings(single_threaded(backend), x_or_N)
 end
 
 function DI.threshold_batchsize(

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
@@ -28,14 +28,18 @@ end
 
 DI.check_available(::AutoPolyesterForwardDiff) = true
 
-function DI.pick_batchsize(backend::AutoPolyesterForwardDiff, dimension::Integer)
-    return DI.pick_batchsize(single_threaded(backend), dimension)
+function DI.fixed_batchsize(backend::AutoPolyesterForwardDiff)
+    return DI.fixed_batchsize(single_threaded(backend))
+end
+
+function DI.adaptive_batchsize(backend::AutoPolyesterForwardDiff, a)
+    return DI.adaptive_batchsize(single_threaded(backend), a)
 end
 
 function DI.threshold_batchsize(
     backend::AutoPolyesterForwardDiff{chunksize1}, chunksize2::Integer
 ) where {chunksize1}
-    chunksize = (chunksize1 === nothing) ? nothing : min(chunksize1, chunksize2)
+    chunksize = isnothing(chunksize1) ? nothing : min(chunksize1, chunksize2)
     return AutoPolyesterForwardDiff(; chunksize, tag=backend.tag)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
@@ -19,7 +19,6 @@ using DifferentiationInterface:
     PushforwardPrep,
     PushforwardFast,
     PushforwardPerformance,
-    PushforwardSlow,
     inner,
     outer,
     multibasis,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
@@ -20,8 +20,7 @@ using DifferentiationInterface:
     PushforwardSlow,
     inner,
     multibasis,
-    pick_hessian_batchsize,
-    pick_jacobian_batchsize,
+    pick_batchsize,
     pushforward_performance,
     unwrap,
     with_contexts

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
@@ -10,6 +10,7 @@ using ADTypes:
     hessian_sparsity
 using DifferentiationInterface
 using DifferentiationInterface:
+    BatchSizeSettings,
     GradientPrep,
     HessianPrep,
     HVPPrep,
@@ -17,6 +18,7 @@ using DifferentiationInterface:
     PullbackPrep,
     PushforwardPrep,
     PushforwardFast,
+    PushforwardPerformance,
     PushforwardSlow,
     inner,
     outer,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/DifferentiationInterfaceSparseMatrixColoringsExt.jl
@@ -19,6 +19,7 @@ using DifferentiationInterface:
     PushforwardFast,
     PushforwardSlow,
     inner,
+    outer,
     multibasis,
     pick_batchsize,
     pushforward_performance,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/hessian.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/hessian.jl
@@ -42,7 +42,8 @@ SMC.column_groups(prep::SparseHessianPrep) = column_groups(prep.coloring_result)
 function DI.prepare_hessian(
     f::F, backend::AutoSparse, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    valB = pick_hessian_batchsize(dense_ad(backend), length(x))
+    dense_backend = dense_ad(backend)
+    valB = pick_batchsize(outer(dense_backend), x)
     return _prepare_sparse_hessian_aux(valB, f, backend, x, contexts...)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/hessian.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/hessian.jl
@@ -1,36 +1,19 @@
 struct SparseHessianPrep{
-    B,
+    BS<:BatchSizeSettings,
     C<:AbstractColoringResult{:symmetric,:column},
     M<:AbstractMatrix{<:Real},
-    TD<:NTuple{B},
-    TR<:NTuple{B},
+    S<:AbstractVector{<:NTuple},
+    R<:AbstractVector{<:NTuple},
     E2<:HVPPrep,
     E1<:GradientPrep,
 } <: HessianPrep
+    batch_size_settings::BS
     coloring_result::C
     compressed_matrix::M
-    batched_seeds::Vector{TD}
-    batched_results::Vector{TR}
+    batched_seeds::S
+    batched_results::R
     hvp_prep::E2
     gradient_prep::E1
-end
-
-function SparseHessianPrep{B}(;
-    coloring_result::C,
-    compressed_matrix::M,
-    batched_seeds::Vector{TD},
-    batched_results::Vector{TR},
-    hvp_prep::E2,
-    gradient_prep::E1,
-) where {B,C,M,TD,TR,E2,E1}
-    return SparseHessianPrep{B,C,M,TD,TR,E2,E1}(
-        coloring_result,
-        compressed_matrix,
-        batched_seeds,
-        batched_results,
-        hvp_prep,
-        gradient_prep,
-    )
 end
 
 SMC.sparsity_pattern(prep::SparseHessianPrep) = sparsity_pattern(prep.coloring_result)
@@ -43,14 +26,6 @@ function DI.prepare_hessian(
     f::F, backend::AutoSparse, x, contexts::Vararg{Context,C}
 ) where {F,C}
     dense_backend = dense_ad(backend)
-    valB = pick_batchsize(outer(dense_backend), x)
-    return _prepare_sparse_hessian_aux(valB, f, backend, x, contexts...)
-end
-
-function _prepare_sparse_hessian_aux(
-    ::Val{B}, f::F, backend::AutoSparse, x, contexts::Vararg{Context,C}
-) where {B,F,C}
-    dense_backend = dense_ad(backend)
     sparsity = hessian_sparsity(
         with_contexts(f, contexts...), x, sparsity_detector(backend)
     )
@@ -58,18 +33,34 @@ function _prepare_sparse_hessian_aux(
     coloring_result = coloring(
         sparsity, problem, coloring_algorithm(backend); decompression_eltype=eltype(x)
     )
+    N = length(column_groups(coloring_result))
+    batch_size_settings = pick_batchsize(outer(dense_backend), N)
+    return _prepare_sparse_hessian_aux(
+        batch_size_settings, coloring_result, f, backend, x, contexts...
+    )
+end
+
+function _prepare_sparse_hessian_aux(
+    batch_size_settings::BatchSizeSettings{B},
+    coloring_result::AbstractColoringResult{:symmetric,:column},
+    f::F,
+    backend::AutoSparse,
+    x,
+    contexts::Vararg{Context,C},
+) where {B,F,C}
+    (; N, A) = batch_size_settings
+    dense_backend = dense_ad(backend)
     groups = column_groups(coloring_result)
-    Ng = length(groups)
     seeds = [multibasis(backend, x, eachindex(x)[group]) for group in groups]
     compressed_matrix = stack(_ -> vec(similar(x)), groups; dims=2)
     batched_seeds = [
-        ntuple(b -> seeds[1 + ((a - 1) * B + (b - 1)) % Ng], Val(B)) for
-        a in 1:div(Ng, B, RoundUp)
+        ntuple(b -> seeds[1 + ((a - 1) * B + (b - 1)) % N], Val(B)) for a in 1:A
     ]
     batched_results = [ntuple(b -> similar(x), Val(B)) for _ in batched_seeds]
     hvp_prep = prepare_hvp(f, dense_backend, x, batched_seeds[1], contexts...)
     gradient_prep = prepare_gradient(f, inner(dense_backend), x, contexts...)
-    return SparseHessianPrep{B}(;
+    return SparseHessianPrep(
+        batch_size_settings,
         coloring_result,
         compressed_matrix,
         batched_seeds,
@@ -82,14 +73,21 @@ end
 function DI.hessian!(
     f::F,
     hess,
-    prep::SparseHessianPrep{B},
+    prep::SparseHessianPrep{<:BatchSizeSettings{B}},
     backend::AutoSparse,
     x,
     contexts::Vararg{Context,C},
 ) where {F,B,C}
-    (; coloring_result, compressed_matrix, batched_seeds, batched_results, hvp_prep) = prep
+    (;
+        batch_size_settings,
+        coloring_result,
+        compressed_matrix,
+        batched_seeds,
+        batched_results,
+        hvp_prep,
+    ) = prep
+    (; N) = batch_size_settings
     dense_backend = dense_ad(backend)
-    Ng = length(column_groups(coloring_result))
 
     hvp_prep_same = prepare_hvp_same_point(
         f, hvp_prep, dense_backend, x, batched_seeds[1], contexts...
@@ -108,7 +106,7 @@ function DI.hessian!(
 
         for b in eachindex(batched_results[a])
             copyto!(
-                view(compressed_matrix, :, 1 + ((a - 1) * B + (b - 1)) % Ng),
+                view(compressed_matrix, :, 1 + ((a - 1) * B + (b - 1)) % N),
                 vec(batched_results[a][b]),
             )
         end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian.jl
@@ -73,17 +73,27 @@ end
 function DI.prepare_jacobian(
     f::F, backend::AutoSparse, x, contexts::Vararg{Context,C}
 ) where {F,C}
+    dense_backend = dense_ad(backend)
     y = f(x, map(unwrap, contexts)...)
-    perf = pushforward_performance(backend)
-    valB = pick_jacobian_batchsize(perf, dense_ad(backend); N=length(x), M=length(y))
+    perf = pushforward_performance(dense_backend)
+    if perf isa PushforwardFast
+        valB = pick_batchsize(dense_backend, x)
+    else
+        valB = pick_batchsize(dense_backend, y)
+    end
     return _prepare_sparse_jacobian_aux(perf, valB, y, (f,), backend, x, contexts...)
 end
 
 function DI.prepare_jacobian(
     f!::F, y, backend::AutoSparse, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    perf = pushforward_performance(backend)
-    valB = pick_jacobian_batchsize(perf, dense_ad(backend); N=length(x), M=length(y))
+    dense_backend = dense_ad(backend)
+    perf = pushforward_performance(dense_backend)
+    if perf isa PushforwardFast
+        valB = pick_batchsize(dense_backend, x)
+    else
+        valB = pick_batchsize(dense_backend, y)
+    end
     return _prepare_sparse_jacobian_aux(perf, valB, y, (f!, y), backend, x, contexts...)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceStaticArraysExt/DifferentiationInterfaceStaticArraysExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceStaticArraysExt/DifferentiationInterfaceStaticArraysExt.jl
@@ -1,10 +1,14 @@
 module DifferentiationInterfaceStaticArraysExt
 
+using ADTypes: AutoForwardDiff, AutoEnzyme
 import DifferentiationInterface as DI
-using StaticArrays: SArray
+using StaticArrays: SArray, StaticArray
 
 function DI.stack_vec_col(t::NTuple{B,<:SArray}) where {B}
     return hcat(map(vec, t)...)
 end
+
+DI.adaptive_batchsize(::AutoForwardDiff{nothing}, a::StaticArray) = Val(length(a))
+DI.adaptive_batchsize(::AutoEnzyme, a::StaticArray) = Val(length(a))
 
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceStaticArraysExt/DifferentiationInterfaceStaticArraysExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceStaticArraysExt/DifferentiationInterfaceStaticArraysExt.jl
@@ -9,6 +9,10 @@ function DI.stack_vec_col(t::NTuple{B,<:StaticArray}) where {B}
     return hcat(map(vec, t)...)
 end
 
+function DI.stack_vec_row(t::NTuple{B,<:StaticArray}) where {B}
+    return vcat(transpose.(map(vec, t))...)
+end
+
 function DI.BatchSizeSettings(::AutoForwardDiff{nothing}, x::StaticArray)
     return BatchSizeSettings{length(x),true,true}(length(x))
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceStaticArraysExt/DifferentiationInterfaceStaticArraysExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceStaticArraysExt/DifferentiationInterfaceStaticArraysExt.jl
@@ -2,13 +2,19 @@ module DifferentiationInterfaceStaticArraysExt
 
 using ADTypes: AutoForwardDiff, AutoEnzyme
 import DifferentiationInterface as DI
+using DifferentiationInterface: BatchSizeSettings
 using StaticArrays: SArray, StaticArray
 
-function DI.stack_vec_col(t::NTuple{B,<:SArray}) where {B}
+function DI.stack_vec_col(t::NTuple{B,<:StaticArray}) where {B}
     return hcat(map(vec, t)...)
 end
 
-DI.adaptive_batchsize(::AutoForwardDiff{nothing}, a::StaticArray) = Val(length(a))
-DI.adaptive_batchsize(::AutoEnzyme, a::StaticArray) = Val(length(a))
+function DI.BatchSizeSettings(::AutoForwardDiff{nothing}, x::StaticArray)
+    return BatchSizeSettings{length(x),true,true}(length(x))
+end
+
+function DI.BatchSizeSettings(::AutoEnzyme, x::StaticArray)
+    return BatchSizeSettings{length(x),true,true}(length(x))
+end
 
 end

--- a/DifferentiationInterface/src/first_order/jacobian.jl
+++ b/DifferentiationInterface/src/first_order/jacobian.jl
@@ -87,7 +87,13 @@ function prepare_jacobian(
 ) where {F,C}
     y = f(x, map(unwrap, contexts)...)
     perf = pushforward_performance(backend)
-    valB = pick_jacobian_batchsize(perf, backend; N=length(x), M=length(y))
+    # type-unstable
+    if perf isa PushforwardFast
+        valB = pick_batchsize(backend, x)
+    else
+        valB = pick_batchsize(backend, y)
+    end
+    # function barrier
     return _prepare_jacobian_aux(perf, valB, y, (f,), backend, x, contexts...)
 end
 
@@ -95,7 +101,13 @@ function prepare_jacobian(
     f!::F, y, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
     perf = pushforward_performance(backend)
-    valB = pick_jacobian_batchsize(perf, backend; N=length(x), M=length(y))
+    # type-unstable
+    if perf isa PushforwardFast
+        valB = pick_batchsize(backend, x)
+    else
+        valB = pick_batchsize(backend, y)
+    end
+    # function barrier
     return _prepare_jacobian_aux(perf, valB, y, (f!, y), backend, x, contexts...)
 end
 

--- a/DifferentiationInterface/src/first_order/jacobian.jl
+++ b/DifferentiationInterface/src/first_order/jacobian.jl
@@ -261,7 +261,8 @@ function _jacobian_aux(
     x,
     contexts::Vararg{Context,C},
 ) where {FY,B,aligned,C}
-    (; batched_seeds, pushforward_prep) = prep
+    (; batch_size_settings, batched_seeds, pushforward_prep) = prep
+    (; B_last) = batch_size_settings
     dy_batch = pushforward(
         f_or_f!y..., pushforward_prep, backend, x, only(batched_seeds), contexts...
     )
@@ -314,7 +315,7 @@ function _jacobian_aux(
     contexts::Vararg{Context,C},
 ) where {FY,B,aligned,C}
     (; batch_size_settings, batched_seeds, pullback_prep) = prep
-    (; N, A, B_last) = batch_size_settings
+    (; B_last) = batch_size_settings
     dx_batch = pullback(
         f_or_f!y..., pullback_prep, backend, x, only(batched_seeds), contexts...
     )

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -11,8 +11,12 @@ end
 check_available(fromprim::FromPrimitive) = check_available(fromprim.backend)
 inplace_support(fromprim::FromPrimitive) = inplace_support(fromprim.backend)
 
-function pick_batchsize(fromprim::FromPrimitive, dimension::Integer)
-    return pick_batchsize(fromprim.backend, dimension)
+function BatchSizeSettings(fromprim::FromPrimitive, x::AbstractArray)
+    return BatchSizeSettings(fromprim.backend, x)
+end
+
+function BatchSizeSettings(fromprim::FromPrimitive, N::Integer)
+    return BatchSizeSettings(fromprim.backend, N)
 end
 
 ## Forward

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -23,6 +23,10 @@ end
 
 ADTypes.mode(::AutoForwardFromPrimitive) = ADTypes.ForwardMode()
 
+function threshold_batchsize(fromprim::AutoForwardFromPrimitive, dimension::Integer)
+    return AutoForwardFromPrimitive(threshold_batchsize(fromprim.backend, dimension))
+end
+
 struct FromPrimitivePushforwardPrep{E<:PushforwardPrep} <: PushforwardPrep
     pushforward_prep::E
 end
@@ -104,6 +108,10 @@ struct AutoReverseFromPrimitive{B} <: FromPrimitive
 end
 
 ADTypes.mode(::AutoReverseFromPrimitive) = ADTypes.ReverseMode()
+
+function threshold_batchsize(fromprim::AutoReverseFromPrimitive, dimension::Integer)
+    return AutoReverseFromPrimitive(threshold_batchsize(fromprim.backend, dimension))
+end
 
 struct FromPrimitivePullbackPrep{E<:PullbackPrep} <: PullbackPrep
     pullback_prep::E

--- a/DifferentiationInterface/src/misc/zero_backends.jl
+++ b/DifferentiationInterface/src/misc/zero_backends.jl
@@ -4,7 +4,7 @@ end
 
 (rz::ReturnZero)(i) = zero(rz.template)
 
-_zero!(x::AbstractArray) = fill!(x, zero(eltype(x)))
+_zero!(x::AbstractArray{T}) where {T} = fill!(x, zero(T))
 
 ## Forward
 

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -61,47 +61,46 @@ function value_gradient_and_hessian! end
 ## Preparation
 
 struct HVPGradientHessianPrep{
-    B,singlebatch,TD<:NTuple{B},TR<:NTuple{B},E2<:HVPPrep,E1<:GradientPrep
+    BS<:BatchSizeSettings,
+    S<:AbstractVector{<:NTuple},
+    R<:AbstractVector{<:NTuple},
+    E2<:HVPPrep,
+    E1<:GradientPrep,
 } <: HessianPrep
-    batched_seeds::Vector{TD}
-    batched_results::Vector{TR}
+    batch_size_settings::BS
+    batched_seeds::S
+    batched_results::R
     hvp_prep::E2
     gradient_prep::E1
-    N::Int
 end
 
 function prepare_hessian(
     f::F, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
     # type-unstable
-    valB = pick_batchsize(outer(backend), x)
-    val_singlebatch = Val(unval(valB) >= length(x))
+    batch_size_settings = pick_batchsize(outer(backend), x)
     # function barrier
-    return _prepare_hessian_aux(valB, val_singlebatch, f, backend, x, contexts...)
+    return _prepare_hessian_aux(batch_size_settings, f, backend, x, contexts...)
 end
 
 function _prepare_hessian_aux(
-    ::Val{B},
-    ::Val{singlebatch},
+    batch_size_settings::BatchSizeSettings{B},
     f::F,
     backend::AbstractADType,
     x,
     contexts::Vararg{Context,C},
-) where {B,singlebatch,F,C}
+) where {B,F,C}
+    (; N, A) = batch_size_settings
     N = length(x)
     seeds = [basis(backend, x, ind) for ind in eachindex(x)]
     batched_seeds = [
-        ntuple(b -> seeds[1 + ((a - 1) * B + (b - 1)) % N], Val(B)) for
-        a in 1:div(N, B, RoundUp)
+        ntuple(b -> seeds[1 + ((a - 1) * B + (b - 1)) % N], Val(B)) for a in 1:A
     ]
     batched_results = [ntuple(b -> similar(x), Val(B)) for _ in batched_seeds]
     hvp_prep = prepare_hvp(f, backend, x, batched_seeds[1], contexts...)
     gradient_prep = prepare_gradient(f, inner(backend), x, contexts...)
-    TD = eltype(batched_seeds)
-    TR = eltype(batched_results)
-    E2, E1 = typeof(hvp_prep), typeof(gradient_prep)
-    return HVPGradientHessianPrep{B,singlebatch,TD,TR,E2,E1}(
-        batched_seeds, batched_results, hvp_prep, gradient_prep, N
+    return HVPGradientHessianPrep(
+        batch_size_settings, batched_seeds, batched_results, hvp_prep, gradient_prep
     )
 end
 
@@ -109,7 +108,7 @@ end
 
 function hessian(
     f::F,
-    prep::HVPGradientHessianPrep{B,true},
+    prep::HVPGradientHessianPrep{<:BatchSizeSettings{B,true}},
     backend::AbstractADType,
     x,
     contexts::Vararg{Context,C},
@@ -122,12 +121,13 @@ end
 
 function hessian(
     f::F,
-    prep::HVPGradientHessianPrep{B},
+    prep::HVPGradientHessianPrep{<:BatchSizeSettings{B,false,aligned}},
     backend::AbstractADType,
     x,
     contexts::Vararg{Context,C},
-) where {F,B,C}
-    (; batched_seeds, hvp_prep, N) = prep
+) where {F,B,aligned,C}
+    (; batch_size_settings, batched_seeds, hvp_prep) = prep
+    (; A, B_last) = batch_size_settings
 
     hvp_prep_same = prepare_hvp_same_point(
         f, hvp_prep, backend, x, batched_seeds[1], contexts...
@@ -136,10 +136,11 @@ function hessian(
     hess = mapreduce(hcat, eachindex(batched_seeds)) do a
         dg_batch = hvp(f, hvp_prep_same, backend, x, batched_seeds[a], contexts...)
         block = stack_vec_col(dg_batch)
-        if N % B != 0 && a == lastindex(batched_seeds)
-            block = block[:, 1:(N - (a - 1) * B)]
+        if !aligned && a == A
+            return block[:, 1:B_last]
+        else
+            return block
         end
-        block
     end
     return hess
 end
@@ -147,12 +148,13 @@ end
 function hessian!(
     f::F,
     hess,
-    prep::HVPGradientHessianPrep{B},
+    prep::HVPGradientHessianPrep{<:BatchSizeSettings{B}},
     backend::AbstractADType,
     x,
     contexts::Vararg{Context,C},
 ) where {F,B,C}
-    (; batched_seeds, batched_results, hvp_prep, N) = prep
+    (; batch_size_settings, batched_seeds, batched_results, hvp_prep) = prep
+    (; N) = batch_size_settings
 
     hvp_prep_same = prepare_hvp_same_point(
         f, hvp_prep, backend, x, batched_seeds[1], contexts...

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -91,7 +91,6 @@ function _prepare_hessian_aux(
     contexts::Vararg{Context,C},
 ) where {B,F,C}
     (; N, A) = batch_size_settings
-    N = length(x)
     seeds = [basis(backend, x, ind) for ind in eachindex(x)]
     batched_seeds = [
         ntuple(b -> seeds[1 + ((a - 1) * B + (b - 1)) % N], Val(B)) for a in 1:A

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -72,7 +72,9 @@ end
 function prepare_hessian(
     f::F, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    valB = pick_hessian_batchsize(backend, length(x))
+    # type-unstable
+    valB = pick_batchsize(outer(backend), x)
+    # function barrier
     return _prepare_hessian_aux(valB, f, backend, x, contexts...)
 end
 

--- a/DifferentiationInterface/src/second_order/hessian.jl
+++ b/DifferentiationInterface/src/second_order/hessian.jl
@@ -113,7 +113,7 @@ function hessian(
     x,
     contexts::Vararg{Context,C},
 ) where {F,B,C}
-    (; batched_seeds, hvp_prep, N) = prep
+    (; batched_seeds, hvp_prep) = prep
     dg_batch = hvp(f, hvp_prep, backend, x, only(batched_seeds), contexts...)
     block = stack_vec_col(dg_batch)
     return block

--- a/DifferentiationInterface/src/utils/batchsize.jl
+++ b/DifferentiationInterface/src/utils/batchsize.jl
@@ -1,11 +1,45 @@
-unval(::Val{B}) where {B} = B
+"""
+    BatchSizeSettings{B,singlebatch,aligned}
 
-has_fixed_batchsize(::AbstractADType) = true
-fixed_batchsize(::AbstractADType) = Val(1)
+Configuration for the batch size deduced from a backend and a sample array of length `N`.
 
-function adaptive_batchsize end
+# Type parameters
 
-function pick_batchsize(backend::AbstractADType, a)
+- `B::Int`: batch size
+- `singlebatch::Bool`: whether `B > N`
+- `aligned::Bool`: whether `N % B == 0`
+
+# Fields
+
+- `N::Int`: array length
+- `A::Int`: number of batches `A = div(N, B, RoundUp)`
+- `B_last::Int`: size of the last batch (if `aligned` is `false`)
+"""
+struct BatchSizeSettings{B,singlebatch,aligned}
+    N::Int
+    A::Int
+    B_last::Int
+end
+
+function BatchSizeSettings{B,singlebatch,aligned}(N::Integer) where {B,singlebatch,aligned}
+    A = div(N, B, RoundUp)
+    B_last = -1
+    return BatchSizeSettings{B,singlebatch,aligned}(N, A, B_last)
+end
+
+function BatchSizeSettings(::AbstractADType, N::Integer)
+    B = 1
+    singlebatch = false
+    aligned = true
+    return BatchSizeSettings{B,singlebatch,aligned}(N)
+end
+
+function BatchSizeSettings(backend::AbstractADType, x::AbstractArray)
+    N = length(x)
+    return BatchSizeSettings(backend, N)
+end
+
+function pick_batchsize(backend::AbstractADType, x_or_N::Union{AbstractArray,Integer})
     if backend isa SecondOrder
         throw(
             ArgumentError(
@@ -18,10 +52,8 @@ function pick_batchsize(backend::AbstractADType, a)
                 "You should select the batch size for the dense backend of $backend"
             ),
         )
-    elseif has_fixed_batchsize(backend)
-        return fixed_batchsize(backend)
     else
-        return adaptive_batchsize(backend, a)
+        return BatchSizeSettings(backend, x_or_N)
     end
 end
 

--- a/DifferentiationInterface/src/utils/batchsize.jl
+++ b/DifferentiationInterface/src/utils/batchsize.jl
@@ -23,7 +23,7 @@ end
 
 function BatchSizeSettings{B,singlebatch,aligned}(N::Integer) where {B,singlebatch,aligned}
     A = div(N, B, RoundUp)
-    B_last = -1
+    B_last = N % B
     return BatchSizeSettings{B,singlebatch,aligned}(N, A, B_last)
 end
 

--- a/DifferentiationInterface/src/utils/batchsize.jl
+++ b/DifferentiationInterface/src/utils/batchsize.jl
@@ -1,3 +1,5 @@
+unval(::Val{B}) where {B} = B
+
 has_fixed_batchsize(::AbstractADType) = true
 fixed_batchsize(::AbstractADType) = Val(1)
 

--- a/DifferentiationInterface/src/utils/traits.jl
+++ b/DifferentiationInterface/src/utils/traits.jl
@@ -63,6 +63,10 @@ pushforward_performance(::ForwardOrReverseMode) = PushforwardFast()
 pushforward_performance(::ReverseMode) = PushforwardSlow()
 pushforward_performance(::SymbolicMode) = PushforwardFast()
 
+function pushforward_performance(backend::Union{AutoSparse,SecondOrder})
+    throw(ArgumentError("Pushforward performance not defined for $backend`."))
+end
+
 ## Pullback
 
 abstract type PullbackPerformance end
@@ -91,6 +95,10 @@ pullback_performance(::ForwardMode) = PullbackSlow()
 pullback_performance(::ForwardOrReverseMode) = PullbackFast()
 pullback_performance(::ReverseMode) = PullbackFast()
 pullback_performance(::SymbolicMode) = PullbackFast()
+
+function pullback_performance(backend::Union{AutoSparse,SecondOrder})
+    throw(ArgumentError("Pullback performance not defined for $backend`."))
+end
 
 ## HVP
 
@@ -136,6 +144,10 @@ function hvp_mode(ba::SecondOrder)
     else
         return ForwardOverForward()
     end
+end
+
+function hvp_mode(backend::AutoSparse)
+    throw(ArgumentError("HVP mode not defined for $backend`."))
 end
 
 ## Conversions

--- a/DifferentiationInterface/src/utils/traits.jl
+++ b/DifferentiationInterface/src/utils/traits.jl
@@ -24,7 +24,8 @@ Return [`InPlaceSupported`](@ref) or [`InPlaceNotSupported`](@ref) in a statical
 inplace_support(::AbstractADType) = InPlaceSupported()
 
 function inplace_support(backend::SecondOrder)
-    if Bool(inplace_support(inner(backend))) && Bool(inplace_support(outer(backend)))
+    if inplace_support(inner(backend)) isa InPlaceSupported &&
+        inplace_support(outer(backend)) isa InPlaceSupported
         return InPlaceSupported()
     else
         return InPlaceNotSupported()
@@ -61,7 +62,6 @@ pushforward_performance(::ForwardMode) = PushforwardFast()
 pushforward_performance(::ForwardOrReverseMode) = PushforwardFast()
 pushforward_performance(::ReverseMode) = PushforwardSlow()
 pushforward_performance(::SymbolicMode) = PushforwardFast()
-pushforward_performance(backend::AutoSparse) = pushforward_performance(dense_ad(backend))
 
 ## Pullback
 
@@ -91,7 +91,6 @@ pullback_performance(::ForwardMode) = PullbackSlow()
 pullback_performance(::ForwardOrReverseMode) = PullbackFast()
 pullback_performance(::ReverseMode) = PullbackFast()
 pullback_performance(::SymbolicMode) = PullbackFast()
-pullback_performance(backend::AutoSparse) = pullback_performance(dense_ad(backend))
 
 ## HVP
 
@@ -138,8 +137,6 @@ function hvp_mode(ba::SecondOrder)
         return ForwardOverForward()
     end
 end
-
-hvp_mode(backend::AutoSparse{<:SecondOrder}) = hvp_mode(dense_ad(backend))
 
 ## Conversions
 

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -5,6 +5,7 @@ using ADTypes: ADTypes
 using DifferentiationInterface, DifferentiationInterfaceTest
 import DifferentiationInterfaceTest as DIT
 using Enzyme: Enzyme
+using StaticArrays
 using Test
 
 LOGGING = get(ENV, "CI", "false") == "false"
@@ -91,3 +92,19 @@ test_differentiation(
 test_differentiation(
     MyAutoSparse.(AutoEnzyme()), sparse_scenarios(); sparsity=true, logging=LOGGING
 );
+
+## Static
+
+test_differentiation(
+    [
+        # AutoEnzyme(; mode=Enzyme.Forward),  #
+        AutoEnzyme(; mode=Enzyme.Reverse),
+    ],
+    filter(
+        s -> DIT.operator_place(s) == :out,
+        # normal falls back on Enzyme jacobian, which errors on setindex!
+        static_scenarios(; include_normal=false, include_constantified=true),
+    );
+    excluded=SECOND_ORDER,
+    logging=true,
+)

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -92,19 +92,3 @@ test_differentiation(
 test_differentiation(
     MyAutoSparse.(AutoEnzyme()), sparse_scenarios(); sparsity=true, logging=LOGGING
 );
-
-## Static
-
-test_differentiation(
-    [
-        # AutoEnzyme(; mode=Enzyme.Forward),  #
-        AutoEnzyme(; mode=Enzyme.Reverse),
-    ],
-    filter(
-        s -> DIT.operator_place(s) == :out,
-        # normal falls back on Enzyme jacobian, which errors on setindex!
-        static_scenarios(; include_normal=false, include_constantified=true),
-    );
-    excluded=SECOND_ORDER,
-    logging=true,
-)

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -45,10 +45,10 @@ test_differentiation(
 
 ## Sparse
 
-test_differentiation(MyAutoSparse.(backends), default_scenarios(); logging=LOGGING);
+test_differentiation(MyAutoSparse.(backends[1:2]), default_scenarios(); logging=LOGGING);
 
 test_differentiation(
-    MyAutoSparse.(backends),
+    MyAutoSparse.(backends[1:2]),
     sparse_scenarios(; include_constantified=true);
     sparsity=true,
     logging=LOGGING,

--- a/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
+++ b/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
@@ -7,18 +7,18 @@ using Test
 LOGGING = get(ENV, "CI", "false") == "false"
 
 backends = [ #
-    AutoForwardFromPrimitive(AutoForwardDiff()),
-    AutoReverseFromPrimitive(AutoForwardDiff()),
+    AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
+    AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=4)),
 ]
 
 second_order_backends = [ #
     SecondOrder(
-        AutoForwardFromPrimitive(AutoForwardDiff()),
-        AutoReverseFromPrimitive(AutoForwardDiff()),
+        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
+        AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=4)),
     ),
     SecondOrder(
-        AutoReverseFromPrimitive(AutoForwardDiff()),
-        AutoForwardFromPrimitive(AutoForwardDiff()),
+        AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
+        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=4)),
     ),
 ]
 

--- a/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
+++ b/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
@@ -7,18 +7,18 @@ using Test
 LOGGING = get(ENV, "CI", "false") == "false"
 
 backends = [ #
-    AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=5)),
-    AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=4)),
+    AutoForwardFromPrimitive(AutoForwardDiff()),
+    AutoReverseFromPrimitive(AutoForwardDiff()),
 ]
 
 second_order_backends = [ #
     SecondOrder(
-        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=4)),
-        AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
+        AutoForwardFromPrimitive(AutoForwardDiff()),
+        AutoReverseFromPrimitive(AutoForwardDiff()),
     ),
     SecondOrder(
-        AutoReverseFromPrimitive(AutoForwardDiff(; chunksize=5)),
-        AutoForwardFromPrimitive(AutoForwardDiff(; chunksize=4)),
+        AutoReverseFromPrimitive(AutoForwardDiff()),
+        AutoForwardFromPrimitive(AutoForwardDiff()),
     ),
 ]
 

--- a/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
+++ b/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
@@ -65,13 +65,17 @@ test_differentiation(
 
 ## Misc
 
-jac_for_prep = prepare_jacobian(copy, MyAutoSparse(backends[1]), rand(10));
-jac_rev_prep = prepare_jacobian(copy, MyAutoSparse(backends[2]), rand(10));
-hess_prep = prepare_hessian(x -> sum(abs2, x), MyAutoSparse(backends[1]), rand(10));
+@testset "SparseMatrixColorings access" begin
+    jac_for_prep = prepare_jacobian(copy, MyAutoSparse(adaptive_backends[1]), rand(10))
+    jac_rev_prep = prepare_jacobian(copy, MyAutoSparse(adaptive_backends[2]), rand(10))
+    hess_prep = prepare_hessian(
+        x -> sum(abs2, x), MyAutoSparse(adaptive_backends[1]), rand(10)
+    )
 
-@test all(==(1), column_colors(jac_for_prep))
-@test all(==(1), row_colors(jac_rev_prep))
-@test all(==(1), column_colors(hess_prep))
-@test only(column_groups(jac_for_prep)) == 1:10
-@test only(row_groups(jac_rev_prep)) == 1:10
-@test only(column_groups(hess_prep)) == 1:10
+    @test all(==(1), column_colors(jac_for_prep))
+    @test all(==(1), row_colors(jac_rev_prep))
+    @test all(==(1), column_colors(hess_prep))
+    @test only(column_groups(jac_for_prep)) == 1:10
+    @test only(row_groups(jac_rev_prep)) == 1:10
+    @test only(column_groups(hess_prep)) == 1:10
+end

--- a/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
+++ b/DifferentiationInterface/test/Misc/FromPrimitive/test.jl
@@ -22,6 +22,19 @@ second_order_backends = [ #
     ),
 ]
 
+adaptive_backends = [ #
+    AutoForwardFromPrimitive(AutoForwardDiff()),
+    AutoReverseFromPrimitive(AutoForwardDiff()),
+    SecondOrder(
+        AutoForwardFromPrimitive(AutoForwardDiff()),
+        AutoReverseFromPrimitive(AutoForwardDiff()),
+    ),
+    SecondOrder(
+        AutoReverseFromPrimitive(AutoForwardDiff()),
+        AutoForwardFromPrimitive(AutoForwardDiff()),
+    ),
+]
+
 for backend in vcat(backends, second_order_backends)
     @test check_available(backend)
     @test check_inplace(backend)
@@ -38,13 +51,13 @@ test_differentiation(
 ## Sparse scenarios
 
 test_differentiation(
-    MyAutoSparse.(vcat(backends, second_order_backends)),
+    MyAutoSparse.(adaptive_backends),
     default_scenarios(; include_constantified=true);
     logging=LOGGING,
 );
 
 test_differentiation(
-    MyAutoSparse.(vcat(backends, second_order_backends)),
+    MyAutoSparse.(adaptive_backends),
     sparse_scenarios(; include_constantified=true);
     sparsity=true,
     logging=LOGGING,

--- a/DifferentiationInterface/test/Misc/Internals/backends.jl
+++ b/DifferentiationInterface/test/Misc/Internals/backends.jl
@@ -1,19 +1,21 @@
 using ADTypes
 using DifferentiationInterface
+using DifferentiationInterface:
+    pick_batchsize, inner, outer, inplace_support, threshold_batchsize
 import DifferentiationInterface as DI
 using ForwardDiff: ForwardDiff
 using StaticArrays
 using Test
 
+BSS = BatchSizeSettings
+
 @testset "SecondOrder" begin
     backend = SecondOrder(AutoForwardDiff(), AutoZygote())
     @test ADTypes.mode(backend) isa ADTypes.ForwardMode
-    @test DI.outer(backend) isa AutoForwardDiff
-    @test DI.inner(backend) isa AutoZygote
-    @test Bool(DI.inplace_support(backend)) == (
-        Bool(DI.inplace_support(DI.inner(backend))) &&
-        Bool(DI.inplace_support(DI.outer(backend)))
-    )
+    @test outer(backend) isa AutoForwardDiff
+    @test inner(backend) isa AutoZygote
+    @test Bool(inplace_support(backend)) ==
+        (Bool(inplace_support(inner(backend))) && Bool(inplace_support(outer(backend))))
 end
 
 @testset "Sparse" begin
@@ -21,34 +23,35 @@ end
         sparse_backend = AutoSparse(backend)
         @test ADTypes.mode(sparse_backend) == ADTypes.mode(backend)
         @test check_available(sparse_backend) == check_available(backend)
-        @test DI.inplace_support(sparse_backend) == DI.inplace_support(backend)
+        @test inplace_support(sparse_backend) == inplace_support(backend)
     end
 end
 
 @testset "Batch size" begin
     @testset "Default" begin
-        @test (@inferred DI.pick_batchsize(AutoZygote(), zeros(2))) == Val(1)
-        @test (@inferred DI.pick_batchsize(AutoZygote(), zeros(100))) == Val(1)
+        @test (@inferred pick_batchsize(AutoZygote(), zeros(2))) isa BSS{1,false,true}
+        @test (@inferred pick_batchsize(AutoZygote(), zeros(100))) isa BSS{1,false,true}
     end
 
     @testset "ForwardDiff" begin
-        @test (DI.pick_batchsize(AutoForwardDiff(), zeros(2))) == Val(2)
-        @test (DI.pick_batchsize(AutoForwardDiff(), zeros(6))) == Val(6)
-        @test (DI.pick_batchsize(AutoForwardDiff(), zeros(100))) == Val(12)
-        @test (@inferred DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(2)))) == Val(2)
-        @test (@inferred DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(6)))) == Val(6)
-        @test (@inferred DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(100)))) ==
-            Val(100)
-        @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(2))) ==
-            Val(4)
-        @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(6))) ==
-            Val(4)
-        @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(100))) ==
-            Val(4)
-        @test DI.threshold_batchsize(AutoForwardDiff(), 2) isa AutoForwardDiff{nothing}
-        @test DI.threshold_batchsize(AutoForwardDiff(; chunksize=4), 2) isa
-            AutoForwardDiff{2}
-        @test DI.threshold_batchsize(AutoForwardDiff(; chunksize=4), 6) isa
-            AutoForwardDiff{4}
+        @test (pick_batchsize(AutoForwardDiff(), zeros(2))) isa BSS{2,true,true}
+        @test (pick_batchsize(AutoForwardDiff(), zeros(6))) isa BSS{6,true,true}
+        @test (pick_batchsize(AutoForwardDiff(), zeros(12))) isa BSS{12,true,true}
+        @test (pick_batchsize(AutoForwardDiff(), zeros(24))) isa BSS{12,false,true}
+        @test (pick_batchsize(AutoForwardDiff(), zeros(100))) isa BSS{12,false,false}
+        @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(2)))) isa
+            BSS{2,true,true}
+        @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(6)))) isa
+            BSS{6,true,true}
+        @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(100)))) isa
+            BSS{100,true,true}
+        @test_throws ArgumentError pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(2))
+        @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(6))) isa
+            BSS{4}
+        @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(100))) isa
+            BSS{4}
+        @test threshold_batchsize(AutoForwardDiff(), 2) isa AutoForwardDiff{nothing}
+        @test threshold_batchsize(AutoForwardDiff(; chunksize=4), 2) isa AutoForwardDiff{2}
+        @test threshold_batchsize(AutoForwardDiff(; chunksize=4), 6) isa AutoForwardDiff{4}
     end
 end

--- a/DifferentiationInterface/test/Misc/Internals/backends.jl
+++ b/DifferentiationInterface/test/Misc/Internals/backends.jl
@@ -1,57 +1,32 @@
 using ADTypes
+using ADTypes: mode
 using DifferentiationInterface
 using DifferentiationInterface:
-    BatchSizeSettings, pick_batchsize, inner, outer, inplace_support, threshold_batchsize
+    inner, outer, inplace_support, pushforward_performance, pullback_performance, hvp_mode
 import DifferentiationInterface as DI
 using ForwardDiff: ForwardDiff
-using StaticArrays
 using Test
-
-BSS = BatchSizeSettings
 
 @testset "SecondOrder" begin
     backend = SecondOrder(AutoForwardDiff(), AutoZygote())
     @test ADTypes.mode(backend) isa ADTypes.ForwardMode
     @test outer(backend) isa AutoForwardDiff
     @test inner(backend) isa AutoZygote
+    @test mode(backend) isa ADTypes.ForwardMode
     @test Bool(inplace_support(backend)) ==
         (Bool(inplace_support(inner(backend))) && Bool(inplace_support(outer(backend))))
+    @test_throws ArgumentError pushforward_performance(backend)
+    @test_throws ArgumentError pullback_performance(backend)
 end
 
 @testset "Sparse" begin
-    for backend in [AutoForwardDiff(), AutoZygote()]
-        sparse_backend = AutoSparse(backend)
-        @test ADTypes.mode(sparse_backend) == ADTypes.mode(backend)
-        @test check_available(sparse_backend) == check_available(backend)
-        @test inplace_support(sparse_backend) == inplace_support(backend)
-    end
-end
-
-@testset "Batch size" begin
-    @testset "Default" begin
-        @test (@inferred pick_batchsize(AutoZygote(), zeros(2))) isa BSS{1,false,true}
-        @test (@inferred pick_batchsize(AutoZygote(), zeros(100))) isa BSS{1,false,true}
-    end
-
-    @testset "ForwardDiff" begin
-        @test (pick_batchsize(AutoForwardDiff(), zeros(2))) isa BSS{2,true,true}
-        @test (pick_batchsize(AutoForwardDiff(), zeros(6))) isa BSS{6,true,true}
-        @test (pick_batchsize(AutoForwardDiff(), zeros(12))) isa BSS{12,true,true}
-        @test (pick_batchsize(AutoForwardDiff(), zeros(24))) isa BSS{12,false,true}
-        @test (pick_batchsize(AutoForwardDiff(), zeros(100))) isa BSS{12,false,false}
-        @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(2)))) isa
-            BSS{2,true,true}
-        @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(6)))) isa
-            BSS{6,true,true}
-        @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(100)))) isa
-            BSS{100,true,true}
-        @test_throws ArgumentError pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(2))
-        @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(6))) isa
-            BSS{4}
-        @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(100))) isa
-            BSS{4}
-        @test threshold_batchsize(AutoForwardDiff(), 2) isa AutoForwardDiff{nothing}
-        @test threshold_batchsize(AutoForwardDiff(; chunksize=4), 2) isa AutoForwardDiff{2}
-        @test threshold_batchsize(AutoForwardDiff(; chunksize=4), 6) isa AutoForwardDiff{4}
+    for dense_backend in [AutoForwardDiff(), AutoZygote()]
+        backend = AutoSparse(dense_backend)
+        @test ADTypes.mode(backend) == ADTypes.mode(dense_backend)
+        @test check_available(backend) == check_available(dense_backend)
+        @test inplace_support(backend) == inplace_support(dense_backend)
+        @test_throws ArgumentError pushforward_performance(backend)
+        @test_throws ArgumentError pullback_performance(backend)
+        @test_throws ArgumentError hvp_mode(backend)
     end
 end

--- a/DifferentiationInterface/test/Misc/Internals/backends.jl
+++ b/DifferentiationInterface/test/Misc/Internals/backends.jl
@@ -1,7 +1,7 @@
 using ADTypes
 using DifferentiationInterface
 using DifferentiationInterface:
-    pick_batchsize, inner, outer, inplace_support, threshold_batchsize
+    BatchSizeSettings, pick_batchsize, inner, outer, inplace_support, threshold_batchsize
 import DifferentiationInterface as DI
 using ForwardDiff: ForwardDiff
 using StaticArrays

--- a/DifferentiationInterface/test/Misc/Internals/backends.jl
+++ b/DifferentiationInterface/test/Misc/Internals/backends.jl
@@ -26,18 +26,29 @@ end
 end
 
 @testset "Batch size" begin
-    @test (@inferred DI.pick_batchsize(AutoZygote(), zeros(2))) == Val(1)
-    @test (DI.pick_batchsize(AutoForwardDiff(), zeros(2))) == Val(2)
-    @test (DI.pick_batchsize(AutoForwardDiff(), zeros(6))) == Val(6)
-    @test (DI.pick_batchsize(AutoForwardDiff(), zeros(100))) == Val(12)
-    @test (DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(2)))) == Val(2)
-    @test (DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(6)))) == Val(6)
-    @test (DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(100)))) == Val(100)
-    @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(2))) == Val(4)
-    @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(6))) == Val(4)
-    @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(100))) ==
-        Val(4)
-    @test DI.threshold_batchsize(AutoForwardDiff(), 2) isa AutoForwardDiff{nothing}
-    @test DI.threshold_batchsize(AutoForwardDiff(; chunksize=4), 2) isa AutoForwardDiff{2}
-    @test DI.threshold_batchsize(AutoForwardDiff(; chunksize=4), 6) isa AutoForwardDiff{4}
+    @testset "Default" begin
+        @test (@inferred DI.pick_batchsize(AutoZygote(), zeros(2))) == Val(1)
+        @test (@inferred DI.pick_batchsize(AutoZygote(), zeros(100))) == Val(1)
+    end
+
+    @testset "ForwardDiff" begin
+        @test (DI.pick_batchsize(AutoForwardDiff(), zeros(2))) == Val(2)
+        @test (DI.pick_batchsize(AutoForwardDiff(), zeros(6))) == Val(6)
+        @test (DI.pick_batchsize(AutoForwardDiff(), zeros(100))) == Val(12)
+        @test (@inferred DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(2)))) == Val(2)
+        @test (@inferred DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(6)))) == Val(6)
+        @test (@inferred DI.pick_batchsize(AutoForwardDiff(), @SVector(zeros(100)))) ==
+            Val(100)
+        @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(2))) ==
+            Val(4)
+        @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(6))) ==
+            Val(4)
+        @test (@inferred DI.pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(100))) ==
+            Val(4)
+        @test DI.threshold_batchsize(AutoForwardDiff(), 2) isa AutoForwardDiff{nothing}
+        @test DI.threshold_batchsize(AutoForwardDiff(; chunksize=4), 2) isa
+            AutoForwardDiff{2}
+        @test DI.threshold_batchsize(AutoForwardDiff(; chunksize=4), 6) isa
+            AutoForwardDiff{4}
+    end
 end

--- a/DifferentiationInterface/test/Misc/Internals/batchsize.jl
+++ b/DifferentiationInterface/test/Misc/Internals/batchsize.jl
@@ -1,0 +1,74 @@
+using ADTypes
+using DifferentiationInterface
+using DifferentiationInterface:
+    BatchSizeSettings, pick_batchsize, reasonable_batchsize, threshold_batchsize
+import DifferentiationInterface as DI
+using ForwardDiff: ForwardDiff
+using StaticArrays
+using Test
+
+BSS = BatchSizeSettings
+
+@testset "Default" begin
+    @test (@inferred pick_batchsize(AutoZygote(), zeros(2))) isa BSS{1,false,true}
+    @test (@inferred pick_batchsize(AutoZygote(), zeros(100))) isa BSS{1,false,true}
+end
+
+@testset "ForwardDiff (adaptive)" begin
+    @test (pick_batchsize(AutoForwardDiff(), zeros(2))) isa BSS{2,true,true}
+    @test (pick_batchsize(AutoForwardDiff(), zeros(6))) isa BSS{6,true,true}
+    @test (pick_batchsize(AutoForwardDiff(), zeros(12))) isa BSS{12,true,true}
+    @test (pick_batchsize(AutoForwardDiff(), zeros(24))) isa BSS{12,false,true}
+    @test (pick_batchsize(AutoForwardDiff(), zeros(100))) isa BSS{12,false,false}
+    @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(2)))) isa
+        BSS{2,true,true}
+    @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(6)))) isa
+        BSS{6,true,true}
+    @test (@inferred pick_batchsize(AutoForwardDiff(), @SVector(zeros(100)))) isa
+        BSS{100,true,true}
+end
+
+@testset "ForwardDiff (fixed)" begin
+    @test_throws ArgumentError pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(2))
+    @test_throws ArgumentError pick_batchsize(
+        AutoForwardDiff(; chunksize=4), @SVector(zeros(2))
+    )
+    @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(6))) isa BSS{4}
+    @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(100))) isa BSS{4}
+    BSS{4,true,true}
+    @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), @SVector(zeros(6)))) isa
+        BSS{4,true,true}
+    @test (@inferred pick_batchsize(
+        AutoForwardDiff(; chunksize=4), @SVector(zeros(100))
+    )) isa BSS{4,true,true}
+end
+
+@testset "Thresholding" begin
+    @test threshold_batchsize(AutoForwardDiff(), 2) isa AutoForwardDiff{nothing}
+    @test threshold_batchsize(AutoForwardDiff(; chunksize=4), 2) isa AutoForwardDiff{2}
+    @test threshold_batchsize(AutoForwardDiff(; chunksize=4), 6) isa AutoForwardDiff{4}
+    @test threshold_batchsize(AutoSparse(AutoForwardDiff(; chunksize=4)), 2) isa
+        AutoSparse{<:AutoForwardDiff{2}}
+    @test threshold_batchsize(
+        SecondOrder(AutoForwardDiff(; chunksize=4), AutoForwardDiff(; chunksize=3)), 6
+    ) isa SecondOrder{<:AutoForwardDiff{4},<:AutoForwardDiff{3}}
+    @test threshold_batchsize(
+        SecondOrder(AutoForwardDiff(; chunksize=4), AutoForwardDiff(; chunksize=3)), 2
+    ) isa SecondOrder{<:AutoForwardDiff{2},<:AutoForwardDiff{2}}
+    @test threshold_batchsize(
+        SecondOrder(AutoForwardDiff(; chunksize=1), AutoForwardDiff(; chunksize=3)), 2
+    ) isa SecondOrder{<:AutoForwardDiff{1},<:AutoForwardDiff{2}}
+    @test threshold_batchsize(
+        SecondOrder(AutoForwardDiff(; chunksize=4), AutoForwardDiff(; chunksize=1)), 2
+    ) isa SecondOrder{<:AutoForwardDiff{2},<:AutoForwardDiff{1}}
+end
+
+@testset "Reasonable" begin
+    for Bmax in 1:5
+        @test all(<=(Bmax), reasonable_batchsize.(1:10, Bmax))
+        @test issorted(div.(1:10, reasonable_batchsize.(1:10, Bmax), RoundUp))
+        if Bmax > 2
+            @test reasonable_batchsize(Bmax + 1, Bmax) < Bmax
+        end
+    end
+end

--- a/DifferentiationInterface/test/Misc/Internals/batchsize.jl
+++ b/DifferentiationInterface/test/Misc/Internals/batchsize.jl
@@ -37,14 +37,16 @@ end
     @test_throws ArgumentError pick_batchsize(
         AutoForwardDiff(; chunksize=4), @SVector(zeros(2))
     )
-    @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(6))) isa BSS{4}
-    @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(100))) isa BSS{4}
+    @test pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(6)) isa BSS{4}
+    @test pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(100)) isa BSS{4}
     BSS{4,true,true}
+    @test pick_batchsize(AutoForwardDiff(; chunksize=4), zeros(99)) isa BSS{4}
+    BSS{4,true,false}
     @test (@inferred pick_batchsize(AutoForwardDiff(; chunksize=4), @SVector(zeros(6)))) isa
-        BSS{4,true,true}
+        BSS{4,false,false}
     @test (@inferred pick_batchsize(
         AutoForwardDiff(; chunksize=4), @SVector(zeros(100))
-    )) isa BSS{4,true,true}
+    )) isa BSS{4,false,true}
 end
 
 @testset "Thresholding" begin

--- a/DifferentiationInterface/test/Misc/Internals/batchsize.jl
+++ b/DifferentiationInterface/test/Misc/Internals/batchsize.jl
@@ -12,6 +12,10 @@ BSS = BatchSizeSettings
 @testset "Default" begin
     @test (@inferred pick_batchsize(AutoZygote(), zeros(2))) isa BSS{1,false,true}
     @test (@inferred pick_batchsize(AutoZygote(), zeros(100))) isa BSS{1,false,true}
+    @test_throws ArgumentError pick_batchsize(AutoSparse(AutoZygote()), zeros(2))
+    @test_throws ArgumentError pick_batchsize(
+        SecondOrder(AutoZygote(), AutoZygote()), zeros(2)
+    )
 end
 
 @testset "ForwardDiff (adaptive)" begin

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -118,8 +118,13 @@ end
 adapt_batchsize(backend::AbstractADType, ::Scenario) = backend
 
 function adapt_batchsize(backend::AbstractADType, scen::Scenario)
-    if ADTypes.mode(backend) isa Union{ADTypes.ForwardMode,ADTypes.ForwardOrReverseMode} &&
-        operator(scen) in (:jacobian, :hessian)
+    if operator(scen) == :jacobian
+        if ADTypes.mode(backend) isa Union{ADTypes.ForwardMode,ADTypes.ForwardOrReverseMode}
+            return DI.threshold_batchsize(backend, length(scen.x))
+        else
+            return DI.threshold_batchsize(backend, length(scen.y))
+        end
+    elseif operator(scen) == :hessian
         return DI.threshold_batchsize(backend, length(scen.x))
     else
         return backend

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -117,8 +117,11 @@ end
 
 adapt_batchsize(backend::AbstractADType, ::Scenario) = backend
 
-function adapt_batchsize(
-    backend::Union{ADTypes.AutoForwardDiff,ADTypes.AutoPolyesterForwardDiff}, scen::Scenario
-)
-    return DI.threshold_batchsize(backend, length(scen.x))
+function adapt_batchsize(backend::AbstractADType, scen::Scenario)
+    if ADTypes.mode(backend) isa Union{ADTypes.ForwardMode,ADTypes.ForwardOrReverseMode} &&
+        operator(scen) in (:jacobian, :hessian)
+        return DI.threshold_batchsize(backend, length(scen.x))
+    else
+        return backend
+    end
 end

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -115,8 +115,6 @@ function Base.show(
     return nothing
 end
 
-adapt_batchsize(backend::AbstractADType, ::Scenario) = backend
-
 function adapt_batchsize(backend::AbstractADType, scen::Scenario)
     if operator(scen) == :jacobian
         if ADTypes.mode(backend) isa Union{ADTypes.ForwardMode,ADTypes.ForwardOrReverseMode}


### PR DESCRIPTION
**Versions**

- Bump DI to v0.6.13

**DI source**

- Define `BatchSizeSettings` to store every necessary information about batches:
  - batch size `B`
  - whether we need a single batch or several
  - whether the batch size is aligned with the input size (zero remainder)
- Revamp `jacobian` and `hessian` to use these `BatchSizeSettings`. Add a custom out-of-place `jacobian` and `hessian` for the single-batch case which does not use `mapreduce`
- Add reasonable batch size selector borrowed from ForwardDiff, to use in Enzyme so that `x = ones(17)` requires 2 batches of 9 instead of 2 batches of 16.
- Throw errors on traits and batch size selection for `AutoSparse` and `SecondOrder`

**DI extensions**

- ForwardDiff (and PolyesterForwardDiff): Implement `BatchSizeSettings`
- Enzyme: Implement `BatchSizeSettings`
- StaticArrays:
  - Implement custom row stacking (only column stacking was available so far)
  - Override `BatchSizeSettings` for `x::StaticArray` and `backend::Union{AutoForwardDiff{nothing},AutoEnzyme}` to take batch size = input length
- SparseMatrixColorings:
  - Revamp `jacobian` and `hessian` to use `BatchSizeSettings`
  - Perform batch size selection based on the number of groups, not the total number of dimensions!!!

**DI docs**

- Discuss batching in the advanced explanations

**DIT source**

- Improve scenario batch size thresholding