### PR TITLE
Fix tutorial typo

### DIFF
--- a/DifferentiationInterfaceTest/docs/src/tutorial.md
+++ b/DifferentiationInterfaceTest/docs/src/tutorial.md
@@ -9,7 +9,7 @@ import ForwardDiff, Zygote
 
 ## Introduction
 
-The AD backends we want to compare are [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) and [Enzyme.jl](https://github.com/EnzymeAD/Enzyme.jl).
+The AD backends we want to compare are [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) and [Zygote.jl](https://github.com/FluxML/Zygote.jl).
 
 ```@example tuto
 backends = [AutoForwardDiff(), AutoZygote()]

--- a/DifferentiationInterfaceTest/docs/src/tutorial.md
+++ b/DifferentiationInterfaceTest/docs/src/tutorial.md
@@ -60,8 +60,6 @@ test_differentiation(
 )
 ```
 
-If you are too lazy to manually specify the reference, you can also provide an AD backend as the `ref_backend` keyword argument, which will serve as the ground truth for comparison.
-
 ## Benchmarking
 
 Once you are confident that your backends give the correct answers, you probably want to compare their performance.


### PR DESCRIPTION
Hello, this is just a very trivial typo fix as the rest of the tutorial uses `AutoZygote` :)