### PR TITLE
Fix typo for `gradient` in docs

### DIFF
--- a/DifferentiationInterface/docs/src/explanation/operators.md
+++ b/DifferentiationInterface/docs/src/explanation/operators.md
@@ -27,7 +27,7 @@ These operators are computed using only the input `x`.
 | :-------------------------- | :---- | :-------------- | :-------------- | :------------------- | :----------------------- |
 | [`derivative`](@ref)        | 1     | `Number`        | `Any`           | similar to `y`       | `size(y)`                |
 | [`second_derivative`](@ref) | 2     | `Number`        | `Any`           | similar to `y`       | `size(y)`                |
-| [`gradient`](@ref)          | 1     | `Any`           | `Number`        | similar to `x`       | `size(x)`                |
+| [`gradient`](@ref)          | 1     | `AbstractArray` | `Number`        | similar to `x`       | `size(x)`                |
 | [`jacobian`](@ref)          | 1     | `AbstractArray` | `AbstractArray` | `AbstractMatrix`     | `(length(y), length(x))` |
 | [`hessian`](@ref)           | 2     | `AbstractArray` | `Number`        | `AbstractMatrix`     | `(length(x), length(x))` |
 


### PR DESCRIPTION
This fixes a minor typo in the docs for `gradient`, as it must take an array and not `Any`, e.g.
```julia
julia> gradient(x->sin(x), AutoForwardDiff(), 1)
ERROR: DimensionMismatch: gradient(f, x) expects that x is an array. Perhaps you meant derivative(f, x)?
Stacktrace:
 [1] gradient(f::Function, x::Int64)
   @ ForwardDiff ~/.julia/packages/ForwardDiff/UBbGT/src/gradient.jl:46
 [2] gradient(::var"#1#2", ::AutoForwardDiff{nothing, Nothing}, ::Int64)
   @ DifferentiationInterfaceForwardDiffExt ~/.julia/dev/DifferentiationInterface/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl:295
 [3] top-level scope
   @ REPL[5]:1
```