### PR TITLE
refactor!: remove randomness in scenario creation

### DIFF
--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterfaceTest"
 uuid = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.8.5"
+version = "0.9.0"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestComponentArraysExt/DifferentiationInterfaceTestComponentArraysExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestComponentArraysExt/DifferentiationInterfaceTestComponentArraysExt.jl
@@ -5,7 +5,6 @@ using DifferentiationInterface
 using DifferentiationInterfaceTest
 import DifferentiationInterfaceTest as DIT
 using LinearAlgebra: dot
-using Random: AbstractRNG, default_rng
 
 ## Vector to scalar
 
@@ -49,11 +48,11 @@ end
 
 ## Gather
 
-function DIT.component_scenarios(rng::AbstractRNG=default_rng())
-    dy_ = rand(rng)
+function DIT.component_scenarios()
+    dy_ = -1 / 12
 
-    x_comp = ComponentVector(; a=randn(rng, 4), b=randn(rng, 2))
-    dx_comp = ComponentVector(; a=randn(rng, 4), b=randn(rng, 2))
+    x_comp = ComponentVector(; a=float.(1:4), b=float.(5:6))
+    dx_comp = ComponentVector(; a=float.(4:-1:1), b=float.(6:-1:5))
 
     scens = vcat(
         # one argument

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestJLArraysExt/DifferentiationInterfaceTestJLArraysExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestJLArraysExt/DifferentiationInterfaceTestJLArraysExt.jl
@@ -4,7 +4,6 @@ import DifferentiationInterface as DI
 using DifferentiationInterfaceTest
 import DifferentiationInterfaceTest as DIT
 using JLArrays: JLArray, JLVector, JLMatrix, jl
-using Random: AbstractRNG, default_rng
 
 myjl(f::Function) = f
 function myjl(::DIT.NumToArr{A}) where {T,N,A<:AbstractArray{T,N}}

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestStaticArraysExt/DifferentiationInterfaceTestStaticArraysExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestStaticArraysExt/DifferentiationInterfaceTestStaticArraysExt.jl
@@ -3,7 +3,6 @@ module DifferentiationInterfaceTestStaticArraysExt
 import DifferentiationInterface as DI
 using DifferentiationInterfaceTest
 import DifferentiationInterfaceTest as DIT
-using Random: AbstractRNG, default_rng
 using SparseArrays: SparseArrays, SparseMatrixCSC, nnz, spdiagm
 using StaticArrays: MArray, MMatrix, MVector, SArray, SMatrix, SVector
 

--- a/DifferentiationInterfaceTest/src/scenarios/allocfree.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/allocfree.jl
@@ -41,21 +41,21 @@ function copyto!_scenarios(x::AbstractArray; dx::AbstractArray, dy::AbstractArra
 end
 
 """
-    allocfree_scenarios(rng::AbstractRNG=default_rng())
+    allocfree_scenarios()
 
 Create a vector of [`Scenario`](@ref)s with functions that do not allocate.
 
 !!! warning
     At the moment, second-order scenarios are excluded.
 """
-function allocfree_scenarios(rng::AbstractRNG=default_rng())
-    x_ = rand(rng)
-    dx_ = rand(rng)
-    dy_ = rand(rng)
+function allocfree_scenarios()
+    x_ = 0.42
+    dx_ = 3.14
+    dy_ = -1 / 12
 
-    x_6 = rand(rng, 6)
-    dx_6 = rand(rng, 6)
-    dy_6 = rand(rng, 6)
+    x_6 = float.(1:6)
+    dx_6 = float.(-1:-1:-6)
+    dy_6 = float.(-5:2:5)
 
     scens = vcat(
         identity_scenarios(x_; dx=dx_, dy=dy_), #

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -448,12 +448,11 @@ end
 ## Gather
 
 """
-    default_scenarios(rng=Random.default_rng())
+    default_scenarios()
 
 Create a vector of [`Scenario`](@ref)s with standard array types.
 """
-function default_scenarios(
-    rng::AbstractRNG=default_rng();
+function default_scenarios(;
     linalg=true,
     include_normal=true,
     include_batchified=true,
@@ -461,20 +460,20 @@ function default_scenarios(
     include_constantified=false,
     include_cachified=false,
 )
-    x_ = rand(rng)
-    dx_ = rand(rng)
-    dy_ = rand(rng)
+    x_ = 0.42
+    dx_ = 3.14
+    dy_ = -1 / 12
 
-    x_6 = rand(rng, 6)
-    dx_6 = rand(rng, 6)
+    x_6 = float.(1:6)
+    dx_6 = float.(-1:-1:-6)
 
-    x_2_3 = rand(rng, 2, 3)
-    dx_2_3 = rand(rng, 2, 3)
+    x_2_3 = float.(reshape(1:6, 2, 3))
+    dx_2_3 = float.(reshape(-1:-1:-6, 2, 3))
 
-    dy_6 = rand(rng, 6)
-    dy_12 = rand(rng, 12)
-    dy_2_3 = rand(rng, 2, 3)
-    dy_6_2 = rand(rng, 6, 2)
+    dy_6 = float.(-5:2:5)
+    dy_12 = float.(-11:2:11)
+    dy_2_3 = float.(reshape(-5:2:5, 2, 3))
+    dy_6_2 = float.(reshape(-11:2:11, 6, 2))
 
     V = Vector{Float64}
     M = Matrix{Float64}

--- a/DifferentiationInterfaceTest/src/scenarios/extensions.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/extensions.jl
@@ -1,5 +1,5 @@
 """
-    static_scenarios(rng=Random.default_rng())
+    static_scenarios()
 
 Create a vector of [`Scenario`](@ref)s with static array types from [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl).
 
@@ -9,7 +9,7 @@ Create a vector of [`Scenario`](@ref)s with static array types from [StaticArray
 function static_scenarios end
 
 """
-    component_scenarios(rng=Random.default_rng())
+    component_scenarios()
 
 Create a vector of [`Scenario`](@ref)s with component array types from [ComponentArrays.jl](https://github.com/jonniedie/ComponentArrays.jl).
 
@@ -19,7 +19,7 @@ Create a vector of [`Scenario`](@ref)s with component array types from [Componen
 function component_scenarios end
 
 """
-    gpu_scenarios(rng=Random.default_rng())
+    gpu_scenarios()
 
 Create a vector of [`Scenario`](@ref)s with GPU array types from [JLArrays.jl](https://github.com/JuliaGPU/GPUArrays.jl/tree/master/lib/JLArrays).
 

--- a/DifferentiationInterfaceTest/src/scenarios/sparse.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/sparse.jl
@@ -320,24 +320,26 @@ end
 ## Gather
 
 """
-    sparse_scenarios(rng=Random.default_rng())
+    sparse_scenarios()
 
 Create a vector of [`Scenario`](@ref)s with sparse array types, focused on sparse Jacobians and Hessians.
 """
-function sparse_scenarios(
-    rng::AbstractRNG=default_rng(); band_sizes=[5, 10, 20], include_constantified=false
-)
+function sparse_scenarios(band_sizes=[5, 10, 20], include_constantified=false)
+    x_6 = float.(1:6)
+    x_2_3 = float.(reshape(1:6, 2, 3))
+    x_50 = float.(1:50)
+
     scens = vcat(
-        sparse_vec_to_vec_scenarios(rand(rng, 6)),
-        sparse_vec_to_mat_scenarios(rand(rng, 6)),
-        sparse_mat_to_vec_scenarios(rand(rng, 2, 3)),
-        sparse_mat_to_mat_scenarios(rand(rng, 2, 3)),
-        sparse_vec_to_num_scenarios(rand(rng, 6)),
-        sparse_mat_to_num_scenarios(rand(rng, 2, 3)),
+        sparse_vec_to_vec_scenarios(x_6),
+        sparse_vec_to_mat_scenarios(x_6),
+        sparse_mat_to_vec_scenarios(x_2_3),
+        sparse_mat_to_mat_scenarios(x_2_3),
+        sparse_vec_to_num_scenarios(x_6),
+        sparse_mat_to_num_scenarios(x_2_3),
     )
     if !isempty(band_sizes)
-        append!(scens, squarelinearmap_scenarios(rand(rng, 50), band_sizes))
-        append!(scens, squarequadraticform_scenarios(rand(rng, 50), band_sizes))
+        append!(scens, squarelinearmap_scenarios(x_50, band_sizes))
+        append!(scens, squarequadraticform_scenarios(x_50, band_sizes))
     end
     include_constantified && append!(scens, constantify(scens))
     return scens

--- a/DifferentiationInterfaceTest/src/scenarios/sparse.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/sparse.jl
@@ -324,7 +324,7 @@ end
 
 Create a vector of [`Scenario`](@ref)s with sparse array types, focused on sparse Jacobians and Hessians.
 """
-function sparse_scenarios(band_sizes=[5, 10, 20], include_constantified=false)
+function sparse_scenarios(; band_sizes=[5, 10, 20], include_constantified=false)
     x_6 = float.(1:6)
     x_2_3 = float.(reshape(1:6, 2, 3))
     x_50 = float.(1:50)

--- a/DifferentiationInterfaceTest/test/standard.jl
+++ b/DifferentiationInterfaceTest/test/standard.jl
@@ -11,9 +11,7 @@ LOGGING = get(ENV, "CI", "false") == "false"
 ## Dense
 
 test_differentiation(
-    AutoForwardDiff(),
-    default_scenarios(Random.default_rng(); include_constantified=true);
-    logging=LOGGING,
+    AutoForwardDiff(), default_scenarios(; include_constantified=true); logging=LOGGING
 )
 
 ## Sparse


### PR DESCRIPTION
**Versions**

- Bump DIT to v0.9.0 (BREAKING CHANGE)

**DIT source**

- Remove use of random number generators for most scenario creations (except Lux and Flux). Use fixed values for `x`, `y`, `dx`, `dy` instead (aka [manual randomness](https://xkcd.com/221/)).