### PR TITLE
Catch Zygote `nothing` returns and give an informative error message

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -103,6 +103,9 @@ function DI.value_and_gradient!(
     f, grad, prep::NoGradientPrep, backend::AutoZygote, x, contexts::Vararg{Constant,C}
 ) where {C}
     y, new_grad = DI.value_and_gradient(f, prep, backend, x, contexts...)
+    if isnothing(new_grad)
+        error("Exact zero gradient detected via Zygote `nothing` derivative. This is indicative of a coding error making the function `f` not a function of the `x` being differentiated")
+    end
     return y, copyto!(grad, new_grad)
 end
 


### PR DESCRIPTION
This is much more informative than `iterate(::Nothing)` not defined.