### PR TITLE
feat: customizable DIT benchmarks

### DIFF
--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestLuxExt/DifferentiationInterfaceTestLuxExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestLuxExt/DifferentiationInterfaceTestLuxExt.jl
@@ -181,7 +181,7 @@ function DIT.lux_scenarios(rng::AbstractRNG=default_rng())
         scen = Scenario{:gradient,:out}(
             square_loss,
             ComponentArray(ps);
-            contexts=(Constant(model), Constant(x), Constant(st)),
+            contexts=(DI.Constant(model), DI.Constant(x), DI.Constant(st)),
             res1=g,
         )
         push!(scens, scen)

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -56,6 +56,7 @@ Each setting tests/benchmarks a different subset of calls:
 
 - `count_calls=true`: whether to also count function calls during benchmarking
 - `benchmark_test=true`: whether to include tests which succeed iff benchmark doesn't error
+- `benchmark_seconds=1`: how long to run each benchmark for
 """
 function test_differentiation(
     backends::Vector{<:AbstractADType},
@@ -87,6 +88,7 @@ function test_differentiation(
     # benchmark options
     count_calls::Bool=true,
     benchmark_test::Bool=true,
+    benchmark_seconds::Real=1,
 )
     @assert type_stability in (:none, :prepared, :full)
     @assert allocations in (:none, :prepared, :full)
@@ -173,6 +175,7 @@ function test_differentiation(
                             subset=benchmark,
                             count_calls,
                             benchmark_test,
+                            benchmark_seconds,
                         )
                     end
                     yield()
@@ -211,6 +214,7 @@ function benchmark_differentiation(
     logging::Bool=false,
     count_calls::Bool=true,
     benchmark_test::Bool=true,
+    benchmark_seconds::Real=1,
 )
     return test_differentiation(
         backends,
@@ -223,5 +227,6 @@ function benchmark_differentiation(
         excluded,
         count_calls,
         benchmark_test,
+        benchmark_seconds,
     )
 end

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -57,6 +57,7 @@ Each setting tests/benchmarks a different subset of calls:
 - `count_calls=true`: whether to also count function calls during benchmarking
 - `benchmark_test=true`: whether to include tests which succeed iff benchmark doesn't error
 - `benchmark_seconds=1`: how long to run each benchmark for
+- `benchmark_aggregation=minimum`: function used to aggregate sample measurements
 """
 function test_differentiation(
     backends::Vector{<:AbstractADType},
@@ -89,6 +90,7 @@ function test_differentiation(
     count_calls::Bool=true,
     benchmark_test::Bool=true,
     benchmark_seconds::Real=1,
+    benchmark_aggregation=minimum,
 )
     @assert type_stability in (:none, :prepared, :full)
     @assert allocations in (:none, :prepared, :full)
@@ -176,6 +178,7 @@ function test_differentiation(
                             count_calls,
                             benchmark_test,
                             benchmark_seconds,
+                            benchmark_aggregation,
                         )
                     end
                     yield()
@@ -215,6 +218,7 @@ function benchmark_differentiation(
     count_calls::Bool=true,
     benchmark_test::Bool=true,
     benchmark_seconds::Real=1,
+    benchmark_aggregation=minimum,
 )
     return test_differentiation(
         backends,
@@ -228,5 +232,6 @@ function benchmark_differentiation(
         count_calls,
         benchmark_test,
         benchmark_seconds,
+        benchmark_aggregation,
     )
 end

--- a/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -56,7 +56,7 @@ $(TYPEDFIELDS)
 
 See the documentation of [Chairmarks.jl](https://github.com/LilithHafner/Chairmarks.jl) for more details on the measurement fields.
 """
-Base.@kwdef struct DifferentiationBenchmarkDataRow
+Base.@kwdef struct DifferentiationBenchmarkDataRow{T}
     "backend used for benchmarking"
     backend::AbstractADType
     "scenario used for benchmarking"
@@ -71,16 +71,16 @@ Base.@kwdef struct DifferentiationBenchmarkDataRow
     samples::Int
     "number of evaluations used for averaging in each sample"
     evals::Int
-    "minimum runtime over all samples, in seconds"
-    time::Float64
-    "minimum number of allocations over all samples"
-    allocs::Float64
-    "minimum memory allocated over all samples, in bytes"
-    bytes::Float64
-    "minimum fraction of time spent in garbage collection over all samples, between 0.0 and 1.0"
-    gc_fraction::Float64
-    "minimum fraction of time spent compiling over all samples, between 0.0 and 1.0"
-    compile_fraction::Float64
+    "aggregated runtime over all samples, in seconds"
+    time::T
+    "aggregated number of allocations over all samples"
+    allocs::T
+    "aggregated memory allocated over all samples, in bytes"
+    bytes::T
+    "aggregated fraction of time spent in garbage collection over all samples, between 0.0 and 1.0"
+    gc_fraction::T
+    "aggregated fraction of time spent compiling over all samples, between 0.0 and 1.0"
+    compile_fraction::T
 end
 
 function record!(
@@ -91,8 +91,9 @@ function record!(
     prepared::Union{Nothing,Bool},
     bench::Benchmark,
     calls::Integer,
+    aggregation,
 )
-    bench_min = minimum(bench)
+    bench_agg = aggregation(bench)
     row = DifferentiationBenchmarkDataRow(;
         backend=backend,
         scenario=scenario,
@@ -100,12 +101,12 @@ function record!(
         prepared=prepared,
         calls=calls,
         samples=length(bench.samples),
-        evals=Int(bench_min.evals),
-        time=bench_min.time,
-        allocs=bench_min.allocs,
-        bytes=bench_min.bytes,
-        gc_fraction=bench_min.gc_fraction,
-        compile_fraction=bench_min.compile_fraction,
+        evals=Int(bench_agg.evals),
+        time=bench_agg.time,
+        allocs=bench_agg.allocs,
+        bytes=bench_agg.bytes,
+        gc_fraction=bench_agg.gc_fraction,
+        compile_fraction=bench_agg.compile_fraction,
     )
     return push!(data, row)
 end

--- a/DifferentiationInterfaceTest/src/tests/benchmark_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark_eval.jl
@@ -42,12 +42,13 @@ for op in ALL_OPS
         subset::Symbol,
         count_calls::Bool,
         benchmark_test::Bool,
+        benchmark_seconds::Real,
     )
         @assert subset in (:full, :prepared)
 
         bench_success = true
         bench_result = try
-            benchmark_aux(backend, scenario; subset)
+            benchmark_aux(backend, scenario; subset, s=benchmark_seconds)
         catch exception
             bench_success = false
             logging && @warn "Error during benchmarking" backend scenario exception
@@ -58,7 +59,7 @@ for op in ALL_OPS
         if count_calls
             count_success = true
             calls_result = try
-                calls_aux(backend, scenario; subset)
+                calls_aux(backend, scenario; subset, s=nothing)
             catch exception
                 count_success = false
                 logging && @warn "Error during call counting" backend scenario exception
@@ -129,15 +130,15 @@ for op in ALL_OPS
     end
 
     if op in [:derivative, :gradient, :jacobian]
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S1out; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S1out; subset::Symbol, s)
             (; f, x, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, contexts...)
-            prepared_valop = @be prep $val_and_op(f, _, ba, x, contexts...)
-            prepared_op = @be prep $op(f, _, ba, x, contexts...)
+            prepared_valop = @be prep $val_and_op(f, _, ba, x, contexts...) seconds = s
+            prepared_op = @be prep $op(f, _, ba, x, contexts...) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, ba, x, contexts...)
-                unprepared_valop = @be $val_and_op(f, ba, x, contexts...)
-                unprepared_op = @be $op(f, ba, x, contexts...)
+                preparation = @be $prep_op(f, ba, x, contexts...) seconds = s
+                unprepared_valop = @be $val_and_op(f, ba, x, contexts...) seconds = s
+                unprepared_op = @be $op(f, ba, x, contexts...) seconds = s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -150,7 +151,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S1out; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S1out; subset::Symbol, s)
             (; f, x, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, contexts...)
@@ -168,21 +169,22 @@ for op in ALL_OPS
             )
         end
 
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol, s)
             (; f, x, res1, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, contexts...)
             prepared_valop = @be (mysimilar(res1), prep) $val_and_op!(
                 f, _[1], _[2], ba, x, contexts...
-            )
+            ) seconds = s
             prepared_op = @be (mysimilar(res1), prep) $op!(
                 f, _[1], _[2], ba, x, contexts...
-            )
+            ) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, ba, x, contexts...)
+                preparation = @be $prep_op(f, ba, x, contexts...) seconds = s
                 unprepared_valop = @be mysimilar(res1) $val_and_op!(
                     f, _, ba, x, contexts...
-                )
-                unprepared_op = @be mysimilar(res1) $op!(f, _, ba, x, contexts...)
+                ) seconds = s
+                unprepared_op = @be mysimilar(res1) $op!(f, _, ba, x, contexts...) seconds =
+                    s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -195,7 +197,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S1in; subset::Symbol, s)
             (; f, x, res1, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, contexts...)
@@ -215,15 +217,16 @@ for op in ALL_OPS
 
         op == :gradient && continue
 
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S2out; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S2out; subset::Symbol, s)
             (; f, x, y, contexts) = deepcopy(scen)
             prep = $prep_op(f, y, ba, x, contexts...)
-            prepared_valop = @be (y, prep) $val_and_op(f, _[1], _[2], ba, x, contexts...)
-            prepared_op = @be (y, prep) $op(f, _[1], _[2], ba, x, contexts...)
+            prepared_valop = @be (y, prep) $val_and_op(f, _[1], _[2], ba, x, contexts...) seconds =
+                s
+            prepared_op = @be (y, prep) $op(f, _[1], _[2], ba, x, contexts...) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, y, ba, x, contexts...)
-                unprepared_valop = @be y $val_and_op(f, _, ba, x, contexts...)
-                unprepared_op = @be y $op(f, _, ba, x, contexts...)
+                preparation = @be $prep_op(f, y, ba, x, contexts...) seconds = s
+                unprepared_valop = @be y $val_and_op(f, _, ba, x, contexts...) seconds = s
+                unprepared_op = @be y $op(f, _, ba, x, contexts...) seconds = s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -236,7 +239,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S2out; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S2out; subset::Symbol, s)
             (; f, x, y, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, y, ba, x, contexts...)
@@ -254,23 +257,23 @@ for op in ALL_OPS
             )
         end
 
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S2in; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S2in; subset::Symbol, s)
             (; f, x, y, res1, contexts) = deepcopy(scen)
             prep = $prep_op(f, y, ba, x, contexts...)
             prepared_valop = @be (y, mysimilar(res1), prep) $val_and_op!(
                 f, _[1], _[2], _[3], ba, x, contexts...
-            )
+            ) seconds = s
             prepared_op = @be (y, mysimilar(res1), prep) $op!(
                 f, _[1], _[2], _[3], ba, x, contexts...
-            )
+            ) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, y, ba, x, contexts...)
+                preparation = @be $prep_op(f, y, ba, x, contexts...) seconds = s
                 unprepared_valop = @be (y, mysimilar(res1)) $val_and_op!(
                     f, _[1], _[2], ba, x, contexts...
-                )
+                ) seconds = s
                 unprepared_op = @be (y, mysimilar(res1)) $op!(
                     f, _[1], _[2], ba, x, contexts...
-                )
+                ) seconds = s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -283,7 +286,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S2in; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S2in; subset::Symbol, s)
             (; f, x, y, res1, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, y, ba, x, contexts...)
@@ -302,15 +305,15 @@ for op in ALL_OPS
         end
 
     elseif op in [:hessian, :second_derivative]
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S1out; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S1out; subset::Symbol, s)
             (; f, x, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, contexts...)
-            prepared_valop = @be prep $val_and_op(f, _, ba, x, contexts...)
-            prepared_op = @be prep $op(f, _, ba, x, contexts...)
+            prepared_valop = @be prep $val_and_op(f, _, ba, x, contexts...) seconds = s
+            prepared_op = @be prep $op(f, _, ba, x, contexts...) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, ba, x, contexts...)
-                unprepared_valop = @be $val_and_op(f, ba, x, contexts...)
-                unprepared_op = @be $op(f, ba, x, contexts...)
+                preparation = @be $prep_op(f, ba, x, contexts...) seconds = s
+                unprepared_valop = @be $val_and_op(f, ba, x, contexts...) seconds = s
+                unprepared_op = @be $op(f, ba, x, contexts...) seconds = s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -323,7 +326,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S1out; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S1out; subset::Symbol, s)
             (; f, x, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, contexts...)
@@ -341,22 +344,23 @@ for op in ALL_OPS
             )
         end
 
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol, s)
             (; f, x, res1, res2, contexts) = deepcopy(scen)
 
             prep = $prep_op(f, ba, x, contexts...)
             prepared_valop = @be (mysimilar(res1), mysimilar(res2), prep) $val_and_op!(
                 f, _[1], _[2], _[3], ba, x, contexts...
-            )
+            ) seconds = s
             prepared_op = @be (mysimilar(res2), prep) $op!(
                 f, _[1], _[2], ba, x, contexts...
-            )
+            ) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, ba, x, contexts...)
+                preparation = @be $prep_op(f, ba, x, contexts...) seconds = s
                 unprepared_valop = @be (mysimilar(res1), mysimilar(res2)) $val_and_op!(
                     f, _[1], _[2], ba, x, contexts...
-                )
-                unprepared_op = @be mysimilar(res2) $op!(f, _, ba, x, contexts...)
+                ) seconds = s
+                unprepared_op = @be mysimilar(res2) $op!(f, _, ba, x, contexts...) seconds =
+                    s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -369,7 +373,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S1in; subset::Symbol, s)
             (; f, x, res1, res2, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, contexts...)
@@ -388,15 +392,16 @@ for op in ALL_OPS
         end
 
     elseif op in [:pushforward, :pullback]
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S1out; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S1out; subset::Symbol, s)
             (; f, x, tang, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, tang, contexts...)
-            prepared_valop = @be prep $val_and_op(f, _, ba, x, tang, contexts...)
-            prepared_op = @be prep $op(f, _, ba, x, tang, contexts...)
+            prepared_valop = @be prep $val_and_op(f, _, ba, x, tang, contexts...) seconds =
+                s
+            prepared_op = @be prep $op(f, _, ba, x, tang, contexts...) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, ba, x, tang, contexts...)
-                unprepared_valop = @be $val_and_op(f, ba, x, tang, contexts...)
-                unprepared_op = @be $op(f, ba, x, tang, contexts...)
+                preparation = @be $prep_op(f, ba, x, tang, contexts...) seconds = s
+                unprepared_valop = @be $val_and_op(f, ba, x, tang, contexts...) seconds = s
+                unprepared_op = @be $op(f, ba, x, tang, contexts...) seconds = s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -408,7 +413,7 @@ for op in ALL_OPS
                 return BenchmarkResult(; prepared_valop, prepared_op)
             end
         end
-        @eval function calls_aux(ba::AbstractADType, scen::$S1out; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S1out; subset::Symbol, s)
             (; f, x, tang, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, tang, contexts...)
@@ -426,21 +431,22 @@ for op in ALL_OPS
             )
         end
 
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol, s)
             (; f, x, tang, res1, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, tang, contexts...)
             prepared_valop = @be (mysimilar(res1), prep) $val_and_op!(
                 f, _[1], _[2], ba, x, tang, contexts...
-            )
+            ) seconds = s
             prepared_op = @be (mysimilar(res1), prep) $op!(
                 f, _[1], _[2], ba, x, tang, contexts...
-            )
+            ) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, ba, x, tang, contexts...)
+                preparation = @be $prep_op(f, ba, x, tang, contexts...) seconds = s
                 unprepared_valop = @be mysimilar(res1) $val_and_op!(
                     f, _, ba, x, tang, contexts...
-                )
-                unprepared_op = @be mysimilar(res1) $op!(f, _, ba, x, tang, contexts...)
+                ) seconds = s
+                unprepared_op = @be mysimilar(res1) $op!(f, _, ba, x, tang, contexts...) seconds =
+                    s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -453,7 +459,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S1in; subset::Symbol, s)
             (; f, x, tang, res1, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, tang, contexts...)
@@ -471,7 +477,7 @@ for op in ALL_OPS
             )
         end
 
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S2out; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S2out; subset::Symbol, s)
             (; f, x, y, tang, contexts) = deepcopy(scen)
             prep = $prep_op(f, y, ba, x, tang, contexts...)
             prepared_valop = @be (y, prep) $val_and_op(
@@ -479,9 +485,10 @@ for op in ALL_OPS
             )
             prepared_op = @be (y, prep) $op(f, _[1], _[2], ba, x, tang, contexts...)
             if subset == :full
-                preparation = @be $prep_op(f, y, ba, x, tang, contexts...)
-                unprepared_valop = @be y $val_and_op(f, _, ba, x, tang, contexts...)
-                unprepared_op = @be y $op(f, _, ba, x, tang, contexts...)
+                preparation = @be $prep_op(f, y, ba, x, tang, contexts...) seconds = s
+                unprepared_valop = @be y $val_and_op(f, _, ba, x, tang, contexts...) seconds =
+                    s
+                unprepared_op = @be y $op(f, _, ba, x, tang, contexts...) seconds = s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -494,7 +501,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S2out; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S2out; subset::Symbol, s)
             (; f, x, y, tang, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, y, ba, x, tang, contexts...)
@@ -512,23 +519,23 @@ for op in ALL_OPS
             )
         end
 
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S2in; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S2in; subset::Symbol, s)
             (; f, x, y, tang, res1, contexts) = deepcopy(scen)
             prep = $prep_op(f, y, ba, x, tang, contexts...)
             prepared_valop = @be (y, mysimilar(res1), prep) $val_and_op!(
                 f, _[1], _[2], _[3], ba, x, tang, contexts...
-            )
+            ) seconds = s
             prepared_op = @be (y, mysimilar(res1), prep) $op!(
                 f, _[1], _[2], _[3], ba, x, tang, contexts...
-            )
+            ) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, y, ba, x, tang, contexts...)
+                preparation = @be $prep_op(f, y, ba, x, tang, contexts...) seconds = s
                 unprepared_valop = @be (y, mysimilar(res1)) $val_and_op!(
                     f, _[1], _[2], ba, x, tang, contexts...
-                )
+                ) seconds = s
                 unprepared_op = @be (y, mysimilar(res1)) $op!(
                     f, _[1], _[2], ba, x, tang, contexts...
-                )
+                ) seconds = s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -541,7 +548,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S2in; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S2in; subset::Symbol, s)
             (; f, x, y, tang, res1, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, y, ba, x, tang, contexts...)
@@ -560,15 +567,16 @@ for op in ALL_OPS
         end
 
     elseif op in [:hvp]
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S1out; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S1out; subset::Symbol, s)
             (; f, x, tang, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, tang, contexts...)
-            prepared_valop = @be prep $val_and_op(f, _, ba, x, tang, contexts...)
-            prepared_op = @be prep $op(f, _, ba, x, tang, contexts...)
+            prepared_valop = @be prep $val_and_op(f, _, ba, x, tang, contexts...) seconds =
+                s
+            prepared_op = @be prep $op(f, _, ba, x, tang, contexts...) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, ba, x, tang, contexts...)
-                unprepared_valop = @be $val_and_op(f, ba, x, tang, contexts...)
-                unprepared_op = @be $op(f, ba, x, tang, contexts...)
+                preparation = @be $prep_op(f, ba, x, tang, contexts...) seconds = s
+                unprepared_valop = @be $val_and_op(f, ba, x, tang, contexts...) seconds = s
+                unprepared_op = @be $op(f, ba, x, tang, contexts...) seconds = s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -581,7 +589,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S1out; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S1out; subset::Symbol, s)
             (; f, x, tang, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, tang, contexts...)
@@ -599,21 +607,22 @@ for op in ALL_OPS
             )
         end
 
-        @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
+        @eval function benchmark_aux(ba::AbstractADType, scen::$S1in; subset::Symbol, s)
             (; f, x, tang, res1, res2, contexts) = deepcopy(scen)
             prep = $prep_op(f, ba, x, tang, contexts...)
             prepared_valop = @be (mysimilar(res1), mysimilar(res2), prep) $val_and_op!(
                 f, _[1], _[2], _[3], ba, x, tang, contexts...
-            )
+            ) seconds = s
             prepared_op = @be (mysimilar(res2), prep) $op!(
                 f, _[1], _[2], ba, x, tang, contexts...
-            )
+            ) seconds = s
             if subset == :full
-                preparation = @be $prep_op(f, ba, x, tang, contexts...)
+                preparation = @be $prep_op(f, ba, x, tang, contexts...) seconds = s
                 unprepared_valop = @be (mysimilar(res1), mysimilar(res2)) $val_and_op!(
                     f, _[1], _[2], ba, x, tang, contexts...
-                )
-                unprepared_op = @be mysimilar(res2) $op!(f, _, ba, x, tang, contexts...)
+                ) seconds = s
+                unprepared_op = @be mysimilar(res2) $op!(f, _, ba, x, tang, contexts...) seconds =
+                    s
                 return BenchmarkResult(;
                     prepared_valop,
                     prepared_op,
@@ -626,7 +635,7 @@ for op in ALL_OPS
             end
         end
 
-        @eval function calls_aux(ba::AbstractADType, scen::$S1in; subset::Symbol)
+        @eval function calls_aux(ba::AbstractADType, scen::$S1in; subset::Symbol, s)
             (; f, x, tang, res1, res2, contexts) = deepcopy(scen)
             cc = CallCounter(f)
             prep = $prep_op(cc, ba, x, tang, contexts...)

--- a/DifferentiationInterfaceTest/src/tests/benchmark_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark_eval.jl
@@ -43,6 +43,7 @@ for op in ALL_OPS
         count_calls::Bool,
         benchmark_test::Bool,
         benchmark_seconds::Real,
+        benchmark_aggregation,
     )
         @assert subset in (:full, :prepared)
 
@@ -87,6 +88,7 @@ for op in ALL_OPS
             prepared=true,
             bench=bench_result.prepared_valop,
             calls=calls_result.prepared_valop,
+            aggregation=benchmark_aggregation,
         )
         record!(
             data;
@@ -96,6 +98,7 @@ for op in ALL_OPS
             prepared=true,
             bench=bench_result.prepared_op,
             calls=calls_result.prepared_op,
+            aggregation=benchmark_aggregation,
         )
         if subset == :full
             record!(
@@ -106,6 +109,7 @@ for op in ALL_OPS
                 prepared=nothing,
                 bench=bench_result.preparation,
                 calls=calls_result.preparation,
+                aggregation=benchmark_aggregation,
             )
             record!(
                 data;
@@ -115,6 +119,7 @@ for op in ALL_OPS
                 prepared=false,
                 bench=bench_result.unprepared_valop,
                 calls=calls_result.unprepared_valop,
+                aggregation=benchmark_aggregation,
             )
             record!(
                 data;
@@ -124,6 +129,7 @@ for op in ALL_OPS
                 prepared=false,
                 bench=bench_result.unprepared_op,
                 calls=calls_result.unprepared_op,
+                aggregation=benchmark_aggregation,
             )
         end
         return nothing

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -40,6 +40,7 @@ data1 = benchmark_differentiation(
     benchmark=:full,
     logging=LOGGING,
     benchmark_seconds=0.2,
+    benchmark_aggregation=maximum,
 );
 
 struct FakeBackend <: ADTypes.AbstractADType end

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -31,6 +31,7 @@ data0 = benchmark_differentiation(
     AutoZeroForward(),
     default_scenarios(; include_batchified=false, include_constantified=true);
     logging=LOGGING,
+    benchmark_seconds=0.1,
 );
 
 data1 = benchmark_differentiation(
@@ -38,6 +39,7 @@ data1 = benchmark_differentiation(
     default_scenarios(; include_batchified=false);
     benchmark=:full,
     logging=LOGGING,
+    benchmark_seconds=0.2,
 );
 
 struct FakeBackend <: ADTypes.AbstractADType end


### PR DESCRIPTION
**DIT source**

Add two benchmark-related options to `DIT.test_differentiation` and `DIT.benchmark_differentiation`:

- `benchmark_seconds=1`: duration of each benchmark
- `benchmark_aggregation=minimum`: metric aggregation over samples 