### PR TITLE
Relax type annotations in sparse prep

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/hessian.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/hessian.jl
@@ -1,7 +1,7 @@
 struct SparseHessianPrep{
     BS<:BatchSizeSettings,
     C<:AbstractColoringResult{:symmetric,:column},
-    M<:AbstractMatrix{<:Real},
+    M<:AbstractMatrix{<:Number},
     S<:AbstractVector{<:NTuple},
     R<:AbstractVector{<:NTuple},
     E2<:HVPPrep,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian.jl
@@ -3,7 +3,7 @@
 struct PushforwardSparseJacobianPrep{
     BS<:BatchSizeSettings,
     C<:AbstractColoringResult{:nonsymmetric,:column},
-    M<:AbstractMatrix{<:Real},
+    M<:AbstractMatrix{<:Number},
     S<:AbstractVector{<:NTuple},
     R<:AbstractVector{<:NTuple},
     E<:PushforwardPrep,
@@ -19,7 +19,7 @@ end
 struct PullbackSparseJacobianPrep{
     BS<:BatchSizeSettings,
     C<:AbstractColoringResult{:nonsymmetric,:row},
-    M<:AbstractMatrix{<:Real},
+    M<:AbstractMatrix{<:Number},
     S<:AbstractVector{<:NTuple},
     R<:AbstractVector{<:NTuple},
     E<:PullbackPrep,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian_mixed.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian_mixed.jl
@@ -4,7 +4,7 @@ struct MixedModeSparseJacobianPrep{
     BSf<:BatchSizeSettings,
     BSr<:BatchSizeSettings,
     C<:AbstractColoringResult{:nonsymmetric,:bidirectional},
-    M<:AbstractMatrix{<:Real},
+    M<:AbstractMatrix{<:Number},
     Sf<:Vector{<:NTuple},
     Sr<:Vector{<:NTuple},
     Rf<:Vector{<:NTuple},

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -3,6 +3,7 @@ Pkg.add("FiniteDiff")
 
 using DifferentiationInterface, DifferentiationInterfaceTest
 using FiniteDiff: FiniteDiff
+using SparseMatrixColorings
 using Test
 
 LOGGING = get(ENV, "CI", "false") == "false"
@@ -18,3 +19,11 @@ test_differentiation(
     excluded=[:second_derivative, :hvp],
     logging=LOGGING,
 );
+
+@testset verbose = true "Complex number support" begin
+    backend = AutoSparse(AutoFiniteDiff(); coloring_algorithm=GreedyColoringAlgorithm())
+    x = float.(1:3) .+ im
+    @test_nowarn jacobian(identity, backend, x)
+    @test_nowarn jacobian(copyto!, similar(x), backend, x)
+    @test_nowarn hessian(sum, backend, x)
+end

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -100,5 +100,5 @@ end;
         coloring_algorithm=ConstantColoringAlgorithm(ones(3, 3), ones(Int64, 3)),
     )
     u1 = [2.0; 2.0; 3.0] .+ 1im
-    @test_nowarn DI.prepare_jacobian(loss, similar(u1), backend, u1)
+    @test_nowarn DI.prepare_jacobian(nothing, similar(u1), backend, u1)
 end

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -1,10 +1,12 @@
 using Pkg
 Pkg.add("ForwardDiff")
 
+using ADTypes: ADTypes
 using ComponentArrays: ComponentArrays
 using DifferentiationInterface, DifferentiationInterfaceTest
 import DifferentiationInterfaceTest as DIT
 using ForwardDiff: ForwardDiff
+using SparseMatrixColorings: ConstantColoringAlgorithm
 using StaticArrays: StaticArrays
 using Test
 
@@ -88,3 +90,15 @@ test_differentiation(AutoForwardDiff(), static_scenarios(); logging=LOGGING)
         end
     end
 end;
+
+# Complex number support
+
+@testset verbose = true "Complex number support" begin
+    backend = AutoSparse(
+        AutoForwardDiff();
+        sparsity_detector=ADTypes.KnownJacobianSparsityDetector(ones(3, 3)),
+        coloring_algorithm=ConstantColoringAlgorithm(ones(3, 3), ones(Int64, 3)),
+    )
+    u1 = [2.0; 2.0; 3.0] .+ 1im
+    @test_nowarn DI.prepare_jacobian(loss, similar(u1), backend, u1)
+end

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -6,7 +6,6 @@ using ComponentArrays: ComponentArrays
 using DifferentiationInterface, DifferentiationInterfaceTest
 import DifferentiationInterfaceTest as DIT
 using ForwardDiff: ForwardDiff
-using SparseMatrixColorings: ConstantColoringAlgorithm
 using StaticArrays: StaticArrays
 using Test
 
@@ -90,15 +89,3 @@ test_differentiation(AutoForwardDiff(), static_scenarios(); logging=LOGGING)
         end
     end
 end;
-
-# Complex number support
-
-@testset verbose = true "Complex number support" begin
-    backend = AutoSparse(
-        AutoForwardDiff();
-        sparsity_detector=ADTypes.KnownJacobianSparsityDetector(ones(3, 3)),
-        coloring_algorithm=ConstantColoringAlgorithm(ones(3, 3), ones(Int64, 3)),
-    )
-    u1 = [2.0; 2.0; 3.0] .+ 1im
-    @test_nowarn DI.prepare_jacobian(nothing, similar(u1), backend, u1)
-end


### PR DESCRIPTION
Part of #646 

Relax type annotations of the compressed matrix from `AbstractMatrix{<:Real}` to `AbstractMatrix{<:Number}` in `PushforwardSparseJacobianPrep`, `PullbackSparseJacobianPrep`, `SparseHessianPrep` and `MixedModeSparseJacobianPrep` to support sparse Jacobian/Hessian preparation for complex numbers.

The test case for this PR is adapted from MWE,  so need some advice on this.