### PR TITLE
Cache support with ForwardDiff

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.15"
+version = "0.6.16"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/docs/src/explanation/advanced.md
+++ b/DifferentiationInterface/docs/src/explanation/advanced.md
@@ -19,7 +19,7 @@ Right now, there are two kinds of context: [`Constant`](@ref) and [`Cache`](@ref
     This feature is still experimental and will not be supported by all backends.
     At the moment:
     - `Constant` is supported by all backends except symbolic ones
-    - `Cache` is only supported by finite difference backends
+    - `Cache` is only supported by finite difference backends and [`AutoForwardDiff`](@ref), but it is not yet optimized
 
 Semantically, both of these calls compute the partial gradient of `f(x, c)` with respect to `x`, but they consider `c` differently:
 

--- a/DifferentiationInterface/docs/src/tutorials/advanced.md
+++ b/DifferentiationInterface/docs/src/tutorials/advanced.md
@@ -49,6 +49,8 @@ prep_other_constant = prepare_gradient(f_multiarg, backend, x, Constant(-1))
 gradient(f_multiarg, prep_other_constant, backend, x, Constant(10))
 ```
 
+For additional arguments which act as mutated buffers, the [`Cache`](@ref) wrapper is the appropriate choice instead of [`Constant`](@ref).
+
 ## Sparsity
 
 Sparse AD is very useful when Jacobian or Hessian matrices have a lot of zeros.

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -5,6 +5,8 @@ using Base: Fix1, Fix2
 import DifferentiationInterface as DI
 using DifferentiationInterface:
     BatchSizeSettings,
+    Cache,
+    Constant,
     Context,
     DerivativePrep,
     DifferentiateWith,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -83,3 +83,17 @@ function mypartials!(::Type{T}, ty::NTuple{B}, ydual) where {T,B}
     end
     return ty
 end
+
+_translate(::Type{T}, ::Val{B}, c::Constant) where {T,B} = unwrap(c)
+
+function _translate(::Type{T}, ::Val{B}, c::Cache) where {T,B}
+    c0 = unwrap(c)
+    return make_dual(T, c0, ntuple(_ -> similar(c0), Val(B)))  # TODO: optimize
+end
+
+function translate(::Type{T}, ::Val{B}, contexts::Vararg{Context,C}) where {T,B,C}
+    new_contexts = map(contexts) do c
+        _translate(T, Val(B), c)
+    end
+    return new_contexts
+end

--- a/DifferentiationInterface/src/utils/context.jl
+++ b/DifferentiationInterface/src/utils/context.jl
@@ -52,6 +52,7 @@ struct Constant{T} <: Context
 end
 
 constant_maker(c) = Constant(c)
+maker(::Constant) = constant_maker
 unwrap(c::Constant) = c.data
 
 Base.:(==)(c1::Constant, c2::Constant) = c1.data == c2.data
@@ -68,6 +69,7 @@ struct Cache{T} <: Context
 end
 
 cache_maker(c) = Cache(c)
+maker(::Cache) = cache_maker
 unwrap(c::Cache) = c.data
 
 Base.:(==)(c1::Cache, c2::Cache) = c1.data == c2.data
@@ -75,15 +77,7 @@ Base.:(==)(c1::Cache, c2::Cache) = c1.data == c2.data
 struct Rewrap{C,T}
     context_makers::T
     function Rewrap(contexts::Vararg{Context,C}) where {C}
-        context_makers = map(contexts) do c
-            if c isa Cache
-                cache_maker
-            elseif c isa Constant
-                constant_maker
-            else
-                nothing
-            end
-        end
+        context_makers = map(maker, contexts)
         return new{C,typeof(context_makers)}(context_makers)
     end
 end

--- a/DifferentiationInterface/src/utils/context.jl
+++ b/DifferentiationInterface/src/utils/context.jl
@@ -51,13 +51,10 @@ struct Constant{T} <: Context
     data::T
 end
 
+constant_maker(c) = Constant(c)
 unwrap(c::Constant) = c.data
 
-function Base.convert(::Type{Constant{T}}, x::Constant) where {T}
-    return Constant(convert(T, x.data))
-end
-
-Base.convert(::Type{Constant{T}}, x) where {T} = Constant(convert(T, x))
+Base.:(==)(c1::Constant, c2::Constant) = c1.data == c2.data
 
 """
     Cache
@@ -70,25 +67,33 @@ struct Cache{T} <: Context
     data::T
 end
 
+cache_maker(c) = Cache(c)
 unwrap(c::Cache) = c.data
 
-function Base.convert(::Type{Cache{T}}, x::Cache) where {T}
-    return Cache(convert(T, x.data))
-end
-
-Base.convert(::Type{Cache{T}}, x) where {T} = Cache(convert(T, x))
+Base.:(==)(c1::Cache, c2::Cache) = c1.data == c2.data
 
 struct Rewrap{C,T}
+    context_makers::T
     function Rewrap(contexts::Vararg{Context,C}) where {C}
-        T = typeof(contexts)
-        return new{C,T}()
+        context_makers = map(contexts) do c
+            if c isa Cache
+                cache_maker
+            elseif c isa Constant
+                constant_maker
+            else
+                nothing
+            end
+        end
+        return new{C,typeof(context_makers)}(context_makers)
     end
 end
 
 (::Rewrap{0})() = ()
 
 function (r::Rewrap{C,T})(unannotated_contexts::Vararg{Any,C}) where {C,T}
-    return T(unannotated_contexts)
+    return map(r.context_makers, unannotated_contexts) do maker, c
+        maker(c)
+    end
 end
 
 with_contexts(f) = f

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -25,6 +25,14 @@ test_differentiation(
 );
 
 test_differentiation(
+    AutoForwardDiff(),
+    default_scenarios(;
+        include_normal=false, include_batchified=false, include_cachified=true
+    );
+    logging=LOGGING,
+);
+
+test_differentiation(
     AutoForwardDiff(); correctness=false, type_stability=:prepared, logging=LOGGING
 );
 

--- a/DifferentiationInterface/test/Misc/Internals/context.jl
+++ b/DifferentiationInterface/test/Misc/Internals/context.jl
@@ -14,6 +14,7 @@ contexts = ()
 r = @inferred Rewrap()
 @test r() == ()
 
-contexts = (Constant(1), Constant(2.0))
+contexts = (Constant(1.0), Cache([2.0]))
 r = @inferred Rewrap(contexts...)
-@test r(3, 4) == (Constant(3), Constant(4.0))
+@test (@inferred r(3.0, [4.0])) == (Constant(3.0), Cache([4.0]))
+@test (@inferred r(3, [4.0f0])) isa Tuple{Constant{Int},Cache{Vector{Float32}}}


### PR DESCRIPTION
**Versions**

- Bump DI to v0.6.16

**DI extensions**

- ForwardDiff:
  - Define translation mechanism to map `Constant(c)` to `c` and `Cache(c)` to an object like `c` full of `Dual` numbers. Use this translation in `pushforward`.
  - Restrict other operators to `Vararg{Constant}` instead of `Vararg{Context}` because putting caches in the closure `fc` leads to error. So if there is a `Cache` among the contexts, DI's fallback cascade will kick in.

**DI source**

- Revamp `Rewrap` so that it doesn't force `FLoat64` when `Dual` numbers are passed: it only remembers the annotation `Cache` or `Constant` and applies it. This is important for second-order ForwardDiff.

**DI tests**

- ForwardDiff: Test cachified scenarios.