### PR TITLE
fix: remove ambiguity in BatchSizeSettings with PolyesterForwardDiff

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.18"
+version = "0.6.19"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
@@ -28,8 +28,12 @@ end
 
 DI.check_available(::AutoPolyesterForwardDiff) = true
 
-function DI.BatchSizeSettings(backend::AutoPolyesterForwardDiff, x_or_N)
-    return DI.BatchSizeSettings(single_threaded(backend), x_or_N)
+function DI.BatchSizeSettings(backend::AutoPolyesterForwardDiff, x::AbstractArray)
+    return DI.BatchSizeSettings(single_threaded(backend), x)
+end
+
+function DI.BatchSizeSettings(backend::AutoPolyesterForwardDiff, N::Integer)
+    return DI.BatchSizeSettings(single_threaded(backend), N)
 end
 
 function DI.threshold_batchsize(

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -41,12 +41,16 @@ test_differentiation(
     logging=LOGGING,
 );
 
+#=
+# TODO: reactivate closurified tests once Enzyme#2056 is fixed
+
 test_differentiation(
     duplicated_backends,
     default_scenarios(; include_normal=false, include_closurified=true);
     excluded=SECOND_ORDER,
     logging=LOGGING,
 );
+=#
 
 #=
 # TODO: reactivate type stability tests


### PR DESCRIPTION
**Versions**

- Bump DI to v0.6.19

**DI extensions**

- PolyesterForwardDiff: define two methods for `BatchSizeSettings` (array and integer) instead of one. Fixes #605

**DI tests**

- Temporarily disable tests with `Duplicated` functions due to https://github.com/EnzymeAD/Enzyme.jl/issues/2056