### PR TITLE
test: only run Core tests upon `pkg> test`

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -103,4 +103,21 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "ExplicitImports", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StableRNGs", "StaticArrays", "Test", "Zygote"]
+test = [
+    "ADTypes",
+    "Aqua",
+    "ComponentArrays",
+    "DataFrames",
+    "ExplicitImports",
+    "JET",
+    "JLArrays",
+    "JuliaFormatter",
+    "Pkg",
+    "Random",
+    "SparseArrays",
+    "SparseConnectivityTracer",
+    "SparseMatrixColorings",
+    "StableRNGs",
+    "StaticArrays",
+    "Test",
+]

--- a/DifferentiationInterface/test/Core/Internals/display.jl
+++ b/DifferentiationInterface/test/Core/Internals/display.jl
@@ -3,16 +3,14 @@ using DifferentiationInterface
 using Test
 
 backend = SecondOrder(AutoForwardDiff(), AutoZygote())
-@test startswith(string(backend), "SecondOrder(")
-@test endswith(string(backend), ")")
+@test string(backend) == "SecondOrder(AutoForwardDiff(), AutoZygote())"
 
 detector = DenseSparsityDetector(AutoForwardDiff(); atol=1e-23)
-@test startswith(string(detector), "DenseSparsityDetector(")
-@test endswith(string(detector), ")")
+@test string(detector) ==
+    "DenseSparsityDetector(AutoForwardDiff(); atol=1.0e-23, method=:iterative)"
 
 diffwith = DifferentiateWith(exp, AutoForwardDiff())
-@test startswith(string(diffwith), "DifferentiateWith(")
-@test endswith(string(diffwith), ")")
+@test string(diffwith) == "DifferentiateWith(exp, AutoForwardDiff())"
 
 @test DifferentiationInterface.package_name(AutoForwardDiff()) == "ForwardDiff"
 @test DifferentiationInterface.package_name(AutoZygote()) == "Zygote"

--- a/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
@@ -35,44 +35,44 @@ end
 
 ## Dense scenarios
 
-test_differentiation(
-    vcat(backends, second_order_backends),
-    default_scenarios(; include_constantified=true);
-    logging=LOGGING,
-);
+@testset "Dense" begin
+    test_differentiation(
+        vcat(backends, second_order_backends),
+        default_scenarios(; include_constantified=true);
+        logging=LOGGING,
+    )
+end
 
