### PR TITLE
Shorter sparse AD tests

### DIFF
--- a/DifferentiationInterface/test/runtests.jl
+++ b/DifferentiationInterface/test/runtests.jl
@@ -28,7 +28,9 @@ GROUP = get(ENV, "JULIA_DI_TEST_GROUP", "All")
             isdir(joinpath(@__DIR__, category)) || continue
             @testset verbose = true for folder in readdir(joinpath(@__DIR__, category))
                 isdir(joinpath(@__DIR__, category, folder)) || continue
-                @testset "$file" for file in readdir(joinpath(@__DIR__, category, folder))
+                @testset verbose = true "$file" for file in readdir(
+                    joinpath(@__DIR__, category, folder)
+                )
                     endswith(file, ".jl") || continue
                     @info "Testing $category/$folder/$file"
                     include(joinpath(@__DIR__, category, folder, file))
@@ -39,7 +41,9 @@ GROUP = get(ENV, "JULIA_DI_TEST_GROUP", "All")
         category, folder = split(GROUP, '/')
         @testset verbose = true "$category" begin
             @testset verbose = true "$folder" begin
-                @testset "$file" for file in readdir(joinpath(@__DIR__, category, folder))
+                @testset verbose = true "$file" for file in readdir(
+                    joinpath(@__DIR__, category, folder)
+                )
                     endswith(file, ".jl") || continue
                     @info "Testing $category/$folder/$file"
                     include(joinpath(@__DIR__, category, folder, file))

--- a/DifferentiationInterfaceTest/test/runtests.jl
+++ b/DifferentiationInterfaceTest/test/runtests.jl
@@ -17,19 +17,19 @@ GROUP = get(ENV, "JULIA_DIT_TEST_GROUP", "All")
     end
 
     if GROUP == "Zero" || GROUP == "All"
-        @testset verbose = false "Zero" begin
+        @testset verbose = true "Zero" begin
             include("zero_backends.jl")
         end
     end
 
     if GROUP == "Standard" || GROUP == "All"
-        @testset verbose = false "Standard" begin
+        @testset verbose = true "Standard" begin
             include("standard.jl")
         end
     end
 
     if GROUP == "Weird" || GROUP == "All"
-        @testset verbose = false "Weird" begin
+        @testset verbose = true "Weird" begin
             include("weird.jl")
         end
     end


### PR DESCRIPTION
**DIT source**

- Reduce the number of sparse (banded) scenarios introduced in #578 so that CI finishes within 1h. The issue is probably `AutoReverseFromPrimitive(AutoForwardDiff())`, whose pullbacks are by definition inefficient.

**DI and DIT tests**

- Make file test sets verbose so we can know what took how long inside each