### PR TITLE
chore: replace "gdalle" with "JuliaDiff"

### DIFF
--- a/CITATION.bib
+++ b/CITATION.bib
@@ -3,7 +3,7 @@
   author = {Dalle, Guillaume and Hill, Adrian},
   year   = 2024,
   doi    = {10.5281/zenodo.11092033},
-  url    = {https://github.com/gdalle/DifferentiationInterface.jl}
+  url    = {https://github.com/JuliaDiff/DifferentiationInterface.jl}
 }
 
 @article{Schafer_AbstractDifferentiation_2021,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 # Contributing
 
-Thank you for your willingness to contribute to [DifferentiationInterface.jl](https://github.com/gdalle/DifferentiationInterface.jl).
+Thank you for your willingness to contribute to [DifferentiationInterface.jl](https://github.com/JuliaDiff/DifferentiationInterface.jl).
 The maintainers of this package are Guillaume Dalle ([@gdalle](https://github.com/gdalle)) and Adrian Hill ([@adrhill](https://github.com/adrhill)).
 
-If you have a problem to report or an improvement to suggest, please [open an issue](https://github.com/gdalle/DifferentiationInterface.jl/issues/new/choose) with a precise description (and a reproducible example whenever possible).
+If you have a problem to report or an improvement to suggest, please [open an issue](https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/new/choose) with a precise description (and a reproducible example whenever possible).
 Once your issue receives positive feedback, you can open a pull request to address it.
 _Only the two maintainers are allowed to approve and merge pull requests._
 Feel free to ping them if they do not answer within a week or so.
 
 Apart from the conditions above, this repository follows the [ColPrac](https://github.com/SciML/ColPrac) best practices and [Conventional Commits](https://www.conventionalcommits.org/en/).
 Its code is formatted using [JuliaFormatter.jl](https://github.com/domluna/JuliaFormatter.jl) with [BlueStyle](https://github.com/JuliaDiff/BlueStyle) -- please format any modified code before opening a pull request, otherwise CI will fail.
-You can refer to the [dev guide](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterface/dev/dev_guide/) for details on the package structure and the testing pipeline.
+You can refer to the [dev guide](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterface/dev/dev_guide/) for details on the package structure and the testing pipeline.

--- a/DifferentiationInterface/README.md
+++ b/DifferentiationInterface/README.md
@@ -1,17 +1,17 @@
-![DifferentiationInterface Logo](https://raw.githubusercontent.com/gdalle/DifferentiationInterface.jl/main/DifferentiationInterface/docs/src/assets/logo.svg)
+![DifferentiationInterface Logo](https://raw.githubusercontent.com/JuliaDiff/DifferentiationInterface.jl/main/DifferentiationInterface/docs/src/assets/logo.svg)
 
 # DifferentiationInterface
 
-[![Build Status](https://github.com/gdalle/DifferentiationInterface.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/gdalle/DifferentiationInterface.jl/actions/workflows/Test.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/gdalle/DifferentiationInterface.jl/branch/main/graph/badge.svg?flag=DI)](https://app.codecov.io/gh/gdalle/DifferentiationInterface.jl)
-[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
+[![Build Status](https://github.com/JuliaDiff/DifferentiationInterface.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/JuliaDiff/DifferentiationInterface.jl/actions/workflows/Test.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/JuliaDiff/DifferentiationInterface.jl/branch/main/graph/badge.svg?flag=DI)](https://app.codecov.io/gh/JuliaDiff/DifferentiationInterface.jl)
+[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/JuliaDiff/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![DOI](https://zenodo.org/badge/740973714.svg)](https://zenodo.org/doi/10.5281/zenodo.11092033)
 
 |           Package            |                                                                                                                                                    Docs                                                                                                                                                    |
 | :--------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|   DifferentiationInterface   |   [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterface/stable/)     [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterface/dev/)   |
-| DifferentiationInterfaceTest | [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterfaceTest/stable/) [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterfaceTest/dev/) |
+|   DifferentiationInterface   |   [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterface/stable/)     [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterface/dev/)   |
+| DifferentiationInterfaceTest | [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterfaceTest/stable/) [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterfaceTest/dev/) |
 
 An interface to various automatic differentiation (AD) backends in Julia.
 
@@ -24,7 +24,7 @@ This package provides a unified syntax to differentiate functions, including:
 - Preparation mechanism (e.g. to pre-allocate a cache or record a tape)
 - Built-in sparsity handling
 - Thorough validation on standard inputs and outputs (numbers, vectors, matrices)
-- Testing and benchmarking utilities accessible to users with [DifferentiationInterfaceTest](https://github.com/gdalle/DifferentiationInterface.jl/tree/main/DifferentiationInterfaceTest)
+- Testing and benchmarking utilities accessible to users with [DifferentiationInterfaceTest](https://github.com/JuliaDiff/DifferentiationInterface.jl/tree/main/DifferentiationInterfaceTest)
 
 ## Compatibility
 
@@ -65,7 +65,7 @@ To install the development version, run this instead:
 using Pkg
 
 Pkg.add(
-    url="https://github.com/gdalle/DifferentiationInterface.jl",
+    url="https://github.com/JuliaDiff/DifferentiationInterface.jl",
     subdir="DifferentiationInterface"
 )
 ```

--- a/DifferentiationInterface/docs/make.jl
+++ b/DifferentiationInterface/docs/make.jl
@@ -38,7 +38,7 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/gdalle/DifferentiationInterface.jl",
+    repo="github.com/JuliaDiff/DifferentiationInterface.jl",
     devbranch="main",
     dirname="DifferentiationInterface",
     tag_prefix="DifferentiationInterface-",

--- a/DifferentiationInterface/docs/src/dev_guide.md
+++ b/DifferentiationInterface/docs/src/dev_guide.md
@@ -57,11 +57,11 @@ Every other operator can be deduced from these two, but you can gain efficiency 
 ### Tests and docs
 
 Once that is done, you need to add your new backend to the test suite.
-Test files should be gathered in a folder named `SuperDiff` inside [`DifferentiationInterface/test/Back`](https://github.com/gdalle/DifferentiationInterface.jl/tree/main/DifferentiationInterface/test/Back).
-They should use [DifferentiationInterfaceTest.jl](https://github.com/gdalle/DifferentiationInterface.jl/tree/main/DifferentiationInterfaceTest) to check correctness against the default scenarios.
+Test files should be gathered in a folder named `SuperDiff` inside [`DifferentiationInterface/test/Back`](https://github.com/JuliaDiff/DifferentiationInterface.jl/tree/main/DifferentiationInterface/test/Back).
+They should use [DifferentiationInterfaceTest.jl](https://github.com/JuliaDiff/DifferentiationInterface.jl/tree/main/DifferentiationInterfaceTest) to check correctness against the default scenarios.
 Take inspiration from the tests of other backends to write your own.
-To activate tests in CI, modify the [test workflow](https://github.com/gdalle/DifferentiationInterface.jl/blob/main/.github/workflows/Test.yml) and add your package to the list.
-To run the tests locally, replace the following line in [`DifferentiationInterface/test/runtests.jl`](https://github.com/gdalle/DifferentiationInterface.jl/blob/main/DifferentiationInterface/test/runtests.jl)
+To activate tests in CI, modify the [test workflow](https://github.com/JuliaDiff/DifferentiationInterface.jl/blob/main/.github/workflows/Test.yml) and add your package to the list.
+To run the tests locally, replace the following line in [`DifferentiationInterface/test/runtests.jl`](https://github.com/JuliaDiff/DifferentiationInterface.jl/blob/main/DifferentiationInterface/test/runtests.jl)
 
 ```julia
 GROUP = get(ENV, "JULIA_DI_TEST_GROUP", "All")

--- a/DifferentiationInterface/docs/src/tutorials/basic.md
+++ b/DifferentiationInterface/docs/src/tutorials/basic.md
@@ -127,5 +127,5 @@ prep2 = prepare_gradient(f, backend2, zero(x))
 ```
 
 In short, DifferentiationInterface.jl allows for easy testing and comparison of AD backends.
-If you want to go further, check out the [documentation of DifferentiationInterfaceTest.jl](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterfaceTest).
+If you want to go further, check out the [documentation of DifferentiationInterfaceTest.jl](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterfaceTest).
 This related package provides benchmarking utilities to compare backends and help you select the one that is best suited for your problem.

--- a/DifferentiationInterface/src/utils/exceptions.jl
+++ b/DifferentiationInterface/src/utils/exceptions.jl
@@ -15,7 +15,7 @@ function Base.showerror(io::IO, e::MissingBackendError)
     else
         print(
             io,
-            "Please open an issue: https://github.com/gdalle/DifferentiationInterface.jl/issues/new",
+            "Please open an issue: https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/new",
         )
     end
 end

--- a/DifferentiationInterfaceTest/README.md
+++ b/DifferentiationInterfaceTest/README.md
@@ -1,17 +1,17 @@
 # DifferentiationInterfaceTest
 
-[![Build Status](https://github.com/gdalle/DifferentiationInterface.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/gdalle/DifferentiationInterface.jl/actions/workflows/Test.yml?query=branch%3Amain)
-[![Coverage](https://codecov.io/gh/gdalle/DifferentiationInterface.jl/branch/main/graph/badge.svg?flag=DIT)](https://app.codecov.io/gh/gdalle/DifferentiationInterface.jl)
-[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
+[![Build Status](https://github.com/JuliaDiff/DifferentiationInterface.jl/actions/workflows/Test.yml/badge.svg?branch=main)](https://github.com/JuliaDiff/DifferentiationInterface.jl/actions/workflows/Test.yml?query=branch%3Amain)
+[![Coverage](https://codecov.io/gh/JuliaDiff/DifferentiationInterface.jl/branch/main/graph/badge.svg?flag=DIT)](https://app.codecov.io/gh/JuliaDiff/DifferentiationInterface.jl)
+[![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/JuliaDiff/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 [![DOI](https://zenodo.org/badge/740973714.svg)](https://zenodo.org/doi/10.5281/zenodo.11092033)
 
 |           Package            |                                                                                                                                                    Docs                                                                                                                                                    |
 | :--------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
-|   DifferentiationInterface   |   [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterface/stable/)     [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterface/dev/)   |
-| DifferentiationInterfaceTest | [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterfaceTest/stable/) [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterfaceTest/dev/) |
+|   DifferentiationInterface   |   [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterface/stable/)     [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterface/dev/)   |
+| DifferentiationInterfaceTest | [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterfaceTest/stable/) [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterfaceTest/dev/) |
 
-Testing and benchmarking utilities for automatic differentiation (AD) in Julia, based on [DifferentiationInterface](https://github.com/gdalle/DifferentiationInterface.jl/tree/main/DifferentiationInterface).
+Testing and benchmarking utilities for automatic differentiation (AD) in Julia, based on [DifferentiationInterface](https://github.com/JuliaDiff/DifferentiationInterface.jl/tree/main/DifferentiationInterface).
 
 ## Goal
 
@@ -45,12 +45,12 @@ To install the development version, run this instead:
 using Pkg
 
 Pkg.add(
-    url="https://github.com/gdalle/DifferentiationInterface.jl",
+    url="https://github.com/JuliaDiff/DifferentiationInterface.jl",
     subdir="DifferentiationInterface"
 )
     
 Pkg.add(
-    url="https://github.com/gdalle/DifferentiationInterface.jl",
+    url="https://github.com/JuliaDiff/DifferentiationInterface.jl",
     subdir="DifferentiationInterfaceTest"
 )
 ```

--- a/DifferentiationInterfaceTest/docs/make.jl
+++ b/DifferentiationInterfaceTest/docs/make.jl
@@ -22,7 +22,7 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/gdalle/DifferentiationInterface.jl",
+    repo="github.com/JuliaDiff/DifferentiationInterface.jl",
     devbranch="main",
     dirname="DifferentiationInterfaceTest",
     tag_prefix="DifferentiationInterfaceTest-",

--- a/DifferentiationInterfaceTest/docs/src/tutorial.md
+++ b/DifferentiationInterfaceTest/docs/src/tutorial.md
@@ -1,6 +1,6 @@
 # Tutorial
 
-We present a typical workflow with DifferentiationInterfaceTest.jl, building on the tutorial of the [DifferentiationInterface.jl documentation](https://gdalle.github.io/DifferentiationInterface.jl/DifferentiationInterface) (which we encourage you to read first).
+We present a typical workflow with DifferentiationInterfaceTest.jl, building on the tutorial of the [DifferentiationInterface.jl documentation](https://juliadiff.org/DifferentiationInterface.jl/DifferentiationInterface) (which we encourage you to read first).
 
 ```@repl tuto
 using DifferentiationInterface, DifferentiationInterfaceTest

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestFluxExt/DifferentiationInterfaceTestFluxExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestFluxExt/DifferentiationInterfaceTestFluxExt.jl
@@ -12,8 +12,8 @@ using Random: AbstractRNG, default_rng
 #=
 Relevant discussions:
 
-- https://github.com/gdalle/DifferentiationInterface.jl/issues/105
-- https://github.com/gdalle/DifferentiationInterface.jl/issues/343
+- https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/105
+- https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/343
 - https://github.com/FluxML/Flux.jl/issues/2469
 =#
 


### PR DESCRIPTION
Following repo transfer:
- Replace `gdalle` with `JuliaDiff`
- Replace `gdalle.github.io` with `juliadiff.org`