### PR TITLE
fix: enable arbitrary benchmark aggregations

### DIFF
--- a/DifferentiationInterfaceTest/src/tests/benchmark.jl
+++ b/DifferentiationInterfaceTest/src/tests/benchmark.jl
@@ -93,7 +93,6 @@ function record!(
     calls::Integer,
     aggregation,
 )
-    bench_agg = aggregation(bench)
     row = DifferentiationBenchmarkDataRow(;
         backend=backend,
         scenario=scenario,
@@ -101,12 +100,12 @@ function record!(
         prepared=prepared,
         calls=calls,
         samples=length(bench.samples),
-        evals=Int(bench_agg.evals),
-        time=bench_agg.time,
-        allocs=bench_agg.allocs,
-        bytes=bench_agg.bytes,
-        gc_fraction=bench_agg.gc_fraction,
-        compile_fraction=bench_agg.compile_fraction,
+        evals=Int(bench.samples[1].evals),
+        time=aggregation(getfield.(bench.samples, :time)),
+        allocs=aggregation(getfield.(bench.samples, :allocs)),
+        bytes=aggregation(getfield.(bench.samples, :bytes)),
+        gc_fraction=aggregation(getfield.(bench.samples, :gc_fraction)),
+        compile_fraction=aggregation(getfield.(bench.samples, :compile_fraction)),
     )
     return push!(data, row)
 end


### PR DESCRIPTION
**DIT source**

- Replace `aggregation(benchmark)` with `aggregation(getfield.(benchmark.samples, :time))` so that it works beyond the aggregators that Chairmarks extends. For instance, one can now include uncertainty in the measurements, like so:

```julia
julia> using DifferentiationInterface, DifferentiationInterfaceTest, Measurements, Statistics

julia> import ForwardDiff

julia> scen = Scenario{:gradient, :out}(sum, rand(1000));

julia> backends = [AutoForwardDiff(; chunksize=1), AutoForwardDiff(; chunksize=10)];

julia> data = benchmark_differentiation(backends, [scen]; benchmark_aggregation=x -> mean(x) ± std(x))
Test Summary:                   | Pass  Total  Time
Testing benchmarks              |    4      4  4.6s
  AutoForwardDiff(chunksize=1)  |    2      2  2.3s
  AutoForwardDiff(chunksize=10) |    2      2  2.3s
4×12 DataFrame
 Row │ backend                        scenario                           operator            prepared  calls  samples  evals  time             allocs     bytes       gc_fraction    compile_fract ⋯
     │ AutoForw…                      Scenario…                          Symbol              Bool      Int64  Int64    Int64  Measurem…        Measurem…  Measurem…   Measurem…      Measurem…     ⋯
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   1 │ AutoForwardDiff(chunksize=1)   Scenario{:gradient,:out} sum : V…  value_and_gradient      true   1000      651      1  0.00146±0.00046    4.0±0.0  8096.0±0.0  0.0014±0.035            0.0± ⋯
   2 │ AutoForwardDiff(chunksize=1)   Scenario{:gradient,:out} sum : V…  gradient                true   1000      694      1  0.00137±9.2e-5     3.0±0.0  8064.0±0.0  0.0±0.0                 0.0±
   3 │ AutoForwardDiff(chunksize=10)  Scenario{:gradient,:out} sum : V…  value_and_gradient      true    100     4212      1  0.00022±0.00016    4.0±0.0  8096.0±0.0  0.00046±0.021           0.0±
   4 │ AutoForwardDiff(chunksize=10)  Scenario{:gradient,:out} sum : V…  gradient                true    100     4150      1  0.000227±5.1e-5    3.0±0.0  8064.0±0.0  0.00043±0.019           0.0±
                          
```