### PR TITLE
feat: allow and test holomorphic derivatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.csv
 
 playground.jl
+.vscode

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.30"
+version = "0.6.31"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/docs/src/faq/limitations.md
+++ b/DifferentiationInterface/docs/src/faq/limitations.md
@@ -7,5 +7,7 @@ As a result, DifferentiationInterface only supports a single active argument, ca
 
 ## Complex numbers
 
-At the moment, complex numbers are only handled by a few AD backends, sometimes using different conventions.
-As a result, DifferentiationInterface is only tested on real numbers and complex number support is not part of its API guarantees.
+Complex derivatives are only handled by a few AD backends, sometimes using different conventions.
+To find the easiest common ground, DifferentiationInterface assumes that whenever complex numbers are involved, the function to differentiate is holomorphic.
+This functionality is still considered experimental and not yet part of the public API guarantees.
+If you work with non-holomorphic functions, you will need to manually separate real and imaginary parts.

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian.jl
@@ -319,6 +319,9 @@ function _sparse_jacobian_aux!(
         )
 
         for b in eachindex(batched_results[a])
+            if eltype(x) <: Complex
+                batched_results[a][b] .= conj.(batched_results[a][b])
+            end
             copyto!(
                 view(compressed_matrix, 1 + ((a - 1) * B + (b - 1)) % N, :),
                 vec(batched_results[a][b]),

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian_mixed.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseMatrixColoringsExt/jacobian_mixed.jl
@@ -220,6 +220,9 @@ function _sparse_jacobian_aux!(
         )
 
         for b in eachindex(batched_results_reverse[a])
+            if eltype(x) <: Complex
+                batched_results_reverse[a][b] .= conj.(batched_results_reverse[a][b])
+            end
             copyto!(
                 view(compressed_matrix_reverse, 1 + ((a - 1) * Br + (b - 1)) % Nr, :),
                 vec(batched_results_reverse[a][b]),

--- a/DifferentiationInterface/src/first_order/derivative.jl
+++ b/DifferentiationInterface/src/first_order/derivative.jl
@@ -74,14 +74,14 @@ end
 function prepare_derivative(
     f::F, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    pushforward_prep = prepare_pushforward(f, backend, x, (realone(x),), contexts...)
+    pushforward_prep = prepare_pushforward(f, backend, x, (one(x),), contexts...)
     return PushforwardDerivativePrep(pushforward_prep)
 end
 
 function prepare_derivative(
     f!::F, y, backend::AbstractADType, x, contexts::Vararg{Context,C}
 ) where {F,C}
-    pushforward_prep = prepare_pushforward(f!, y, backend, x, (realone(x),), contexts...)
+    pushforward_prep = prepare_pushforward(f!, y, backend, x, (one(x),), contexts...)
     return PushforwardDerivativePrep(pushforward_prep)
 end
 
@@ -95,7 +95,7 @@ function value_and_derivative(
     contexts::Vararg{Context,C},
 ) where {F,C}
     y, ty = value_and_pushforward(
-        f, prep.pushforward_prep, backend, x, (realone(x),), contexts...
+        f, prep.pushforward_prep, backend, x, (one(x),), contexts...
     )
     return y, only(ty)
 end
@@ -109,7 +109,7 @@ function value_and_derivative!(
     contexts::Vararg{Context,C},
 ) where {F,C}
     y, _ = value_and_pushforward!(
-        f, (der,), prep.pushforward_prep, backend, x, (realone(x),), contexts...
+        f, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...
     )
     return y, der
 end
@@ -121,7 +121,7 @@ function derivative(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    ty = pushforward(f, prep.pushforward_prep, backend, x, (realone(x),), contexts...)
+    ty = pushforward(f, prep.pushforward_prep, backend, x, (one(x),), contexts...)
     return only(ty)
 end
 
@@ -133,7 +133,7 @@ function derivative!(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    pushforward!(f, (der,), prep.pushforward_prep, backend, x, (realone(x),), contexts...)
+    pushforward!(f, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...)
     return der
 end
 
@@ -148,7 +148,7 @@ function value_and_derivative(
     contexts::Vararg{Context,C},
 ) where {F,C}
     y, ty = value_and_pushforward(
-        f!, y, prep.pushforward_prep, backend, x, (realone(x),), contexts...
+        f!, y, prep.pushforward_prep, backend, x, (one(x),), contexts...
     )
     return y, only(ty)
 end
@@ -163,7 +163,7 @@ function value_and_derivative!(
     contexts::Vararg{Context,C},
 ) where {F,C}
     y, _ = value_and_pushforward!(
-        f!, y, (der,), prep.pushforward_prep, backend, x, (realone(x),), contexts...
+        f!, y, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...
     )
     return y, der
 end
@@ -176,7 +176,7 @@ function derivative(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    ty = pushforward(f!, y, prep.pushforward_prep, backend, x, (realone(x),), contexts...)
+    ty = pushforward(f!, y, prep.pushforward_prep, backend, x, (one(x),), contexts...)
     return only(ty)
 end
 
@@ -189,9 +189,7 @@ function derivative!(
     x,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    pushforward!(
-        f!, y, (der,), prep.pushforward_prep, backend, x, (realone(x),), contexts...
-    )
+    pushforward!(f!, y, (der,), prep.pushforward_prep, backend, x, (one(x),), contexts...)
     return der
 end
 

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -157,7 +157,7 @@ function _pullback_via_pushforward(
 ) where {F,C}
     t1 = pushforward(f, pushforward_prep, backend, x, (one(x),), contexts...)
     dx = dot(dy, only(t1))
-    return dx
+    return conj(dx)
 end
 
 function _pullback_via_pushforward(
@@ -170,7 +170,7 @@ function _pullback_via_pushforward(
 ) where {F,C}
     dx = map(CartesianIndices(x)) do j
         t1 = pushforward(f, pushforward_prep, backend, x, (basis(backend, x, j),), contexts...)
-        dot(dy, only(t1))
+        conj(dot(dy, only(t1)))
     end
     return dx
 end
@@ -241,7 +241,7 @@ function _pullback_via_pushforward(
     contexts::Vararg{Context,C},
 ) where {F,C}
     t1 = pushforward(f!, y, pushforward_prep, backend, x, (one(x),), contexts...)
-    dx = dot(dy, only(t1))
+    dx = conj(dot(dy, only(t1)))
     return dx
 end
 
@@ -258,7 +258,7 @@ function _pullback_via_pushforward(
         t1 = pushforward(
             f!, y, pushforward_prep, backend, x, (basis(backend, x, j),), contexts...
         )
-        dot(dy, only(t1))
+        conj(dot(dy, only(t1)))
     end
     return dx
 end

--- a/DifferentiationInterface/src/first_order/pullback.jl
+++ b/DifferentiationInterface/src/first_order/pullback.jl
@@ -156,8 +156,8 @@ function _pullback_via_pushforward(
     contexts::Vararg{Context,C},
 ) where {F,C}
     t1 = pushforward(f, pushforward_prep, backend, x, (one(x),), contexts...)
-    dx = dot(dy, only(t1))
-    return conj(dx)
+    dx = dot(only(t1), dy)
+    return dx
 end
 
 function _pullback_via_pushforward(
@@ -170,7 +170,7 @@ function _pullback_via_pushforward(
 ) where {F,C}
     dx = map(CartesianIndices(x)) do j
         t1 = pushforward(f, pushforward_prep, backend, x, (basis(backend, x, j),), contexts...)
-        conj(dot(dy, only(t1)))
+        dot(only(t1), dy)
     end
     return dx
 end
@@ -241,7 +241,7 @@ function _pullback_via_pushforward(
     contexts::Vararg{Context,C},
 ) where {F,C}
     t1 = pushforward(f!, y, pushforward_prep, backend, x, (one(x),), contexts...)
-    dx = conj(dot(dy, only(t1)))
+    dx = dot(only(t1), dy)
     return dx
 end
 
@@ -258,7 +258,7 @@ function _pullback_via_pushforward(
         t1 = pushforward(
             f!, y, pushforward_prep, backend, x, (basis(backend, x, j),), contexts...
         )
-        conj(dot(dy, only(t1)))
+        dot(only(t1), dy)
     end
     return dx
 end

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -158,7 +158,7 @@ function _pushforward_via_pullback(
     contexts::Vararg{Context,C},
 ) where {F,C}
     t1 = pullback(f, pullback_prep, backend, x, (one(y),), contexts...)
-    dy = conj(dot(dx, only(t1)))
+    dy = dot(only(t1), dx)
     return dy
 end
 
@@ -173,7 +173,7 @@ function _pushforward_via_pullback(
 ) where {F,C}
     dy = map(CartesianIndices(y)) do i
         t1 = pullback(f, pullback_prep, backend, x, (basis(backend, y, i),), contexts...)
-        conj(dot(dx, only(t1)))
+        dot(only(t1), dx)
     end
     return dy
 end
@@ -245,7 +245,7 @@ function _pushforward_via_pullback(
 ) where {F,C}
     dy = map(CartesianIndices(y)) do i  # preserve shape
         t1 = pullback(f!, y, pullback_prep, backend, x, (basis(backend, y, i),), contexts...)
-        conj(dot(dx, only(t1)))
+        dot(only(t1), dx)
     end
     return dy
 end

--- a/DifferentiationInterface/src/first_order/pushforward.jl
+++ b/DifferentiationInterface/src/first_order/pushforward.jl
@@ -158,7 +158,7 @@ function _pushforward_via_pullback(
     contexts::Vararg{Context,C},
 ) where {F,C}
     t1 = pullback(f, pullback_prep, backend, x, (one(y),), contexts...)
-    dy = dot(dx, only(t1))
+    dy = conj(dot(dx, only(t1)))
     return dy
 end
 
@@ -173,7 +173,7 @@ function _pushforward_via_pullback(
 ) where {F,C}
     dy = map(CartesianIndices(y)) do i
         t1 = pullback(f, pullback_prep, backend, x, (basis(backend, y, i),), contexts...)
-        dot(dx, only(t1))
+        conj(dot(dx, only(t1)))
     end
     return dy
 end
@@ -245,7 +245,7 @@ function _pushforward_via_pullback(
 ) where {F,C}
     dy = map(CartesianIndices(y)) do i  # preserve shape
         t1 = pullback(f!, y, pullback_prep, backend, x, (basis(backend, y, i),), contexts...)
-        dot(dx, only(t1))
+        conj(dot(dx, only(t1)))
     end
     return dy
 end

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -1,17 +1,17 @@
 abstract type FromPrimitive <: AbstractADType end
 
-function basis(fromprim::FromPrimitive, x::AbstractArray{<:Real}, i)
+function basis(fromprim::FromPrimitive, x::AbstractArray, i)
     return basis(fromprim.backend, x, i)
 end
 
-function multibasis(fromprim::FromPrimitive, x::AbstractArray{<:Real}, inds)
+function multibasis(fromprim::FromPrimitive, x::AbstractArray, inds)
     return multibasis(fromprim.backend, x, inds)
 end
 
 check_available(fromprim::FromPrimitive) = check_available(fromprim.backend)
 inplace_support(fromprim::FromPrimitive) = inplace_support(fromprim.backend)
 
-function BatchSizeSettings(fromprim::FromPrimitive, x::AbstractArray{<:Real})
+function BatchSizeSettings(fromprim::FromPrimitive, x::AbstractArray)
     return BatchSizeSettings(fromprim.backend, x)
 end
 

--- a/DifferentiationInterface/src/utils/basis.jl
+++ b/DifferentiationInterface/src/utils/basis.jl
@@ -46,7 +46,7 @@ Construct the `i`-th standard basis array in the vector space of `a` with elemen
 If an AD backend benefits from a more specialized basis array implementation,
 this function can be extended on the backend type.
 """
-basis(::AbstractADType, a::AbstractArray{<:Real}, i) = basis(a, i)
+basis(::AbstractADType, a::AbstractArray, i) = basis(a, i)
 
 """
     multibasis(backend, a::AbstractArray, inds::AbstractVector)
@@ -58,18 +58,16 @@ Construct the sum of the `i`-th standard basis arrays in the vector space of `a`
 If an AD backend benefits from a more specialized basis array implementation,
 this function can be extended on the backend type.
 """
-multibasis(::AbstractADType, a::AbstractArray{<:Real}, inds) = multibasis(a, inds)
+multibasis(::AbstractADType, a::AbstractArray, inds) = multibasis(a, inds)
 
-function basis(a::AbstractArray{T,N}, i) where {T<:Real,N}
+function basis(a::AbstractArray{T,N}, i) where {T,N}
     return zero(a) + OneElement(i, one(T), a)
 end
 
-function multibasis(a::AbstractArray{T,N}, inds::AbstractVector) where {T<:Real,N}
+function multibasis(a::AbstractArray{T,N}, inds::AbstractVector) where {T,N}
     seed = zero(a)
     for i in inds
         seed += OneElement(i, one(T), a)
     end
     return seed
 end
-
-realone(x::Real) = one(x)

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -2,6 +2,7 @@ using Pkg
 Pkg.add("FiniteDiff")
 
 using DifferentiationInterface, DifferentiationInterfaceTest
+using DifferentiationInterface: DenseSparsityDetector
 using FiniteDiff: FiniteDiff
 using SparseMatrixColorings
 using Test
@@ -23,14 +24,15 @@ test_differentiation(
     logging=LOGGING,
 );
 
-@testset verbose = true "Complex number support" begin
-    backend = AutoSparse(AutoFiniteDiff(); coloring_algorithm=GreedyColoringAlgorithm())
-    x = float.(1:3) .+ im
-    @test_skip @test_nowarn jacobian(identity, backend, x)
-    @test_skip @test_nowarn jacobian(copyto!, similar(x), backend, x)
-    @test_skip @test_nowarn hessian(sum, backend, x)
-end
-
-test_differentiation(
-    AutoFiniteDiff(), complex_scenarios(); excluded=SECOND_ORDER, logging=LOGGING
-);
+@testset "Complex" begin
+    test_differentiation(AutoFiniteDiff(), complex_scenarios(); logging=LOGGING)
+    test_differentiation(
+        AutoSparse(
+            AutoFiniteDiff();
+            sparsity_detector=DenseSparsityDetector(AutoFiniteDiff(); atol=1e-5),
+            coloring_algorithm=GreedyColoringAlgorithm(),
+        ),
+        complex_sparse_scenarios();
+        logging=LOGGING,
+    )
+end;

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -30,3 +30,7 @@ test_differentiation(
     @test_skip @test_nowarn jacobian(copyto!, similar(x), backend, x)
     @test_skip @test_nowarn hessian(sum, backend, x)
 end
+
+test_differentiation(
+    AutoFiniteDiff(), complex_scenarios(); excluded=SECOND_ORDER, logging=LOGGING
+);

--- a/DifferentiationInterface/test/Back/FiniteDifferences/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDifferences/test.jl
@@ -21,10 +21,3 @@ test_differentiation(
     excluded=SECOND_ORDER,
     logging=LOGGING,
 );
-
-test_differentiation(
-    AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),
-    complex_scenarios();
-    excluded=SECOND_ORDER,
-    logging=LOGGING,
-);

--- a/DifferentiationInterface/test/Back/FiniteDifferences/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDifferences/test.jl
@@ -21,3 +21,10 @@ test_differentiation(
     excluded=SECOND_ORDER,
     logging=LOGGING,
 );
+
+test_differentiation(
+    AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1)),
+    complex_scenarios();
+    excluded=SECOND_ORDER,
+    logging=LOGGING,
+);

--- a/DifferentiationInterface/test/Back/SymbolicBackends/fastdifferentiation.jl
+++ b/DifferentiationInterface/test/Back/SymbolicBackends/fastdifferentiation.jl
@@ -15,7 +15,15 @@ for backend in [AutoFastDifferentiation(), AutoSparse(AutoFastDifferentiation())
     @test check_inplace(backend)
 end
 
-test_differentiation(AutoFastDifferentiation(); logging=LOGGING);
+test_differentiation(
+    AutoFastDifferentiation(),
+    filter(
+        default_scenarios() do s
+            !(s.x isa Matrix) && !(s.y isa Matrix)
+        end,
+    );
+    logging=LOGGING,
+);
 
 test_differentiation(
     AutoSparse(AutoFastDifferentiation()),

--- a/DifferentiationInterface/test/Back/SymbolicBackends/fastdifferentiation.jl
+++ b/DifferentiationInterface/test/Back/SymbolicBackends/fastdifferentiation.jl
@@ -17,11 +17,9 @@ end
 
 test_differentiation(
     AutoFastDifferentiation(),
-    filter(
-        default_scenarios() do s
-            !(s.x isa Matrix) && !(s.y isa Matrix)
-        end,
-    );
+    filter(default_scenarios()) do s
+        !(s.x isa Matrix) && !(s.y isa Matrix)
+    end;
     logging=LOGGING,
 );
 

--- a/DifferentiationInterface/test/Back/Zygote/test.jl
+++ b/DifferentiationInterface/test/Back/Zygote/test.jl
@@ -42,6 +42,10 @@ end
     )
 end
 
+test_differentiation(
+    AutoZygote(), complex_scenarios(); excluded=[:gradient, :jacobian], logging=LOGGING
+);
+
 ## Sparse
 
 @testset "Sparse" begin

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -93,4 +93,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "DifferentiationInterface", "ExplicitImports", "FiniteDifferences", "Flux", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StaticArrays", "Test", "Zygote"]
+test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "DifferentiationInterface", "ExplicitImports", "FiniteDiff", "FiniteDifferences", "Flux", "ForwardDiff", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StaticArrays", "Test", "Zygote"]

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterfaceTest"
 uuid = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterfaceTest/docs/src/api.md
+++ b/DifferentiationInterfaceTest/docs/src/api.md
@@ -36,6 +36,7 @@ component_scenarios
 gpu_scenarios
 static_scenarios
 complex_scenarios
+complex_sparse_scenarios
 ```
 
 ## Internals

--- a/DifferentiationInterfaceTest/docs/src/api.md
+++ b/DifferentiationInterfaceTest/docs/src/api.md
@@ -35,6 +35,7 @@ sparse_scenarios
 component_scenarios
 gpu_scenarios
 static_scenarios
+complex_scenarios
 ```
 
 ## Internals

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -134,7 +134,7 @@ include("test_differentiation.jl")
 
 export FIRST_ORDER, SECOND_ORDER
 export Scenario
-export default_scenarios, sparse_scenarios
+export default_scenarios, complex_scenarios, sparse_scenarios
 export test_differentiation, benchmark_differentiation
 export DifferentiationBenchmarkDataRow
 # extensions

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -121,6 +121,7 @@ include("scenarios/scenario.jl")
 include("scenarios/modify.jl")
 include("scenarios/default.jl")
 include("scenarios/sparse.jl")
+include("scenarios/complex.jl")
 include("scenarios/allocfree.jl")
 include("scenarios/extensions.jl")
 
@@ -134,7 +135,8 @@ include("test_differentiation.jl")
 
 export FIRST_ORDER, SECOND_ORDER
 export Scenario
-export default_scenarios, complex_scenarios, sparse_scenarios
+export default_scenarios, sparse_scenarios
+export complex_scenarios, complex_sparse_scenarios
 export test_differentiation, benchmark_differentiation
 export DifferentiationBenchmarkDataRow
 # extensions

--- a/DifferentiationInterfaceTest/src/scenarios/complex.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/complex.jl
@@ -1,0 +1,42 @@
+"""
+    complex_scenarios()
+
+Create a vector of first-order [`Scenario`](@ref)s with complex-valued array types and holomorphic functions only.
+"""
+function complex_scenarios()
+    x_ = 0.42 + im
+    dx_ = 3.14 + im
+    dy_ = -1 / 12 + im
+
+    x_6 = float.(1:6) .+ im
+    dx_6 = float.(-1:-1:-6) .+ im
+
+    dy_6 = float.(-5:2:5) .+ im
+    dy_12 = float.(-11:2:11) .+ im
+
+    V = Vector{Complex{Float64}}
+
+    scens = vcat(
+        # one argument
+        num_to_num_scenarios(x_; dx=dx_, dy=dy_, add_vectors=false),
+        num_to_arr_scenarios_onearg(x_, V; dx=dx_, dy=dy_6),
+        arr_to_num_scenarios_onearg(x_6; dx=dx_6, dy=dy_),
+        vec_to_vec_scenarios_onearg(x_6; dx=dx_6, dy=dy_12),
+        # two arguments
+        num_to_arr_scenarios_twoarg(x_, V; dx=dx_, dy=dy_6),
+        vec_to_vec_scenarios_twoarg(x_6; dx=dx_6, dy=dy_12),
+    )
+
+    return filter(s -> !(operator(s) in SECOND_ORDER), scens)
+end
+
+"""
+    complex_sparse_scenarios()
+
+Create a vector of Jacobian [`Scenario`](@ref)s with complex-valued array types and holomorphic functions only.
+"""
+function complex_sparse_scenarios()
+    x_6 = float.(1:6) .+ float.(1:6) .^ 2 .* im
+    scens = sparse_vec_to_vec_scenarios(x_6)
+    return scens
+end

--- a/DifferentiationInterfaceTest/test/standard.jl
+++ b/DifferentiationInterfaceTest/test/standard.jl
@@ -1,6 +1,7 @@
 using ADTypes
 using DifferentiationInterface
 using DifferentiationInterfaceTest
+using FiniteDiff: FiniteDiff
 using ForwardDiff: ForwardDiff
 using SparseConnectivityTracer
 using SparseMatrixColorings
@@ -12,6 +13,12 @@ LOGGING = get(ENV, "CI", "false") == "false"
 
 test_differentiation(
     AutoForwardDiff(), default_scenarios(; include_constantified=true); logging=LOGGING
+)
+
+## Complex
+
+test_differentiation(
+    AutoFiniteDiff(), vcat(complex_scenarios(), complex_sparse_scenarios()); logging=LOGGING
 )
 
 ## Sparse


### PR DESCRIPTION
Complex number compatibility (first order only):

- Make sure that `pullback` returns the product with the adjoint (conjugate transpose) of the Jacobian
- Add conjugation in reverse-mode Jacobians, dense and sparse
- Document that we assume functions to be holomorphic when dealing with complex inputs

Complex number testing:

- Create test scenarios with complex holomorphic functions, first order only
- Test these scenarios with FiniteDiff (ForwardDiff doesn't work)
