### PR TITLE
fix: disallow complex basis vectors for now

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.28"
+version = "0.6.29"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/DifferentiationInterfaceReverseDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReverseDiffExt/DifferentiationInterfaceReverseDiffExt.jl
@@ -26,7 +26,7 @@ using ReverseDiff:
 
 DI.check_available(::AutoReverseDiff) = true
 
-function DI.basis(::AutoReverseDiff, a::AbstractArray{T}, i) where {T}
+function DI.basis(::AutoReverseDiff, a::AbstractArray{T}, i) where {T<:Real}
     return DI.OneElement(i, one(T), a)
 end
 

--- a/DifferentiationInterface/src/first_order/derivative.jl
+++ b/DifferentiationInterface/src/first_order/derivative.jl
@@ -74,14 +74,14 @@ end
 function prepare_derivative(
     f::F, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    pushforward_prep = prepare_pushforward(f, backend, x, (one(x),), contexts...)
+    pushforward_prep = prepare_pushforward(f, backend, x, (realone(x),), contexts...)
     return PushforwardDerivativePrep(pushforward_prep)
 end
 
 function prepare_derivative(
     f!::F, y, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    pushforward_prep = prepare_pushforward(f!, y, backend, x, (one(x),), contexts...)
+    pushforward_prep = prepare_pushforward(f!, y, backend, x, (realone(x),), contexts...)
     return PushforwardDerivativePrep(pushforward_prep)
 end
 
@@ -95,7 +95,7 @@ function value_and_derivative(
     contexts::Vararg{Context,C},
 ) where {F,C}
     y, ty = value_and_pushforward(
-        f, prep.pushforward_prep, backend, x, (one(x),), contexts...
+        f, prep.pushforward_prep, backend, x, (realone(x),), contexts...
     )
     return y, only(ty)
 end
@@ -109,7 +109,7 @@ function value_and_derivative!(
     contexts::Vararg{Context,C},
 ) where {F,C}
     y, _ = value_and_pushforward!(
-        f, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...
+        f, (der,), prep.pushforward_prep, backend, x, (realone(x),), contexts...
     )
     return y, der
 end
@@ -121,7 +121,7 @@ function derivative(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    ty = pushforward(f, prep.pushforward_prep, backend, x, (one(x),), contexts...)
+    ty = pushforward(f, prep.pushforward_prep, backend, x, (realone(x),), contexts...)
     return only(ty)
 end
 
@@ -133,7 +133,7 @@ function derivative!(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    pushforward!(f, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...)
+    pushforward!(f, (der,), prep.pushforward_prep, backend, x, (realone(x),), contexts...)
     return der
 end
 
@@ -148,7 +148,7 @@ function value_and_derivative(
     contexts::Vararg{Context,C},
 ) where {F,C}
     y, ty = value_and_pushforward(
-        f!, y, prep.pushforward_prep, backend, x, (one(x),), contexts...
+        f!, y, prep.pushforward_prep, backend, x, (realone(x),), contexts...
     )
     return y, only(ty)
 end
@@ -163,7 +163,7 @@ function value_and_derivative!(
     contexts::Vararg{Context,C},
 ) where {F,C}
     y, _ = value_and_pushforward!(
-        f!, y, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...
+        f!, y, (der,), prep.pushforward_prep, backend, x, (realone(x),), contexts...
     )
     return y, der
 end
@@ -176,7 +176,7 @@ function derivative(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    ty = pushforward(f!, y, prep.pushforward_prep, backend, x, (one(x),), contexts...)
+    ty = pushforward(f!, y, prep.pushforward_prep, backend, x, (realone(x),), contexts...)
     return only(ty)
 end
 
@@ -189,7 +189,9 @@ function derivative!(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    pushforward!(f!, y, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...)
+    pushforward!(
+        f!, y, (der,), prep.pushforward_prep, backend, x, (realone(x),), contexts...
+    )
     return der
 end
 

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -1,10 +1,10 @@
 abstract type FromPrimitive <: AbstractADType end
 
-function basis(fromprim::FromPrimitive, x::AbstractArray, i)
+function basis(fromprim::FromPrimitive, x::AbstractArray{<:Real}, i)
     return basis(fromprim.backend, x, i)
 end
 
-function multibasis(fromprim::FromPrimitive, x::AbstractArray, inds)
+function multibasis(fromprim::FromPrimitive, x::AbstractArray{<:Real}, inds)
     return multibasis(fromprim.backend, x, inds)
 end
 

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -11,7 +11,7 @@ end
 check_available(fromprim::FromPrimitive) = check_available(fromprim.backend)
 inplace_support(fromprim::FromPrimitive) = inplace_support(fromprim.backend)
 
-function BatchSizeSettings(fromprim::FromPrimitive, x::AbstractArray)
+function BatchSizeSettings(fromprim::FromPrimitive, x::AbstractArray{<:Real})
     return BatchSizeSettings(fromprim.backend, x)
 end
 

--- a/DifferentiationInterface/src/utils/basis.jl
+++ b/DifferentiationInterface/src/utils/basis.jl
@@ -46,7 +46,7 @@ Construct the `i`-th standard basis array in the vector space of `a` with elemen
 If an AD backend benefits from a more specialized basis array implementation,
 this function can be extended on the backend type.
 """
-basis(::AbstractADType, a::AbstractArray, i) = basis(a, i)
+basis(::AbstractADType, a::AbstractArray{<:Real}, i) = basis(a, i)
 
 """
     multibasis(backend, a::AbstractArray, inds::AbstractVector)
@@ -58,16 +58,18 @@ Construct the sum of the `i`-th standard basis arrays in the vector space of `a`
 If an AD backend benefits from a more specialized basis array implementation,
 this function can be extended on the backend type.
 """
-multibasis(::AbstractADType, a::AbstractArray, inds) = multibasis(a, inds)
+multibasis(::AbstractADType, a::AbstractArray{<:Real}, inds) = multibasis(a, inds)
 
-function basis(a::AbstractArray{T,N}, i) where {T,N}
+function basis(a::AbstractArray{T,N}, i) where {T<:Real,N}
     return zero(a) + OneElement(i, one(T), a)
 end
 
-function multibasis(a::AbstractArray{T,N}, inds::AbstractVector) where {T,N}
+function multibasis(a::AbstractArray{T,N}, inds::AbstractVector) where {T<:Real,N}
     seed = zero(a)
     for i in inds
         seed += OneElement(i, one(T), a)
     end
     return seed
 end
+
+realone(x::Real) = one(x)

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -26,7 +26,7 @@ test_differentiation(
 @testset verbose = true "Complex number support" begin
     backend = AutoSparse(AutoFiniteDiff(); coloring_algorithm=GreedyColoringAlgorithm())
     x = float.(1:3) .+ im
-    @test_nowarn jacobian(identity, backend, x)
-    @test_nowarn jacobian(copyto!, similar(x), backend, x)
-    @test_nowarn hessian(sum, backend, x)
+    @test_skip @test_nowarn jacobian(identity, backend, x)
+    @test_skip @test_nowarn jacobian(copyto!, similar(x), backend, x)
+    @test_skip @test_nowarn hessian(sum, backend, x)
 end


### PR DESCRIPTION
- Only allow creation of basis arrays when the `eltype` is a subtype of `Real`
- Enforce that the `pushforward` fallback for `derivative` applied to `Real` inputs