### PR TITLE
test: more precise display in correctness tests for seeded operators

### DIFF
--- a/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
@@ -452,10 +452,12 @@ for op in ALL_OPS
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
-                    @test all(res1_out1_val .≈ scen.res1)
-                    @test all(res1_out2_val .≈ scen.res1)
-                    @test all(res1_out1_noval .≈ scen.res1)
-                    @test all(res1_out2_noval .≈ scen.res1)
+                    for b in eachindex(scen.res1)
+                        res1_out1_val[b] ≈ scen.res1[b]
+                        res1_out2_val[b] ≈ scen.res1[b]
+                        res1_out1_noval[b] ≈ scen.res1[b]
+                        res1_out2_noval[b] ≈ scen.res1[b]
+                    end
                 end
             end
             scenario_intact && @test new_scen == scen
@@ -509,14 +511,16 @@ for op in ALL_OPS
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
-                    @test all(res1_in1_val .≈ scen.res1)
-                    @test all(res1_in2_val .≈ scen.res1)
-                    @test all(res1_out1_val .≈ scen.res1)
-                    @test all(res1_out2_val .≈ scen.res1)
-                    @test all(res1_in1_noval .≈ scen.res1)
-                    @test all(res1_in2_noval .≈ scen.res1)
-                    @test all(res1_out1_noval .≈ scen.res1)
-                    @test all(res1_out2_noval .≈ scen.res1)
+                    for b in eachindex(scen.res1)
+                        @test res1_in1_val[b] ≈ scen.res1[b]
+                        @test res1_in2_val[b] ≈ scen.res1[b]
+                        @test res1_out1_val[b] ≈ scen.res1[b]
+                        @test res1_out2_val[b] ≈ scen.res1[b]
+                        @test res1_in1_noval[b] ≈ scen.res1[b]
+                        @test res1_in2_noval[b] ≈ scen.res1[b]
+                        @test res1_out1_noval[b] ≈ scen.res1[b]
+                        @test res1_out2_noval[b] ≈ scen.res1[b]
+                    end
                 end
             end
             scenario_intact && @test new_scen == scen
@@ -573,10 +577,12 @@ for op in ALL_OPS
                     @test y_in2_val ≈ scen.y
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
-                    @test all(res1_out1_val .≈ scen.res1)
-                    @test all(res1_out2_val .≈ scen.res1)
-                    @test all(res1_out1_noval .≈ scen.res1)
-                    @test all(res1_out2_noval .≈ scen.res1)
+                    for b in eachindex(scen.res1)
+                        @test res1_out1_val[b] ≈ scen.res1[b]
+                        @test res1_out2_val[b] ≈ scen.res1[b]
+                        @test res1_out1_noval[b] ≈ scen.res1[b]
+                        @test res1_out2_noval[b] ≈ scen.res1[b]
+                    end
                 end
             end
             scenario_intact && @test new_scen == scen
@@ -647,14 +653,16 @@ for op in ALL_OPS
                     @test y_in2_val ≈ scen.y
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
-                    @test all(res1_in1_val .≈ scen.res1)
-                    @test all(res1_in2_val .≈ scen.res1)
-                    @test all(res1_out1_val .≈ scen.res1)
-                    @test all(res1_out2_val .≈ scen.res1)
-                    @test all(res1_in1_noval .≈ scen.res1)
-                    @test all(res1_in2_noval .≈ scen.res1)
-                    @test all(res1_out1_noval .≈ scen.res1)
-                    @test all(res1_out2_noval .≈ scen.res1)
+                    for b in eachindex(scen.res1)
+                        @test res1_in1_val[b] ≈ scen.res1[b]
+                        @test res1_in2_val[b] ≈ scen.res1[b]
+                        @test res1_out1_val[b] ≈ scen.res1[b]
+                        @test res1_out2_val[b] ≈ scen.res1[b]
+                        @test res1_in1_noval[b] ≈ scen.res1[b]
+                        @test res1_in2_noval[b] ≈ scen.res1[b]
+                        @test res1_out1_noval[b] ≈ scen.res1[b]
+                        @test res1_out2_noval[b] ≈ scen.res1[b]
+                    end
                 end
             end
             scenario_intact && @test new_scen == scen
@@ -699,12 +707,14 @@ for op in ALL_OPS
                 )
                 let (≈)(x, y) = isapprox(x, y; atol, rtol)
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
-                    @test all(res2_out1_noval .≈ scen.res2)
-                    @test all(res2_out2_noval .≈ scen.res2)
                     @test res1_out1_val ≈ scen.res1
                     @test res1_out2_val ≈ scen.res1
-                    @test all(res2_out1_val .≈ scen.res2)
-                    @test all(res2_out2_val .≈ scen.res2)
+                    for b in eachindex(scen.res2)
+                        @test res2_out1_noval[b] ≈ scen.res2[b]
+                        @test res2_out2_noval[b] ≈ scen.res2[b]
+                        @test res2_out1_val[b] ≈ scen.res2[b]
+                        @test res2_out2_val[b] ≈ scen.res2[b]
+                    end
                 end
             end
             scenario_intact && @test new_scen == scen
@@ -770,18 +780,20 @@ for op in ALL_OPS
                 )
                 let (≈)(x, y) = isapprox(x, y; atol, rtol)
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
-                    @test all(res2_in1_noval .≈ scen.res2)
-                    @test all(res2_in2_noval .≈ scen.res2)
-                    @test all(res2_out1_noval .≈ scen.res2)
-                    @test all(res2_out2_noval .≈ scen.res2)
                     @test res1_in1_val ≈ scen.res1
                     @test res1_in2_val ≈ scen.res1
                     @test res1_out1_val ≈ scen.res1
                     @test res1_out2_val ≈ scen.res1
-                    @test all(res2_in1_val .≈ scen.res2)
-                    @test all(res2_in2_val .≈ scen.res2)
-                    @test all(res2_out1_val .≈ scen.res2)
-                    @test all(res2_out2_val .≈ scen.res2)
+                    for b in eachindex(scen.res2)
+                        @test res2_in1_noval[b] ≈ scen.res2[b]
+                        @test res2_in2_noval[b] ≈ scen.res2[b]
+                        @test res2_out1_noval[b] ≈ scen.res2[b]
+                        @test res2_out2_noval[b] ≈ scen.res2[b]
+                        @test res2_in1_val[b] ≈ scen.res2[b]
+                        @test res2_in2_val[b] ≈ scen.res2[b]
+                        @test res2_out1_val[b] ≈ scen.res2[b]
+                        @test res2_out2_val[b] ≈ scen.res2[b]
+                    end
                 end
             end
             scenario_intact && @test new_scen == scen


### PR DESCRIPTION
**DIT source**

- In correctness tests for `pushforward`, `pullback` and `hvp`, test equality of each individual tangent instead of testing `all(res .≈ scen.res)`. This allows the `@test` macro to display the values of both sides.