### PR TITLE
docs: specify complex number support and same type preparation

### DIFF
--- a/DifferentiationInterface/docs/make.jl
+++ b/DifferentiationInterface/docs/make.jl
@@ -30,6 +30,7 @@ makedocs(;
             "explanation/operators.md",
             "explanation/backends.md",
             "explanation/advanced.md",
+            "explanation/faq.md",
         ],
         "api.md",
         "dev_guide.md",

--- a/DifferentiationInterface/docs/src/explanation/faq.md
+++ b/DifferentiationInterface/docs/src/explanation/faq.md
@@ -1,0 +1,6 @@
+# FAQ
+
+## Complex numbers
+
+At the moment, complex numbers are only handled by a few AD backends, sometimes using different conventions.
+As a result, DifferentiationInterface is only tested on real numbers and complex number support is not part of its API guarantees.


### PR DESCRIPTION
**DI docs**

- Add FAQ page containing an entry on complex number support (see #646)
- Clarify the rules of preparation reuse, warn explicitly against using different types (fixes #633)