### PR TITLE
test: allow passing other scenarios to adjust preparation from

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,7 +25,7 @@ jobs:
       actions: write
       contents: read
     strategy:
-      fail-fast: false  # TODO: toggle
+      fail-fast: true  # TODO: toggle
       matrix:
         version:
           - "1.10"

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,7 +25,7 @@ jobs:
       actions: write
       contents: read
     strategy:
-      fail-fast: true  # TODO: toggle
+      fail-fast: false  # TODO: toggle
       matrix:
         version:
           - "1.10"

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.34"
+version = "0.6.35"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -1,5 +1,5 @@
 # until https://github.com/EnzymeAD/Enzyme.jl/pull/1545 is merged
-function DI.BatchSizeSettings(::AutoEnzyme, N::Integer)
+function DI.pick_batchsize(::AutoEnzyme, N::Integer)
     B = DI.reasonable_batchsize(N, 16)
     return DI.BatchSizeSettings{B}(N)
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -207,9 +207,9 @@ function DI.prepare!_derivative(
     x,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {F,C}
-    if x isa Vector
+    if y isa Vector
         (; config) = old_prep
-        resize!(config.duals, length(x))
+        resize!(config.duals, length(y))
         return old_prep
     else
         return DI.prepare_derivative(f!, y, backend, x, contexts...)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -199,6 +199,23 @@ function DI.prepare_derivative(
     return ForwardDiffTwoArgDerivativePrep(config)
 end
 
+function DI.prepare!_derivative(
+    f!::F,
+    y,
+    old_prep::ForwardDiffTwoArgDerivativePrep,
+    backend::AutoForwardDiff,
+    x,
+    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+) where {F,C}
+    if x isa Vector
+        (; config) = old_prep
+        resize!(config.duals, length(x))
+        return old_prep
+    else
+        return DI.prepare_derivative(f!, y, backend, x, contexts...)
+    end
+end
+
 function DI.value_and_derivative(
     f!::F,
     y,
@@ -350,6 +367,25 @@ function DI.prepare_jacobian(
     tag = get_tag(fc!, backend, x)
     config = JacobianConfig(fc!, y, x, chunk, tag)
     return ForwardDiffTwoArgJacobianPrep(config)
+end
+
+function DI.prepare!_jacobian(
+    f!::F,
+    y,
+    old_prep::ForwardDiffTwoArgJacobianPrep,
+    backend::AutoForwardDiff,
+    x,
+    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+) where {F,C}
+    if x isa Vector && y isa Vector
+        (; config) = old_prep
+        (yduals, xduals) = config.duals
+        resize!(yduals, length(y))
+        resize!(xduals, length(x))
+        return old_prep
+    else
+        return DI.prepare_jacobian(f!, y, backend, x, contexts...)
+    end
 end
 
 function DI.value_and_jacobian(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -1,9 +1,9 @@
-function DI.BatchSizeSettings(::AutoForwardDiff{nothing}, N::Integer)
+function DI.pick_batchsize(::AutoForwardDiff{nothing}, N::Integer)
     chunksize = ForwardDiff.pickchunksize(N)
     return DI.BatchSizeSettings{chunksize}(N)
 end
 
-function DI.BatchSizeSettings(::AutoForwardDiff{chunksize}, N::Integer) where {chunksize}
+function DI.pick_batchsize(::AutoForwardDiff{chunksize}, N::Integer) where {chunksize}
     return DI.BatchSizeSettings{chunksize}(N)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
@@ -14,11 +14,11 @@ end
 DI.check_available(::AutoPolyesterForwardDiff) = true
 
 function DI.pick_batchsize(backend::AutoPolyesterForwardDiff, x::AbstractArray)
-    return DI.BatchSizeSettings(single_threaded(backend), x)
+    return DI.pick_batchsize(single_threaded(backend), x)
 end
 
 function DI.pick_batchsize(backend::AutoPolyesterForwardDiff, N::Integer)
-    return DI.BatchSizeSettings(single_threaded(backend), N)
+    return DI.pick_batchsize(single_threaded(backend), N)
 end
 
 function DI.threshold_batchsize(

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/DifferentiationInterfacePolyesterForwardDiffExt.jl
@@ -13,11 +13,11 @@ end
 
 DI.check_available(::AutoPolyesterForwardDiff) = true
 
-function DI.BatchSizeSettings(backend::AutoPolyesterForwardDiff, x::AbstractArray)
+function DI.pick_batchsize(backend::AutoPolyesterForwardDiff, x::AbstractArray)
     return DI.BatchSizeSettings(single_threaded(backend), x)
 end
 
-function DI.BatchSizeSettings(backend::AutoPolyesterForwardDiff, N::Integer)
+function DI.pick_batchsize(backend::AutoPolyesterForwardDiff, N::Integer)
     return DI.BatchSizeSettings(single_threaded(backend), N)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceStaticArraysExt/DifferentiationInterfaceStaticArraysExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceStaticArraysExt/DifferentiationInterfaceStaticArraysExt.jl
@@ -14,27 +14,25 @@ end
 
 DI.ismutable_array(::Type{<:SArray}) = false
 
-function DI.BatchSizeSettings(::DI.AutoSimpleFiniteDiff{nothing}, x::StaticArray)
+function DI.pick_batchsize(::DI.AutoSimpleFiniteDiff{nothing}, x::StaticArray)
     return DI.BatchSizeSettings{length(x),true,true}(length(x))
 end
 
-function DI.BatchSizeSettings(::AutoForwardDiff{nothing}, x::StaticArray)
+function DI.pick_batchsize(::AutoForwardDiff{nothing}, x::StaticArray)
     return DI.BatchSizeSettings{length(x),true,true}(length(x))
 end
 
-function DI.BatchSizeSettings(::AutoEnzyme, x::StaticArray)
+function DI.pick_batchsize(::AutoEnzyme, x::StaticArray)
     return DI.BatchSizeSettings{length(x),true,true}(length(x))
 end
 
-function DI.BatchSizeSettings(
+function DI.pick_batchsize(
     ::DI.AutoSimpleFiniteDiff{chunksize}, x::StaticArray
 ) where {chunksize}
     return DI.BatchSizeSettings{chunksize}(Val(length(x)))
 end
 
-function DI.BatchSizeSettings(
-    ::AutoForwardDiff{chunksize}, x::StaticArray
-) where {chunksize}
+function DI.pick_batchsize(::AutoForwardDiff{chunksize}, x::StaticArray) where {chunksize}
     return DI.BatchSizeSettings{chunksize}(Val(length(x)))
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -28,7 +28,8 @@ function DI.prepare_pullback_same_point(
     ty::NTuple,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {C}
-    y, pb = forward(f, x, map(DI.unwrap, contexts)...)
+    fc = DI.with_contexts(f, contexts...)
+    y, pb = forward(fc, x)
     return TrackerPullbackPrepSamePoint(y, pb)
 end
 
@@ -40,7 +41,8 @@ function DI.value_and_pullback(
     ty::NTuple,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {C}
-    y, pb = forward(f, x, map(DI.unwrap, contexts)...)
+    fc = DI.with_contexts(f, contexts...)
+    y, pb = forward(fc, x)
     tx = map(ty) do dy
         data(first(pb(dy)))
     end
@@ -92,7 +94,8 @@ function DI.value_and_gradient(
     x,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {C}
-    (; val, grad) = withgradient(f, x, map(DI.unwrap, contexts)...)
+    fc = DI.with_contexts(f, contexts...)
+    (; val, grad) = withgradient(fc, x)
     return val, data(first(grad))
 end
 
@@ -103,7 +106,8 @@ function DI.gradient(
     x,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {C}
-    (; grad) = withgradient(f, x, map(DI.unwrap, contexts)...)
+    fc = DI.with_contexts(f, contexts...)
+    (; grad) = withgradient(fc, x)
     return data(first(grad))
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -28,8 +28,7 @@ function DI.prepare_pullback_same_point(
     ty::NTuple,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {C}
-    fc = DI.with_contexts(f, contexts...)
-    y, pb = forward(fc, x)
+    y, pb = forward(f, x, map(DI.unwrap, contexts)...)
     return TrackerPullbackPrepSamePoint(y, pb)
 end
 
@@ -41,8 +40,7 @@ function DI.value_and_pullback(
     ty::NTuple,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {C}
-    fc = DI.with_contexts(f, contexts...)
-    y, pb = forward(fc, x)
+    y, pb = forward(f, x, map(DI.unwrap, contexts)...)
     tx = map(ty) do dy
         data(first(pb(dy)))
     end
@@ -94,8 +92,7 @@ function DI.value_and_gradient(
     x,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {C}
-    fc = DI.with_contexts(f, contexts...)
-    (; val, grad) = withgradient(fc, x)
+    (; val, grad) = withgradient(f, x, map(DI.unwrap, contexts)...)
     return val, data(first(grad))
 end
 
@@ -106,8 +103,7 @@ function DI.gradient(
     x,
     contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
 ) where {C}
-    fc = DI.with_contexts(f, contexts...)
-    (; grad) = withgradient(fc, x)
+    (; grad) = withgradient(f, x, map(DI.unwrap, contexts)...)
     return data(first(grad))
 end
 

--- a/DifferentiationInterface/src/fallbacks/change_prep.jl
+++ b/DifferentiationInterface/src/fallbacks/change_prep.jl
@@ -43,14 +43,14 @@ for op in [
     if op in (:derivative, :gradient, :jacobian)
         # 1-arg
         @eval function $prep_op!(
-            f::F, ::$P, backend::AbstractADType, x, contexts::Vararg{Context,C}
+            f::F, old_prep::$P, backend::AbstractADType, x, contexts::Vararg{Context,C}
         ) where {F,C}
             return $prep_op(f, backend, x, contexts...)
         end
         op == :gradient && continue
         # 2-arg
         @eval function $prep_op!(
-            f!::F, y, ::$P, backend::AbstractADType, x, contexts::Vararg{Context,C}
+            f!::F, y, old_prep::$P, backend::AbstractADType, x, contexts::Vararg{Context,C}
         ) where {F,C}
             return $prep_op(f!, y, backend, x, contexts...)
         end
@@ -58,7 +58,7 @@ for op in [
     elseif op in (:second_derivative, :hessian)
         # 1-arg
         @eval function $prep_op!(
-            f::F, ::$P, backend::AbstractADType, x, contexts::Vararg{Context,C}
+            f::F, old_prep::$P, backend::AbstractADType, x, contexts::Vararg{Context,C}
         ) where {F,C}
             return $prep_op(f, backend, x, contexts...)
         end
@@ -67,7 +67,7 @@ for op in [
         # 1-arg
         @eval function $prep_op!(
             f::F,
-            ::$P,
+            old_prep::$P,
             backend::AbstractADType,
             x,
             seed::NTuple,
@@ -96,7 +96,7 @@ for op in [
         @eval function $prep_op!(
             f!::F,
             y,
-            ::$P,
+            old_prep::$P,
             backend::AbstractADType,
             x,
             seed::NTuple,

--- a/DifferentiationInterface/src/first_order/jacobian.jl
+++ b/DifferentiationInterface/src/first_order/jacobian.jl
@@ -100,9 +100,9 @@ function prepare_jacobian(
     perf = pushforward_performance(backend)
     # type-unstable
     if perf isa PushforwardFast
-        batch_size_settings = BatchSizeSettings(backend, x)
+        batch_size_settings = pick_batchsize(backend, x)
     else
-        batch_size_settings = BatchSizeSettings(backend, y)
+        batch_size_settings = pick_batchsize(backend, y)
     end
     # function barrier
     return _prepare_jacobian_aux(
@@ -116,9 +116,9 @@ function prepare_jacobian(
     perf = pushforward_performance(backend)
     # type-unstable
     if perf isa PushforwardFast
-        batch_size_settings = BatchSizeSettings(backend, x)
+        batch_size_settings = pick_batchsize(backend, x)
     else
-        batch_size_settings = BatchSizeSettings(backend, y)
+        batch_size_settings = pick_batchsize(backend, y)
     end
     # function barrier
     return _prepare_jacobian_aux(

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -3,8 +3,8 @@ abstract type FromPrimitive <: AbstractADType end
 check_available(fromprim::FromPrimitive) = check_available(fromprim.backend)
 inplace_support(fromprim::FromPrimitive) = inplace_support(fromprim.backend)
 
-function pick_batchsize(fromprim::FromPrimitive, x_or_N::Union{AbstractArray,Integer})
-    return pick_batchsize(fromprim.backend, x_or_N)
+function pick_batchsize(fromprim::FromPrimitive, N::Integer)
+    return pick_batchsize(fromprim.backend, N)
 end
 
 struct AutoReverseFromPrimitive{B} <: FromPrimitive

--- a/DifferentiationInterface/src/misc/simple_finite_diff.jl
+++ b/DifferentiationInterface/src/misc/simple_finite_diff.jl
@@ -19,12 +19,12 @@ ADTypes.mode(::AutoSimpleFiniteDiff) = ForwardMode()
 check_available(::AutoSimpleFiniteDiff) = true
 inplace_support(::AutoSimpleFiniteDiff) = InPlaceSupported()
 
-function BatchSizeSettings(::AutoSimpleFiniteDiff{nothing}, N::Integer)
+function pick_batchsize(::AutoSimpleFiniteDiff{nothing}, N::Integer)
     B = reasonable_batchsize(N, 12)
     return BatchSizeSettings{B}(N)
 end
 
-function BatchSizeSettings(::AutoSimpleFiniteDiff{chunksize}, N::Integer) where {chunksize}
+function pick_batchsize(::AutoSimpleFiniteDiff{chunksize}, N::Integer) where {chunksize}
     return BatchSizeSettings{chunksize}(N)
 end
 

--- a/DifferentiationInterface/test/Back/DifferentiateWith/test.jl
+++ b/DifferentiationInterface/test/Back/DifferentiateWith/test.jl
@@ -16,7 +16,9 @@ function differentiatewith_scenarios()
             DIT.function_place(scen) == :out
         end
     good_scens = map(bad_scens) do scen
-        DIT.change_function(scen, DifferentiateWith(scen.f, AutoFiniteDiff()))
+        DIT.change_function(
+            scen, DifferentiateWith(scen.f, AutoFiniteDiff()); keep_smaller=false
+        )
     end
     return good_scens
 end

--- a/DifferentiationInterface/test/Back/PolyesterForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/PolyesterForwardDiff/test.jl
@@ -1,7 +1,9 @@
 using Pkg
-Pkg.add("PolyesterForwardDiff")
+Pkg.add(["ForwardDiff", "PolyesterForwardDiff"])
 
 using DifferentiationInterface, DifferentiationInterfaceTest
+import DifferentiationInterface as DI
+using ForwardDiff: ForwardDiff
 using PolyesterForwardDiff: PolyesterForwardDiff
 using Test
 
@@ -23,3 +25,10 @@ end
 test_differentiation(
     backends, default_scenarios(; include_constantified=true); logging=LOGGING
 );
+
+@testset "Batch size" begin
+    @test DI.pick_batchsize(AutoPolyesterForwardDiff(), 10) ==
+        DI.pick_batchsize(AutoForwardDiff(), 10)
+    @test DI.pick_batchsize(AutoPolyesterForwardDiff(; chunksize=3), rand(10)) ==
+        DI.pick_batchsize(AutoForwardDiff(; chunksize=3), rand(10))
+end

--- a/DifferentiationInterface/test/Core/Internals/batchsize.jl
+++ b/DifferentiationInterface/test/Core/Internals/batchsize.jl
@@ -88,6 +88,9 @@ end
         ),
         2,
     ) isa SecondOrder{<:AutoSimpleFiniteDiff{2},<:AutoSimpleFiniteDiff{1}}
+    @test threshold_batchsize(
+        MixedMode(AutoSimpleFiniteDiff(; chunksize=4), AutoZygote()), 2
+    ) isa MixedMode{<:AutoSimpleFiniteDiff{2},<:AutoZygote}
 end
 
 @testset "Reasonable" begin

--- a/DifferentiationInterfaceTest/Project.toml
+++ b/DifferentiationInterfaceTest/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterfaceTest"
 uuid = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestJLArraysExt/DifferentiationInterfaceTestJLArraysExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestJLArraysExt/DifferentiationInterfaceTestJLArraysExt.jl
@@ -4,12 +4,14 @@ import DifferentiationInterface as DI
 import DifferentiationInterfaceTest as DIT
 using JLArrays: JLArray, JLVector, JLMatrix, jl
 
-jl_num_to_vec(x::Number) = jl([sin(x), cos(2x)])
+jl_num_to_vec(x::Number) = sin.(jl([1, 2]) .* x)
 jl_num_to_mat(x::Number) = hcat(jl_num_to_vec(x), jl_num_to_vec(3x))
 
+const NTV = typeof(DIT.num_to_vec)
+const NTM = typeof(DIT.num_to_mat)
 myjl(f::Function) = f
-myjl(::typeof(DIT.num_to_vec)) = jl_num_to_vec
-myjl(::typeof(DIT.num_to_mat)) = jl_num_to_mat
+myjl(::NTV) = jl_num_to_vec
+myjl(::NTM) = jl_num_to_mat
 myjl(f::DIT.FunctionModifier) = f
 
 myjl(x::Number) = x

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestJLArraysExt/DifferentiationInterfaceTestJLArraysExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestJLArraysExt/DifferentiationInterfaceTestJLArraysExt.jl
@@ -4,21 +4,12 @@ import DifferentiationInterface as DI
 import DifferentiationInterfaceTest as DIT
 using JLArrays: JLArray, JLVector, JLMatrix, jl
 
+jl_num_to_vec(x::Number) = jl([sin(x), cos(2x)])
+jl_num_to_mat(x::Number) = hcat(jl_num_to_vec(x), jl_num_to_vec(3x))
+
 myjl(f::Function) = f
-function myjl(::DIT.NumToArr{A}) where {T,N,A<:AbstractArray{T,N}}
-    return DIT.NumToArr(JLArray{T,N})
-end
-
-function (f::DIT.NumToArr{JLVector{T}})(x::Number) where {T}
-    a = JLVector{T}(Vector(1:6))  # avoid mutation
-    return sin.(x .* a)
-end
-
-function (f::DIT.NumToArr{JLMatrix{T}})(x::Number) where {T}
-    a = JLMatrix{T}(Matrix(reshape(1:6, 2, 3)))  # avoid mutation
-    return sin.(x .* a)
-end
-
+myjl(::typeof(DIT.num_to_vec)) = jl_num_to_vec
+myjl(::typeof(DIT.num_to_mat)) = jl_num_to_mat
 myjl(f::DIT.FunctionModifier) = f
 
 myjl(x::Number) = x

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestStaticArraysExt/DifferentiationInterfaceTestStaticArraysExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestStaticArraysExt/DifferentiationInterfaceTestStaticArraysExt.jl
@@ -5,10 +5,13 @@ import DifferentiationInterfaceTest as DIT
 using SparseArrays: SparseArrays, SparseMatrixCSC, nnz, spdiagm
 using StaticArrays: MArray, MMatrix, MVector, SArray, SMatrix, SVector
 
-mystatic(f::Function) = f
-mystatic(::DIT.NumToArr{A}) where {T,A<:AbstractVector{T}} = DIT.NumToArr(SVector{6,T})
-mystatic(::DIT.NumToArr{A}) where {T,A<:AbstractMatrix{T}} = DIT.NumToArr(SMatrix{2,3,T,6})
-mystatic(f::DIT.FunctionModifier) = f
+static_num_to_vec(x::Number) = SVector(sin(x), cos(2x))
+static_num_to_mat(x::Number) = hcat(static_num_to_vec(x), static_num_to_vec(3x))
+
+mystatic(f::Function)              = f
+mystatic(::typeof(DIT.num_to_vec)) = static_num_to_vec
+mystatic(::typeof(DIT.num_to_mat)) = static_num_to_mat
+mystatic(f::DIT.FunctionModifier)  = f
 
 mystatic(x::Number) = x
 mymutablestatic(x::Number) = x

--- a/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestStaticArraysExt/DifferentiationInterfaceTestStaticArraysExt.jl
+++ b/DifferentiationInterfaceTest/ext/DifferentiationInterfaceTestStaticArraysExt/DifferentiationInterfaceTestStaticArraysExt.jl
@@ -5,16 +5,17 @@ import DifferentiationInterfaceTest as DIT
 using SparseArrays: SparseArrays, SparseMatrixCSC, nnz, spdiagm
 using StaticArrays: MArray, MMatrix, MVector, SArray, SMatrix, SVector
 
-static_num_to_vec(x::Number) = SVector(sin(x), cos(2x))
+static_num_to_vec(x::Number) = sin.(SVector(1, 2) .* x)
 static_num_to_mat(x::Number) = hcat(static_num_to_vec(x), static_num_to_vec(3x))
 
-mystatic(f::Function)              = f
-mystatic(::typeof(DIT.num_to_vec)) = static_num_to_vec
-mystatic(::typeof(DIT.num_to_mat)) = static_num_to_mat
-mystatic(f::DIT.FunctionModifier)  = f
+const NTV                         = typeof(DIT.num_to_vec)
+const NTM                         = typeof(DIT.num_to_mat)
+mystatic(f::Function)             = f
+mystatic(::NTV)                   = static_num_to_vec
+mystatic(::NTM)                   = static_num_to_mat
+mystatic(f::DIT.FunctionModifier) = f
 
 mystatic(x::Number) = x
-mymutablestatic(x::Number) = x
 
 mystatic(x::AbstractVector{T}) where {T} = convert(SVector{length(x),T}, x)
 mymutablestatic(x::AbstractVector{T}) where {T} = convert(MVector{length(x),T}, x)

--- a/DifferentiationInterfaceTest/src/scenarios/complex.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/complex.jl
@@ -23,7 +23,7 @@ function complex_scenarios()
         arr_to_num_scenarios_onearg(x_6; dx=dx_6, dy=dy_),
         vec_to_vec_scenarios_onearg(x_6; dx=dx_6, dy=dy_12),
         # two arguments
-        num_to_arr_scenarios_twoarg(x_, V; dx=dx_, dy=dy_6),
+        num_to_arr_scenarios_twoarg(x_; dx=dx_, dy=dy_6),
         vec_to_vec_scenarios_twoarg(x_6; dx=dx_6, dy=dy_12),
     )
 

--- a/DifferentiationInterfaceTest/src/scenarios/complex.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/complex.jl
@@ -11,6 +11,7 @@ function complex_scenarios()
     x_6 = float.(1:6) .+ im
     dx_6 = float.(-1:-1:-6) .+ im
 
+    dy_2 = [-3.0, 4.0] .+ im
     dy_6 = float.(-5:2:5) .+ im
     dy_12 = float.(-11:2:11) .+ im
 
@@ -18,12 +19,12 @@ function complex_scenarios()
 
     scens = vcat(
         # one argument
-        num_to_num_scenarios(x_; dx=dx_, dy=dy_, add_vectors=false),
-        num_to_arr_scenarios_onearg(x_, V; dx=dx_, dy=dy_6),
+        num_to_num_scenarios(x_; dx=dx_, dy=dy_),
+        num_to_vec_scenarios_onearg(x_; dx=dx_, dy=dy_2),
         arr_to_num_scenarios_onearg(x_6; dx=dx_6, dy=dy_),
         vec_to_vec_scenarios_onearg(x_6; dx=dx_6, dy=dy_12),
         # two arguments
-        num_to_arr_scenarios_twoarg(x_; dx=dx_, dy=dy_6),
+        num_to_vec_scenarios_twoarg(x_; dx=dx_, dy=dy_6),
         vec_to_vec_scenarios_twoarg(x_6; dx=dx_6, dy=dy_12),
     )
 

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -630,7 +630,7 @@ function default_scenarios(;
         ),
     )
 
-    scens = map(initialscens, initialscens) do s1, s2
+    scens = map(initialscens, smallerscens) do s1, s2
         set_smaller(s1, s2)
     end
 

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -100,27 +100,27 @@ end
 
 ## Number to vector
 
-num_to_vec(x::Number) = [sin(x), cos(2x)]
-num_to_vec_derivative(x) = [cos(x), -2sin(2x)]
-num_to_vec_second_derivative(x) = [-sin(x), -4cos(2x)]
+num_to_vec(x::Number) = vcat(sin(x), cos(2 * x))
+num_to_vec_derivative(x) = [cos(x), -2sin(2 * x)]
+num_to_vec_second_derivative(x) = [-sin(x), -4cos(2 * x)]
 num_to_vec_pushforward(x, dx) = dx .* num_to_vec_derivative(x)
 num_to_vec_pullback(x, dy) = sum(conj(num_to_vec_derivative(x)) .* dy)
 
 function num_to_vec!(y::AbstractVector, x::Number)
     n = length(y)
     y[1:(n ÷ 2)] .= sin(x)
-    y[((n ÷ 2) + 1):end] .= cos(2x)
+    y[((n ÷ 2) + 1):end] .= cos(2 * x)
     return nothing
 end
 
 function num_to_vec!_derivative(x; y)
     n = length(y)
-    return vcat(fill(cos(x), n ÷ 2), fill(-2sin(2x), n - n ÷ 2))
+    return vcat(fill(cos(x), n ÷ 2), fill(-2sin(2 * x), n - n ÷ 2))
 end
 
 function num_to_vec!_second_derivative(x; y)
     n = length(y)
-    return vcat(fill(-sin(x), n ÷ 2), fill(-4cos(2x), n - n ÷ 2))
+    return vcat(fill(-sin(x), n ÷ 2), fill(-4cos(2 * x), n - n ÷ 2))
 end
 
 num_to_vec!_pushforward(x, dx; y) = dx .* num_to_vec!_derivative(x; y)
@@ -183,38 +183,38 @@ end
 
 ## Number to matrix
 
-num_to_mat(x::Number) = hcat(num_to_vec(x), num_to_vec(3x))
+num_to_mat(x::Number) = hcat(num_to_vec(x), num_to_vec(3 * x))
 
-num_to_mat_derivative(x) = hcat(num_to_vec_derivative(x), 3 * num_to_vec_derivative(3x))
+num_to_mat_derivative(x) = hcat(num_to_vec_derivative(x), 3 .* num_to_vec_derivative(3 * x))
 function num_to_mat_second_derivative(x)
-    return hcat(num_to_vec_second_derivative(x), 9 * num_to_vec_second_derivative(3x))
+    return hcat(num_to_vec_second_derivative(x), 9 .* num_to_vec_second_derivative(3 * x))
 end
 function num_to_mat_pushforward(x, dx)
-    return hcat(num_to_vec_pushforward(x, dx), 3 * num_to_vec_pushforward(3x, dx))
+    return hcat(num_to_vec_pushforward(x, dx), 3 .* num_to_vec_pushforward(3 * x, dx))
 end
 function num_to_mat_pullback(x, dy)
-    return num_to_vec_pullback(x, dy[:, 1]) + 3 * num_to_vec_pullback(3x, dy[:, 2])
+    return num_to_vec_pullback(x, dy[:, 1]) + 3 * num_to_vec_pullback(3 * x, dy[:, 2])
 end
 
 function num_to_mat!(y::AbstractMatrix, x::Number)
     num_to_vec!(view(y, :, 1), x)
-    num_to_vec!(view(y, :, 2), 3x)
+    num_to_vec!(view(y, :, 2), 3 * x)
     return nothing
 end
 
 function num_to_mat!_derivative(x; y)
     return hcat(
-        num_to_vec!_derivative(x; y=y[:, 1]), 3 * num_to_vec!_derivative(3x; y=y[:, 2])
+        num_to_vec!_derivative(x; y=y[:, 1]), 3 .* num_to_vec!_derivative(3 * x; y=y[:, 2])
     )
 end
 function num_to_mat!_pushforward(x, dx; y)
     return hcat(
         num_to_vec!_pushforward(x, dx; y=y[:, 1]),
-        3 * num_to_vec!_pushforward(3x, dx; y=y[:, 2]),
+        3 .* num_to_vec!_pushforward(3 * x, dx; y=y[:, 2]),
     )
 end
 function num_to_mat!_pullback(x, dy)
-    return num_to_vec!_pullback(x, dy[:, 1]) + 3 * num_to_vec!_pullback(3x, dy[:, 2])
+    return num_to_vec!_pullback(x, dy[:, 1]) + 3 * num_to_vec!_pullback(3 * x, dy[:, 2])
 end
 
 function num_to_mat_scenarios_onearg(x::Number; dx::Number, dy::AbstractArray)

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -100,27 +100,22 @@ end
 
 ## Number to vector
 
-num_to_vec(x::Number) = [sin(x), cos(2 * x)]
-num_to_vec_derivative(x) = [cos(x), -2sin(2 * x)]
-num_to_vec_second_derivative(x) = [-sin(x), -4cos(2 * x)]
+num_to_vec(x::Number) = sin.([1, 2] .* x)
+num_to_vec_derivative(x) = [1, 2] .* cos.([1, 2] .* x)
+num_to_vec_second_derivative(x) = [1, 2] .^ 2 .* (.-sin.([1, 2] .* x))
 num_to_vec_pushforward(x, dx) = dx .* num_to_vec_derivative(x)
 num_to_vec_pullback(x, dy) = sum(conj(num_to_vec_derivative(x)) .* dy)
 
 function num_to_vec!(y::AbstractVector, x::Number)
     n = length(y)
     y[1:(n ÷ 2)] .= sin(x)
-    y[((n ÷ 2) + 1):end] .= cos(2 * x)
+    y[((n ÷ 2) + 1):end] .= sin(2x)
     return nothing
 end
 
 function num_to_vec!_derivative(x; y)
     n = length(y)
-    return vcat(fill(cos(x), n ÷ 2), fill(-2sin(2 * x), n - n ÷ 2))
-end
-
-function num_to_vec!_second_derivative(x; y)
-    n = length(y)
-    return vcat(fill(-sin(x), n ÷ 2), fill(-4cos(2 * x), n - n ÷ 2))
+    return vcat(fill(cos(x), n ÷ 2), fill(2cos(2x), n - n ÷ 2))
 end
 
 num_to_vec!_pushforward(x, dx; y) = dx .* num_to_vec!_derivative(x; y)
@@ -183,38 +178,38 @@ end
 
 ## Number to matrix
 
-num_to_mat(x::Number) = hcat(num_to_vec(x), num_to_vec(3 * x))
+num_to_mat(x::Number) = hcat(num_to_vec(x), num_to_vec(3x))
 
-num_to_mat_derivative(x) = hcat(num_to_vec_derivative(x), 3 .* num_to_vec_derivative(3 * x))
+num_to_mat_derivative(x) = hcat(num_to_vec_derivative(x), 3 .* num_to_vec_derivative(3x))
 function num_to_mat_second_derivative(x)
-    return hcat(num_to_vec_second_derivative(x), 9 .* num_to_vec_second_derivative(3 * x))
+    return hcat(num_to_vec_second_derivative(x), 9 .* num_to_vec_second_derivative(3x))
 end
 function num_to_mat_pushforward(x, dx)
-    return hcat(num_to_vec_pushforward(x, dx), 3 .* num_to_vec_pushforward(3 * x, dx))
+    return hcat(num_to_vec_pushforward(x, dx), 3 .* num_to_vec_pushforward(3x, dx))
 end
 function num_to_mat_pullback(x, dy)
-    return num_to_vec_pullback(x, dy[:, 1]) + 3 * num_to_vec_pullback(3 * x, dy[:, 2])
+    return num_to_vec_pullback(x, dy[:, 1]) + 3 * num_to_vec_pullback(3x, dy[:, 2])
 end
 
 function num_to_mat!(y::AbstractMatrix, x::Number)
     num_to_vec!(view(y, :, 1), x)
-    num_to_vec!(view(y, :, 2), 3 * x)
+    num_to_vec!(view(y, :, 2), 3x)
     return nothing
 end
 
 function num_to_mat!_derivative(x; y)
     return hcat(
-        num_to_vec!_derivative(x; y=y[:, 1]), 3 .* num_to_vec!_derivative(3 * x; y=y[:, 2])
+        num_to_vec!_derivative(x; y=y[:, 1]), 3 .* num_to_vec!_derivative(3x; y=y[:, 2])
     )
 end
 function num_to_mat!_pushforward(x, dx; y)
     return hcat(
         num_to_vec!_pushforward(x, dx; y=y[:, 1]),
-        3 .* num_to_vec!_pushforward(3 * x, dx; y=y[:, 2]),
+        3 .* num_to_vec!_pushforward(3x, dx; y=y[:, 2]),
     )
 end
 function num_to_mat!_pullback(x, dy)
-    return num_to_vec!_pullback(x, dy[:, 1]) + 3 * num_to_vec!_pullback(3 * x, dy[:, 2])
+    return num_to_vec!_pullback(x, dy[:, 1]) + 3 * num_to_vec!_pullback(3x, dy[:, 2])
 end
 
 function num_to_mat_scenarios_onearg(x::Number; dx::Number, dy::AbstractArray)

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -483,7 +483,7 @@ function default_scenarios(;
     V = Vector{Float64}
     M = Matrix{Float64}
 
-    scens = vcat(
+    initialscens = vcat(
         # one argument
         num_to_num_scenarios(x_; dx=dx_, dy=dy_),
         num_to_arr_scenarios_onearg(x_, V; dx=dx_, dy=dy_6),
@@ -502,6 +502,34 @@ function default_scenarios(;
         mat_to_vec_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_12),
         mat_to_mat_scenarios_twoarg(x_2_3; dx=dx_2_3, dy=dy_6_2),
     )
+
+    otherscens = vcat(
+        # one argument
+        num_to_num_scenarios(x_; dx=dx_, dy=dy_),
+        num_to_arr_scenarios_onearg(x_, V; dx=dx_, dy=dy_6),
+        num_to_arr_scenarios_onearg(x_, M; dx=dx_, dy=dy_2_3),
+        arr_to_num_scenarios_onearg(x_6[1:3]; dx=dx_6[1:3], dy=dy_, linalg),
+        arr_to_num_scenarios_onearg(x_2_3[1:1, 1:2]; dx=dx_2_3[1:1, 1:2], dy=dy_, linalg),
+        vec_to_vec_scenarios_onearg(x_6[1:3]; dx=dx_6[1:3], dy=dy_12[1:6]),
+        vec_to_mat_scenarios_onearg(x_6[1:3]; dx=dx_6[1:3], dy=dy_6_2[1:3, 1:2]),
+        mat_to_vec_scenarios_onearg(x_2_3[1:1, 1:2]; dx=dx_2_3[1:1, 1:2], dy=dy_12[1:4]),
+        mat_to_mat_scenarios_onearg(
+            x_2_3[1:1, 1:2]; dx=dx_2_3[1:1, 1:2], dy=dy_6_2[1:2, 1:2]
+        ),
+        # two arguments
+        num_to_arr_scenarios_twoarg(x_, V; dx=dx_, dy=dy_6),
+        num_to_arr_scenarios_twoarg(x_, M; dx=dx_, dy=dy_2_3),
+        vec_to_vec_scenarios_twoarg(x_6[1:3]; dx=dx_6[1:3], dy=dy_12[1:6]),
+        vec_to_mat_scenarios_twoarg(x_6[1:3]; dx=dx_6[1:3], dy=dy_6_2[1:3, 1:2]),
+        mat_to_vec_scenarios_twoarg(x_2_3[1:1, 1:2]; dx=dx_2_3[1:1, 1:2], dy=dy_12[1:4]),
+        mat_to_mat_scenarios_twoarg(
+            x_2_3[1:1, 1:2]; dx=dx_2_3[1:1, 1:2], dy=dy_6_2[1:2, 1:2]
+        ),
+    )
+
+    scens = map(initialscens, otherscens) do s1, s2
+        set_otherscen(s1, s2)
+    end
 
     include_batchified && append!(scens, batchify(scens))
 

--- a/DifferentiationInterfaceTest/src/scenarios/default.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/default.jl
@@ -100,7 +100,7 @@ end
 
 ## Number to vector
 
-num_to_vec(x::Number) = vcat(sin(x), cos(2 * x))
+num_to_vec(x::Number) = [sin(x), cos(2 * x)]
 num_to_vec_derivative(x) = [cos(x), -2sin(2 * x)]
 num_to_vec_second_derivative(x) = [-sin(x), -4cos(2 * x)]
 num_to_vec_pushforward(x, dx) = dx .* num_to_vec_derivative(x)

--- a/DifferentiationInterfaceTest/src/scenarios/modify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/modify.jl
@@ -14,6 +14,7 @@ function Base.zero(scen::Scenario{op,pl_op,pl_fun}) where {op,pl_op,pl_fun}
         contexts=scen.contexts,
         res1=myzero(scen.res1),
         res2=myzero(scen.res2),
+        smaller=isnothing(scen.smaller) ? nothing : zero(scen.smaller),
     )
 end
 
@@ -22,7 +23,9 @@ end
 
 Return a new `Scenario` identical to `scen` except for the function `f` which is changed to `new_f`.
 """
-function change_function(scen::Scenario{op,pl_op,pl_fun}, new_f) where {op,pl_op,pl_fun}
+function change_function(
+    scen::Scenario{op,pl_op,pl_fun}, new_f; keep_smaller
+) where {op,pl_op,pl_fun}
     return Scenario{op,pl_op,pl_fun}(
         new_f;
         x=scen.x,
@@ -31,6 +34,11 @@ function change_function(scen::Scenario{op,pl_op,pl_fun}, new_f) where {op,pl_op
         contexts=scen.contexts,
         res1=scen.res1,
         res2=scen.res2,
+        smaller=if isnothing(scen.smaller) || !keep_smaller
+            nothing
+        else
+            change_function(scen.smaller, new_f; keep_smaller=false)
+        end,
     )
 end
 
@@ -42,18 +50,32 @@ Return a new `Scenario` identical to `scen` except for the tangents `tang` and a
 Only works if `scen` is a `pushforward`, `pullback` or `hvp` scenario.
 """
 function batchify(scen::Scenario{op,pl_op,pl_fun}) where {op,pl_op,pl_fun}
-    (; f, x, y, tang, contexts, res1, res2) = scen
+    (; f, x, y, tang, contexts, res1, res2, smaller) = scen
     if op == :pushforward || op == :pullback
         new_tang = (only(tang), -only(tang))
         new_res1 = (only(res1), -only(res1))
         return Scenario{op,pl_op,pl_fun}(
-            f; x, y, tang=new_tang, contexts, res1=new_res1, res2
+            f;
+            x,
+            y,
+            tang=new_tang,
+            contexts,
+            res1=new_res1,
+            res2,
+            smaller=isnothing(smaller) ? nothing : batchify(smaller),
         )
     elseif op == :hvp
         new_tang = (only(tang), -only(tang))
         new_res2 = (only(res2), -only(res2))
         return Scenario{op,pl_op,pl_fun}(
-            f; x, y, tang=new_tang, contexts, res1, res2=new_res2
+            f;
+            x,
+            y,
+            tang=new_tang,
+            contexts,
+            res1,
+            res2=new_res2,
+            smaller=isnothing(smaller) ? nothing : batchify(smaller),
         )
     end
 end
@@ -96,7 +118,7 @@ function closurify(scen::Scenario)
     x_buffer = [zero(x)]
     y_buffer = [zero(y)]
     closure_f = WritableClosure{function_place(scen)}(f, x_buffer, y_buffer)
-    return change_function(scen, closure_f)
+    return change_function(scen, closure_f; keep_smaller=false)
 end
 
 struct MultiplyByConstant{pl_fun,F} <: FunctionModifier
@@ -137,6 +159,7 @@ function constantify(scen::Scenario{op,pl_op,pl_fun}) where {op,pl_op,pl_fun}
         contexts=(Constant(a),),
         res1=mymultiply(scen.res1, a),
         res2=mymultiply(scen.res2, a),
+        smaller=isnothing(scen.smaller) ? nothing : constantify(scen.smaller),
     )
 end
 
@@ -189,6 +212,7 @@ function cachify(scen::Scenario{op,pl_op,pl_fun}) where {op,pl_op,pl_fun}
         contexts=(Cache(y_cache),),
         res1=scen.res1,
         res2=scen.res2,
+        smaller=isnothing(scen.smaller) ? nothing : cachify(scen.smaller),
     )
 end
 
@@ -201,10 +225,10 @@ closurify(scens::AbstractVector{<:Scenario}) = closurify.(scens)
 constantify(scens::AbstractVector{<:Scenario}) = constantify.(scens)
 cachify(scens::AbstractVector{<:Scenario}) = cachify.(scens)
 
-function set_otherscen(
-    scen::Scenario{op,pl_op,pl_fun}, otherscen::Scenario
+function set_smaller(
+    scen::Scenario{op,pl_op,pl_fun}, smaller::Scenario
 ) where {op,pl_op,pl_fun}
-    @assert scen.f == otherscen.f
+    @assert scen.f == smaller.f
     return Scenario{op,pl_op,pl_fun}(
         scen.f;
         x=scen.x,
@@ -213,6 +237,6 @@ function set_otherscen(
         contexts=scen.contexts,
         res1=scen.res1,
         res2=scen.res2,
-        otherscen=otherscen,
+        smaller=smaller,
     )
 end

--- a/DifferentiationInterfaceTest/src/scenarios/modify.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/modify.jl
@@ -200,3 +200,19 @@ end
 closurify(scens::AbstractVector{<:Scenario}) = closurify.(scens)
 constantify(scens::AbstractVector{<:Scenario}) = constantify.(scens)
 cachify(scens::AbstractVector{<:Scenario}) = cachify.(scens)
+
+function set_otherscen(
+    scen::Scenario{op,pl_op,pl_fun}, otherscen::Scenario
+) where {op,pl_op,pl_fun}
+    @assert scen.f == otherscen.f
+    return Scenario{op,pl_op,pl_fun}(
+        scen.f;
+        x=scen.x,
+        y=scen.y,
+        tang=scen.tang,
+        contexts=scen.contexts,
+        res1=scen.res1,
+        res2=scen.res2,
+        otherscen=otherscen,
+    )
+end

--- a/DifferentiationInterfaceTest/src/scenarios/scenario.jl
+++ b/DifferentiationInterfaceTest/src/scenarios/scenario.jl
@@ -108,9 +108,11 @@ function compatible(backend::AbstractADType, scen::Scenario)
            mixedmode_compatible
 end
 
-function group_by_operator(scenarios::AbstractVector{<:Scenario})
+function group_by_operator(
+    scenario_inds::AbstractVector{<:Integer}, scenarios::AbstractVector{<:Scenario}
+)
     return Dict(
-        op => filter(s -> operator(s) == op, scenarios) for
+        op => filter(l -> operator(scenarios[l]) == op, scenario_inds) for
         op in unique(operator.(scenarios))
     )
 end

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -98,7 +98,9 @@ function test_differentiation(
     @assert benchmark in (:none, :prepared, :full)
 
     scenario_inds = filter(l -> !(operator(scenarios[l]) in excluded), eachindex(scenarios))
-    scenario_inds = sort(scenario_inds; by=l -> (operator(scenarios[l]), string(s.f)))
+    scenario_inds = sort(
+        scenario_inds; by=l -> (operator(scenarios[l]), string(scenarios[l].f))
+    )
 
     title_additions =
         (correctness ? " + correctness" : "") *

--- a/DifferentiationInterfaceTest/src/test_differentiation.jl
+++ b/DifferentiationInterfaceTest/src/test_differentiation.jl
@@ -62,7 +62,7 @@ Each setting tests/benchmarks a different subset of calls:
 function test_differentiation(
     backends::Vector{<:AbstractADType},
     scenarios::Vector{<:Scenario}=default_scenarios(),
-    otherscenarios=similar(scenarios, Nothing);
+    otherscenarios=deepcopy(scenarios);
     # test categories
     correctness::Bool=true,
     type_stability::Symbol=:none,
@@ -120,14 +120,14 @@ function test_differentiation(
             grouped_scenario_inds = group_by_operator(filtered_scenario_inds, scenarios)
             @testset verbose = detailed "$op" for (j, (op, op_group)) in
                                                   enumerate(pairs(grouped_scenario_inds))
-                @testset "$scen" for (k, l) in enumerate(op_group)
+                @testset "$(scenarios[l])" for (k, l) in enumerate(op_group)
                     scen = scenarios[l]
                     otherscen = otherscenarios[l]
                     next!(
                         prog;
                         showvalues=[
                             (:backend, "$backend - $i/$(length(backends))"),
-                            (:scenario_type, "$op - $j/$(length(grouped_scenarios))"),
+                            (:scenario_type, "$op - $j/$(length(grouped_scenario_inds))"),
                             (:scenario, "$k/$(length(op_group))"),
                             (:operator_place, operator_place(scen)),
                             (:function_place, function_place(scen)),

--- a/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
@@ -48,18 +48,21 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, res1, contexts, smaller) = new_scen = deepcopy(scen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(
-                        new_otherscen.f, ba, new_otherscen.x, new_otherscen.contexts...
-                    ),
+                    $prep_op(new_smaller.f, ba, new_smaller.x, new_smaller.contexts...),
                     ba,
                     xrand,
                     contextsrand...,
@@ -104,18 +107,21 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, res1, contexts, smaller) = new_scen = deepcopy(scen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(
-                        new_otherscen.f, ba, new_otherscen.x, new_otherscen.contexts...
-                    ),
+                    $prep_op(new_smaller.f, ba, new_smaller.x, new_smaller.contexts...),
                     ba,
                     xrand,
                     contextsrand...,
@@ -174,22 +180,27 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, res1, contexts, smaller) = new_scen = deepcopy(scen)
             xrand, yrand = myrandom(x), myrandom(y)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, copy(yrand), ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
                     $prep_op(
-                        new_otherscen.f,
-                        copy(new_otherscen.y),
+                        new_smaller.f,
+                        copy(new_smaller.y),
                         ba,
-                        new_otherscen.x,
-                        new_otherscen.contexts...,
+                        new_smaller.x,
+                        new_smaller.contexts...,
                     ),
                     ba,
                     xrand,
@@ -241,22 +252,27 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, res1, contexts, smaller) = new_scen = deepcopy(scen)
             xrand, yrand = myrandom(x), myrandom(y)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, copy(yrand), ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
                     $prep_op(
-                        new_otherscen.f,
-                        copy(new_otherscen.y),
+                        new_smaller.f,
+                        copy(new_smaller.y),
                         ba,
-                        new_otherscen.x,
-                        new_otherscen.contexts...,
+                        new_smaller.x,
+                        new_smaller.contexts...,
                     ),
                     ba,
                     xrand,
@@ -317,18 +333,21 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, res1, res2, contexts, smaller) = new_scen = deepcopy(scen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(
-                        new_otherscen.f, ba, new_otherscen.x, new_otherscen.contexts...
-                    ),
+                    $prep_op(new_smaller.f, ba, new_smaller.x, new_smaller.contexts...),
                     ba,
                     xrand,
                     contextsrand...,
@@ -375,18 +394,21 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, res1, res2, contexts, smaller) = new_scen = deepcopy(scen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(
-                        new_otherscen.f, ba, new_otherscen.x, new_otherscen.contexts...
-                    ),
+                    $prep_op(new_smaller.f, ba, new_smaller.x, new_smaller.contexts...),
                     ba,
                     xrand,
                     contextsrand...,
@@ -448,21 +470,26 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, tang, res1, contexts, smaller) = new_scen = deepcopy(scen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     $prep_op(
-                        new_otherscen.f,
+                        new_smaller.f,
                         ba,
-                        new_otherscen.x,
-                        new_otherscen.tang,
-                        new_otherscen.contexts...,
+                        new_smaller.x,
+                        new_smaller.tang,
+                        new_smaller.contexts...,
                     ),
                     ba,
                     xrand,
@@ -506,21 +533,26 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, tang, res1, contexts, smaller) = new_scen = deepcopy(scen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     $prep_op(
-                        new_otherscen.f,
+                        new_smaller.f,
                         ba,
-                        new_otherscen.x,
-                        new_otherscen.tang,
-                        new_otherscen.contexts...,
+                        new_smaller.x,
+                        new_smaller.tang,
+                        new_smaller.contexts...,
                     ),
                     ba,
                     xrand,
@@ -576,23 +608,28 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, tang, res1, contexts, smaller) = new_scen = deepcopy(scen)
             xrand, yrand, tangrand = myrandom(x), myrandom(y), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, copy(yrand), ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
                     $prep_op(
-                        new_otherscen.f,
-                        copy(new_otherscen.y),
+                        new_smaller.f,
+                        copy(new_smaller.y),
                         ba,
-                        new_otherscen.x,
-                        new_otherscen.tang,
-                        new_otherscen.contexts...,
+                        new_smaller.x,
+                        new_smaller.tang,
+                        new_smaller.contexts...,
                     ),
                     ba,
                     xrand,
@@ -646,23 +683,28 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, tang, res1, contexts, smaller) = new_scen = deepcopy(scen)
             xrand, yrand, tangrand = myrandom(x), myrandom(y), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, copy(yrand), ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
                     $prep_op(
-                        new_otherscen.f,
-                        copy(new_otherscen.y),
+                        new_smaller.f,
+                        copy(new_smaller.y),
                         ba,
-                        new_otherscen.x,
-                        new_otherscen.tang,
-                        new_otherscen.contexts...,
+                        new_smaller.x,
+                        new_smaller.tang,
+                        new_smaller.contexts...,
                     ),
                     ba,
                     xrand,
@@ -735,21 +777,26 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, tang, res1, res2, contexts, smaller) = new_scen = deepcopy(scen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     $prep_op(
-                        new_otherscen.f,
+                        new_smaller.f,
                         ba,
-                        new_otherscen.x,
-                        new_otherscen.tang,
-                        new_otherscen.contexts...,
+                        new_smaller.x,
+                        new_smaller.tang,
+                        new_smaller.contexts...,
                     ),
                     ba,
                     xrand,
@@ -793,21 +840,26 @@ for op in ALL_OPS
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
+            (; f, x, y, tang, res1, res2, contexts, smaller) = new_scen = deepcopy(scen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
-                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
+                new_smaller =
+                    if isnothing(smaller) || adapt_batchsize(ba, smaller) != ba
+                        deepcopy(scen)
+                    else
+                        deepcopy(smaller)
+                    end
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     $prep_op(
-                        new_otherscen.f,
+                        new_smaller.f,
                         ba,
-                        new_otherscen.x,
-                        new_otherscen.tang,
-                        new_otherscen.contexts...,
+                        new_smaller.x,
+                        new_smaller.tang,
+                        new_smaller.contexts...,
                     ),
                     ba,
                     xrand,

--- a/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
@@ -41,16 +41,15 @@ for op in ALL_OPS
     if op in [:derivative, :gradient, :jacobian]
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1out,
-            otherscen;
+            scen::$S1out;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -98,16 +97,15 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1in,
-            otherscen;
+            scen::$S1in;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -169,16 +167,15 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S2out,
-            otherscen;
+            scen::$S2out;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, yrand = myrandom(x), myrandom(y)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -237,16 +234,15 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S2in,
-            otherscen;
+            scen::$S2in;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, yrand = myrandom(x), myrandom(y)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -314,16 +310,15 @@ for op in ALL_OPS
     elseif op in [:second_derivative, :hessian]
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1out,
-            otherscen;
+            scen::$S1out;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, res2, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -373,16 +368,15 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1in,
-            otherscen;
+            scen::$S1in;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, res1, res2, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -447,16 +441,15 @@ for op in ALL_OPS
     elseif op in [:pushforward, :pullback]
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1out,
-            otherscen;
+            scen::$S1out;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -506,16 +499,15 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1in,
-            otherscen;
+            scen::$S1in;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -577,16 +569,15 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S2out,
-            otherscen;
+            scen::$S2out;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, yrand, tangrand = myrandom(x), myrandom(y), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -648,16 +639,15 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S2in,
-            otherscen;
+            scen::$S2in;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, yrand, tangrand = myrandom(x), myrandom(y), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -738,16 +728,15 @@ for op in ALL_OPS
     elseif op in [:hvp]
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1out,
-            otherscen;
+            scen::$S1out;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, res2, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, tang, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -797,16 +786,15 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1in,
-            otherscen;
+            scen::$S1in;
             isapprox::Function,
             atol::Real,
             rtol::Real,
             scenario_intact::Bool,
             sparsity::Bool,
         )
-            (; f, x, y, tang, res1, res2, contexts) = new_scen = deepcopy(scen)
-            new_otherscen = deepcopy(otherscen)
+            (; f, x, y, tang, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
+            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)

--- a/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
@@ -41,7 +41,8 @@ for op in ALL_OPS
     if op in [:derivative, :gradient, :jacobian]
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1out;
+            scen::$S1out,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -49,6 +50,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -56,7 +58,9 @@ for op in ALL_OPS
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(f, ba, xrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f, ba, new_otherscen.x, new_otherscen.contexts...
+                    ),
                     ba,
                     xrand,
                     contextsrand...,
@@ -94,7 +98,8 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1in;
+            scen::$S1in,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -102,6 +107,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -109,7 +115,9 @@ for op in ALL_OPS
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(f, ba, xrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f, ba, new_otherscen.x, new_otherscen.contexts...
+                    ),
                     ba,
                     xrand,
                     contextsrand...,
@@ -161,7 +169,8 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S2out;
+            scen::$S2out,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -169,6 +178,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand, yrand = myrandom(x), myrandom(y)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -177,7 +187,13 @@ for op in ALL_OPS
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
-                    $prep_op(f, copy(yrand), ba, xrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f,
+                        copy(new_otherscen.y),
+                        ba,
+                        new_otherscen.x,
+                        new_otherscen.contexts...,
+                    ),
                     ba,
                     xrand,
                     contextsrand...,
@@ -221,7 +237,8 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S2in;
+            scen::$S2in,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -229,6 +246,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand, yrand = myrandom(x), myrandom(y)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -237,7 +255,13 @@ for op in ALL_OPS
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
-                    $prep_op(f, copy(yrand), ba, xrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f,
+                        copy(new_otherscen.y),
+                        ba,
+                        new_otherscen.x,
+                        new_otherscen.contexts...,
+                    ),
                     ba,
                     xrand,
                     contextsrand...,
@@ -290,7 +314,8 @@ for op in ALL_OPS
     elseif op in [:second_derivative, :hessian]
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1out;
+            scen::$S1out,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -298,6 +323,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, res2, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -305,7 +331,9 @@ for op in ALL_OPS
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(f, ba, xrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f, ba, new_otherscen.x, new_otherscen.contexts...
+                    ),
                     ba,
                     xrand,
                     contextsrand...,
@@ -345,7 +373,8 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1in;
+            scen::$S1in,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -353,6 +382,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, res2, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -360,7 +390,9 @@ for op in ALL_OPS
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(f, ba, xrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f, ba, new_otherscen.x, new_otherscen.contexts...
+                    ),
                     ba,
                     xrand,
                     contextsrand...,
@@ -415,7 +447,8 @@ for op in ALL_OPS
     elseif op in [:pushforward, :pullback]
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1out;
+            scen::$S1out,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -423,6 +456,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -430,7 +464,13 @@ for op in ALL_OPS
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(f, ba, xrand, tangrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f,
+                        ba,
+                        new_otherscen.x,
+                        new_otherscen.tang,
+                        new_otherscen.contexts...,
+                    ),
                     ba,
                     xrand,
                     tangrand,
@@ -466,7 +506,8 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1in;
+            scen::$S1in,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -474,6 +515,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -481,7 +523,13 @@ for op in ALL_OPS
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(f, ba, xrand, tangrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f,
+                        ba,
+                        new_otherscen.x,
+                        new_otherscen.tang,
+                        new_otherscen.contexts...,
+                    ),
                     ba,
                     xrand,
                     tangrand,
@@ -529,7 +577,8 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S2out;
+            scen::$S2out,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -537,6 +586,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand, yrand, tangrand = myrandom(x), myrandom(y), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -545,7 +595,14 @@ for op in ALL_OPS
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
-                    $prep_op(f, copy(yrand), ba, xrand, tangrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f,
+                        copy(new_otherscen.y),
+                        ba,
+                        new_otherscen.x,
+                        new_otherscen.tang,
+                        new_otherscen.contexts...,
+                    ),
                     ba,
                     xrand,
                     tangrand,
@@ -591,7 +648,8 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S2in;
+            scen::$S2in,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -599,6 +657,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand, yrand, tangrand = myrandom(x), myrandom(y), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -607,7 +666,14 @@ for op in ALL_OPS
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
-                    $prep_op(f, copy(yrand), ba, xrand, tangrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f,
+                        copy(y),
+                        ba,
+                        new_otherscen.x,
+                        new_otherscen.tang,
+                        new_otherscen.contexts...,
+                    ),
                     ba,
                     xrand,
                     tangrand,
@@ -672,7 +738,8 @@ for op in ALL_OPS
     elseif op in [:hvp]
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1out;
+            scen::$S1out,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -680,6 +747,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, res2, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -687,7 +755,13 @@ for op in ALL_OPS
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(f, ba, xrand, tangrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f,
+                        ba,
+                        new_otherscen.x,
+                        new_otherscen.tang,
+                        new_otherscen.contexts...,
+                    ),
                     ba,
                     xrand,
                     tangrand,
@@ -723,7 +797,8 @@ for op in ALL_OPS
 
         @eval function test_correctness(
             ba::AbstractADType,
-            scen::$S1in;
+            scen::$S1in,
+            otherscen=deepcopy(scen);
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -731,6 +806,7 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, res2, contexts) = new_scen = deepcopy(scen)
+            new_otherscen = deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
@@ -738,7 +814,13 @@ for op in ALL_OPS
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
-                    $prep_op(f, ba, xrand, tangrand, contextsrand...),
+                    $prep_op(
+                        new_otherscen.f,
+                        ba,
+                        new_otherscen.x,
+                        new_otherscen.tang,
+                        new_otherscen.contexts...,
+                    ),
                     ba,
                     xrand,
                     tangrand,

--- a/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
@@ -149,12 +149,12 @@ for op in ALL_OPS
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
-                    @test res1_in1_val ≈ scen.res1
-                    @test res1_in2_val ≈ scen.res1
+                    @test res1_in1_val === res1_out1_val
+                    @test res1_in2_val === res1_out2_val
                     @test res1_out1_val ≈ scen.res1
                     @test res1_out2_val ≈ scen.res1
-                    @test res1_in1_noval ≈ scen.res1
-                    @test res1_in2_noval ≈ scen.res1
+                    @test res1_in1_noval === res1_out1_noval
+                    @test res1_in2_noval === res1_out2_noval
                     @test res1_out1_noval ≈ scen.res1
                     @test res1_out2_noval ≈ scen.res1
                 end
@@ -223,8 +223,8 @@ for op in ALL_OPS
                 res1_out2_noval = $op(f, y_in2_noval, preptup_noval..., ba, x, contexts...)
                 let (≈)(x, y) = isapprox(x, y; atol, rtol)
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
-                    @test y_in1_val ≈ scen.y
-                    @test y_in2_val ≈ scen.y
+                    @test y_in1_val === y_out1_val
+                    @test y_in2_val === y_out2_val
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
                     @test res1_out1_val ≈ scen.res1
@@ -299,16 +299,16 @@ for op in ALL_OPS
                 )
                 let (≈)(x, y) = isapprox(x, y; atol, rtol)
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
-                    @test y_in1_val ≈ scen.y
-                    @test y_in2_val ≈ scen.y
+                    @test y_in1_val === y_out1_val
+                    @test y_in2_val === y_out2_val
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
-                    @test res1_in1_val ≈ scen.res1
-                    @test res1_in2_val ≈ scen.res1
+                    @test res1_in1_val === res1_out1_val
+                    @test res1_in2_val === res1_out2_val
                     @test res1_out1_val ≈ scen.res1
                     @test res1_out2_val ≈ scen.res1
-                    @test res1_in1_noval ≈ scen.res1
-                    @test res1_in2_noval ≈ scen.res1
+                    @test res1_in1_noval === res1_out1_noval
+                    @test res1_in2_noval === res1_out2_noval
                     @test res1_out1_noval ≈ scen.res1
                     @test res1_out2_noval ≈ scen.res1
                 end
@@ -436,16 +436,16 @@ for op in ALL_OPS
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
-                    @test res1_in1_val ≈ scen.res1
-                    @test res1_in2_val ≈ scen.res1
+                    @test res1_in1_val === res1_out1_val
+                    @test res1_in2_val === res1_out2_val
                     @test res1_out1_val ≈ scen.res1
                     @test res1_out2_val ≈ scen.res1
-                    @test res2_in1_val ≈ scen.res2
-                    @test res2_in2_val ≈ scen.res2
+                    @test res2_in1_val === res2_out1_val
+                    @test res2_in2_val === res2_out2_val
                     @test res2_out1_val ≈ scen.res2
                     @test res2_out2_val ≈ scen.res2
-                    @test res2_in1_noval ≈ scen.res2
-                    @test res2_in2_noval ≈ scen.res2
+                    @test res2_in1_noval === res2_out1_noval
+                    @test res2_in2_noval === res2_out2_noval
                     @test res2_out1_noval ≈ scen.res2
                     @test res2_out2_noval ≈ scen.res2
                 end
@@ -584,12 +584,12 @@ for op in ALL_OPS
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
                     for b in eachindex(scen.res1)
-                        @test res1_in1_val[b] ≈ scen.res1[b]
-                        @test res1_in2_val[b] ≈ scen.res1[b]
+                        @test res1_in1_val[b] === res1_out1_val[b]
+                        @test res1_in2_val[b] === res1_out2_val[b]
                         @test res1_out1_val[b] ≈ scen.res1[b]
                         @test res1_out2_val[b] ≈ scen.res1[b]
-                        @test res1_in1_noval[b] ≈ scen.res1[b]
-                        @test res1_in2_noval[b] ≈ scen.res1[b]
+                        @test res1_in1_noval[b] === res1_out1_noval[b]
+                        @test res1_in2_noval[b] === res1_out2_noval[b]
                         @test res1_out1_noval[b] ≈ scen.res1[b]
                         @test res1_out2_noval[b] ≈ scen.res1[b]
                     end
@@ -658,8 +658,8 @@ for op in ALL_OPS
                 )
                 let (≈)(x, y) = isapprox(x, y; atol, rtol)
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
-                    @test y_in1_val ≈ scen.y
-                    @test y_in2_val ≈ scen.y
+                    @test y_in1_val === y_out1_val
+                    @test y_in2_val === y_out2_val
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
                     for b in eachindex(scen.res1)
@@ -747,17 +747,17 @@ for op in ALL_OPS
                 )
                 let (≈)(x, y) = isapprox(x, y; atol, rtol)
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
-                    @test y_in1_val ≈ scen.y
-                    @test y_in2_val ≈ scen.y
+                    @test y_in1_val === y_out1_val
+                    @test y_in2_val === y_out2_val
                     @test y_out1_val ≈ scen.y
                     @test y_out2_val ≈ scen.y
                     for b in eachindex(scen.res1)
-                        @test res1_in1_val[b] ≈ scen.res1[b]
-                        @test res1_in2_val[b] ≈ scen.res1[b]
+                        @test res1_in1_val[b] === res1_out1_val[b]
+                        @test res1_in2_val[b] === res1_out2_val[b]
                         @test res1_out1_val[b] ≈ scen.res1[b]
                         @test res1_out2_val[b] ≈ scen.res1[b]
-                        @test res1_in1_noval[b] ≈ scen.res1[b]
-                        @test res1_in2_noval[b] ≈ scen.res1[b]
+                        @test res1_in1_noval[b] === res1_out1_noval[b]
+                        @test res1_in2_noval[b] === res1_out2_noval[b]
                         @test res1_out1_noval[b] ≈ scen.res1[b]
                         @test res1_out2_noval[b] ≈ scen.res1[b]
                     end
@@ -902,17 +902,17 @@ for op in ALL_OPS
                 )
                 let (≈)(x, y) = isapprox(x, y; atol, rtol)
                     @test isempty(preptup_noval) || only(preptup_noval) isa $P
-                    @test res1_in1_val ≈ scen.res1
-                    @test res1_in2_val ≈ scen.res1
+                    @test res1_in1_val === res1_out1_val
+                    @test res1_in2_val === res1_out2_val
                     @test res1_out1_val ≈ scen.res1
                     @test res1_out2_val ≈ scen.res1
                     for b in eachindex(scen.res2)
-                        @test res2_in1_noval[b] ≈ scen.res2[b]
-                        @test res2_in2_noval[b] ≈ scen.res2[b]
+                        @test res2_in1_noval[b] === res2_out1_noval[b]
+                        @test res2_in2_noval[b] === res2_out2_noval[b]
                         @test res2_out1_noval[b] ≈ scen.res2[b]
                         @test res2_out2_noval[b] ≈ scen.res2[b]
-                        @test res2_in1_val[b] ≈ scen.res2[b]
-                        @test res2_in2_val[b] ≈ scen.res2[b]
+                        @test res2_in1_val[b] === res2_out1_val[b]
+                        @test res2_in2_val[b] === res2_out2_val[b]
                         @test res2_out1_val[b] ≈ scen.res2[b]
                         @test res2_out2_val[b] ≈ scen.res2[b]
                     end

--- a/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
@@ -49,11 +49,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -105,11 +105,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -175,11 +175,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, yrand = myrandom(x), myrandom(y)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, copy(yrand), ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -242,11 +242,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, yrand = myrandom(x), myrandom(y)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, copy(yrand), ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -318,11 +318,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -376,11 +376,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand = myrandom(x)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, ba, xrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -449,11 +449,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -507,11 +507,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -577,11 +577,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, yrand, tangrand = myrandom(x), myrandom(y), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, copy(yrand), ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -647,18 +647,18 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, yrand, tangrand = myrandom(x), myrandom(y), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, copy(yrand), ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
                     copy(yrand),
                     $prep_op(
                         new_otherscen.f,
-                        copy(y),
+                        copy(new_otherscen.y),
                         ba,
                         new_otherscen.x,
                         new_otherscen.tang,
@@ -736,11 +736,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,
@@ -794,11 +794,11 @@ for op in ALL_OPS
             sparsity::Bool,
         )
             (; f, x, y, tang, res1, res2, contexts, otherscen) = new_scen = deepcopy(scen)
-            new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
             xrand, tangrand = myrandom(x), myrandom(tang)
             rewrap = Rewrap(contexts...)
             contextsrand = rewrap(map(myrandom ∘ unwrap, contexts)...)
             preptup_cands_val, preptup_cands_noval = map(1:2) do _
+                new_otherscen = isnothing(otherscen) ? deepcopy(scen) : deepcopy(otherscen)
                 prep = $prep_op(f, ba, xrand, tangrand, contextsrand...)
                 prepprep = $prep_op!(
                     f,

--- a/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
+++ b/DifferentiationInterfaceTest/src/tests/correctness_eval.jl
@@ -42,7 +42,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S1out,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -99,7 +99,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S1in,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -170,7 +170,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S2out,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -238,7 +238,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S2in,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -315,7 +315,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S1out,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -374,7 +374,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S1in,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -448,7 +448,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S1out,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -507,7 +507,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S1in,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -578,7 +578,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S2out,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -649,7 +649,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S2in,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -739,7 +739,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S1out,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,
@@ -798,7 +798,7 @@ for op in ALL_OPS
         @eval function test_correctness(
             ba::AbstractADType,
             scen::$S1in,
-            otherscen=deepcopy(scen);
+            otherscen;
             isapprox::Function,
             atol::Real,
             rtol::Real,

--- a/DifferentiationInterfaceTest/test/standard.jl
+++ b/DifferentiationInterfaceTest/test/standard.jl
@@ -12,7 +12,9 @@ LOGGING = get(ENV, "CI", "false") == "false"
 ## Dense
 
 test_differentiation(
-    AutoForwardDiff(), default_scenarios(; include_constantified=false); logging=LOGGING
+    [AutoForwardDiff(), AutoForwardDiff(; chunksize=100)],
+    default_scenarios(; include_constantified=true);
+    logging=LOGGING,
 )
 
 ## Complex

--- a/DifferentiationInterfaceTest/test/standard.jl
+++ b/DifferentiationInterfaceTest/test/standard.jl
@@ -12,7 +12,7 @@ LOGGING = get(ENV, "CI", "false") == "false"
 ## Dense
 
 test_differentiation(
-    AutoForwardDiff(), default_scenarios(; include_constantified=true); logging=LOGGING
+    AutoForwardDiff(), default_scenarios(; include_constantified=false); logging=LOGGING
 )
 
 ## Complex


### PR DESCRIPTION
**DIT**

- Augment `Scenario` with a field named `smaller` containing a similar scenario with smaller inputs
- Add correctness tests for preparation adaptation from these smaller inputs (except when a fixed batch size on the backend would prevent it being used)
- Simplify batch size adaptation
- Simplify number-to-array test scenarios and their static/GPU variants
- Test identity of operator input with operator output for in-place operators, instead of comparing values with reference

**DI**

- Preparation adaptation for ForwardDiff's `jacobian` and `derivative` (taken from https://github.com/SciML/OrdinaryDiffEq.jl/blob/013c00d81292d7ddce87841b7765dde030c2875e/lib/OrdinaryDiffEqDifferentiation/src/derivative_wrappers.jl#L326)
- Refactor batch size choice by only overloading `pick_batchsize`