### PR TITLE
fix: handle static arrays with Mooncake

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/DifferentiationInterfaceMooncakeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/DifferentiationInterfaceMooncakeExt.jl
@@ -26,7 +26,7 @@ using Mooncake:
 DI.check_available(::AutoMooncake) = true
 
 copyto!!(dst::Number, src::Number) = convert(typeof(dst), src)
-copyto!!(dst, src) = copyto!(dst, src)
+copyto!!(dst, src) = DI.ismutable_array(dst) ? copyto!(dst, src) : convert(typeof(dst), src)
 
 get_config(::AutoMooncake{Nothing}) = Config()
 get_config(backend::AutoMooncake{<:Config}) = backend.config


### PR DESCRIPTION
Fixes #642 

**DI ext**

- Mooncake: refine `copyto!!` to use the check `DI.ismutable_array`