-## Sparse scenarios
-
-test_differentiation(
-    MyAutoSparse.(adaptive_backends),
-    default_scenarios(; include_constantified=true);
-    logging=LOGGING,
-);
-
-test_differentiation(
-    MyAutoSparse.(
-        vcat(adaptive_backends, MixedMode(adaptive_backends[1], adaptive_backends[2]))
-    ),
-    sparse_scenarios(; include_constantified=true);
-    sparsity=true,
-    logging=LOGGING,
-);
-
-## Misc
-
-@testset "SparseMatrixColorings access" begin
-    jac_for_prep = prepare_jacobian(copy, MyAutoSparse(adaptive_backends[1]), rand(10))
-    jac_rev_prep = prepare_jacobian(copy, MyAutoSparse(adaptive_backends[2]), rand(10))
-    hess_prep = prepare_hessian(
-        x -> sum(abs2, x), MyAutoSparse(adaptive_backends[1]), rand(10)
+@testset "Sparse" begin
+    test_differentiation(
+        MyAutoSparse.(adaptive_backends),
+        default_scenarios(; include_constantified=true);
+        logging=LOGGING,
     )
 
-    @test all(==(1), column_colors(jac_for_prep))
-    @test all(==(1), row_colors(jac_rev_prep))
-    @test all(==(1), column_colors(hess_prep))
-    @test ncolors(jac_for_prep) == 1
-    @test ncolors(hess_prep) == 1
-    @test only(column_groups(jac_for_prep)) == 1:10
-    @test only(row_groups(jac_rev_prep)) == 1:10
-    @test only(column_groups(hess_prep)) == 1:10
+    test_differentiation(
+        MyAutoSparse.(
+            vcat(adaptive_backends, MixedMode(adaptive_backends[1], adaptive_backends[2]))
+        ),
+        sparse_scenarios(; include_constantified=true);
+        sparsity=true,
+        logging=LOGGING,
+    )
+
+    @testset "SparseMatrixColorings access" begin
+        jac_for_prep = prepare_jacobian(copy, MyAutoSparse(adaptive_backends[1]), rand(10))
+        jac_rev_prep = prepare_jacobian(copy, MyAutoSparse(adaptive_backends[2]), rand(10))
+        hess_prep = prepare_hessian(
+            x -> sum(abs2, x), MyAutoSparse(adaptive_backends[1]), rand(10)
+        )
+
+        @test all(==(1), column_colors(jac_for_prep))
+        @test all(==(1), row_colors(jac_rev_prep))
+        @test all(==(1), column_colors(hess_prep))
+        @test ncolors(jac_for_prep) == 1
+        @test ncolors(hess_prep) == 1
+        @test only(column_groups(jac_for_prep)) == 1:10
+        @test only(row_groups(jac_rev_prep)) == 1:10
+        @test only(column_groups(hess_prep)) == 1:10
+    end
 end

--- a/DifferentiationInterface/test/Core/ZeroBackends/test.jl
+++ b/DifferentiationInterface/test/Core/ZeroBackends/test.jl
@@ -16,56 +16,51 @@ for backend in zero_backends
     @test check_inplace(backend)
 end
 
-## Type stability
+@testset "Type stability" begin
+    test_differentiation(
+        AutoZeroForward(),
+        default_scenarios(; include_batchified=false, include_constantified=true);
+        correctness=false,
+        type_stability=:full,
+        logging=LOGGING,
+    )
 
-test_differentiation(
-    AutoZeroForward(),
-    default_scenarios(; include_batchified=false, include_constantified=true);
-    correctness=false,
-    type_stability=:full,
-    logging=LOGGING,
-)
+    test_differentiation(
+        AutoZeroReverse(),
+        default_scenarios(; include_batchified=false, include_constantified=true);
+        correctness=false,
+        type_stability=:full,
+        logging=LOGGING,
+    )
 
-test_differentiation(
-    AutoZeroReverse(),
-    default_scenarios(; include_batchified=false, include_constantified=true);
-    correctness=false,
-    type_stability=:full,
-    logging=LOGGING,
-)
+    test_differentiation(
+        [
+            SecondOrder(AutoZeroForward(), AutoZeroReverse()),
+            SecondOrder(AutoZeroReverse(), AutoZeroForward()),
+        ],
+        default_scenarios(; include_batchified=false, include_constantified=true);
+        correctness=false,
+        type_stability=:full,
+        logging=LOGGING,
+    )
 
-test_differentiation(
-    [
-        SecondOrder(AutoZeroForward(), AutoZeroReverse()),
-        SecondOrder(AutoZeroReverse(), AutoZeroForward()),
-    ],
-    default_scenarios(; include_batchified=false, include_constantified=true);
-    correctness=false,
-    type_stability=:full,
-    logging=LOGGING,
-)
+    test_differentiation(
+        AutoSparse.(zero_backends, coloring_algorithm=GreedyColoringAlgorithm()),
+        default_scenarios(; include_constantified=true);
+        correctness=false,
+        type_stability=:full,
+        excluded=[
+            :pushforward, :pullback, :gradient, :derivative, :hvp, :second_derivative
+        ],
+        logging=LOGGING,
+    )
+end
 
-test_differentiation(
-    AutoSparse.(zero_backends, coloring_algorithm=GreedyColoringAlgorithm()),
-    default_scenarios(; include_constantified=true);
-    correctness=false,
-    type_stability=:full,
-    excluded=[:pushforward, :pullback, :gradient, :derivative, :hvp, :second_derivative],
-    logging=LOGGING,
-)
-
-## Weird arrays
-
-test_differentiation(
-    [AutoZeroForward(), AutoZeroReverse()],
-    zero.(vcat(component_scenarios(), static_scenarios()));
-    correctness=true,
-    logging=LOGGING,
-)
-
-test_differentiation(
-    [AutoZeroForward(), AutoZeroReverse()],
-    zero.(gpu_scenarios());
-    correctness=true,
-    logging=LOGGING,
-)
+@testset "Weird arrays" begin
+    test_differentiation(
+        [AutoZeroForward(), AutoZeroReverse()],
+        zero.(vcat(component_scenarios(), static_scenarios(), gpu_scenarios()));
+        correctness=true,
+        logging=LOGGING,
+    )
+end

--- a/DifferentiationInterface/test/testutils.jl
+++ b/DifferentiationInterface/test/testutils.jl
@@ -1,0 +1,11 @@
+using ADTypes
+using SparseConnectivityTracer
+using SparseMatrixColorings
+
+function MyAutoSparse(backend::AbstractADType)
+    return AutoSparse(
+        backend;
+        sparsity_detector=TracerSparsityDetector(),
+        coloring_algorithm=GreedyColoringAlgorithm(),
+    )
+end


### PR DESCRIPTION
**DI tests**

- Remove all backend-specific dependencies and code from test env
- Upon `pkg> test`, only run the `Core` category of tests instead of every single backend and downstream test suite