### PR TITLE
fix: better warning for MethodError

### DIFF
--- a/DifferentiationInterface/src/init.jl
+++ b/DifferentiationInterface/src/init.jl
@@ -2,12 +2,27 @@ function __init__()
     Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
         if exc.f in (_prepare_pushforward_aux, _prepare_pullback_aux)
             B = first(T for T in argtypes if T <: AbstractADType)
-            printstyled(
-                io,
-                "\n\nThe autodiff backend package you want to use may not be loaded. Please run the following command and try again:";
-                bold=true,
-            )
-            printstyled(io, "\n\n\timport $(package_name(B))"; color=:cyan, bold=true)
+            packages = required_packages(B)
+            loaded = map(string, values(Base.loaded_modules))
+            missing_package = any(!(p in loaded) for p in packages)
+            if missing_package
+                import_statement = "import $(packages[1])"
+                for p in packages[2:end]
+                    import_statement *= ", $p"
+                end
+                printstyled(
+                    io,
+                    "\n\nThe autodiff backend you chose requires a package which may not be loaded. Please run the following command and try again:";
+                    bold=true,
+                )
+                printstyled(io, "\n\n\t$import_statement"; color=:cyan, bold=true)
+            else
+                printstyled(
+                    io,
+                    "\n\nThe autodiff backend you chose may not be compatible with the operation you want to perform. Please refer to the documentation of DifferentiationInterface.jl and open an issue if necessary.";
+                    bold=true,
+                )
+            end
         end
     end
 end

--- a/DifferentiationInterface/src/utils/printing.jl
+++ b/DifferentiationInterface/src/utils/printing.jl
@@ -1,24 +1,32 @@
-package_name(b::AbstractADType) = package_name(typeof(b))
+required_packages(b::AbstractADType) = required_packages(typeof(b))
 
-function package_name(::Type{B}) where {B<:AbstractADType}
+function required_packages(::Type{B}) where {B<:AbstractADType}
     s = string(B)
     s = chopprefix(s, "ADTypes.")
     s = chopprefix(s, "Auto")
     k = findfirst('{', s)
     if isnothing(k)
-        return s
+        return [s]
     else
-        return s[begin:(k - 1)]
+        return [s[begin:(k - 1)]]
     end
 end
 
-function package_name(::Type{SecondOrder{O,I}}) where {O,I}
-    p1 = package_name(O)
-    p2 = package_name(I)
-    return p1 == p2 ? p1 : "$p1, $p2"
+function required_packages(::Type{SecondOrder{O,I}}) where {O,I}
+    p1 = required_packages(O)
+    p2 = required_packages(I)
+    return unique(vcat(p1, p2))
 end
 
-package_name(::Type{<:AutoSparse{D}}) where {D} = package_name(D)
+function required_packages(::Type{MixedMode{F,R}}) where {F,R}
+    p1 = required_packages(F)
+    p2 = required_packages(R)
+    return unique(vcat(p1, p2))
+end
+
+function required_packages(::Type{<:AutoSparse{D}}) where {D}
+    return unique(vcat(required_packages(D), "SparseMatrixColorings"))
+end
 
 function document_preparation(operator_name::AbstractString; same_point=false)
     if same_point

--- a/DifferentiationInterface/test/Core/Internals/display.jl
+++ b/DifferentiationInterface/test/Core/Internals/display.jl
@@ -1,5 +1,6 @@
 using ADTypes
 using DifferentiationInterface
+using DifferentiationInterface: required_packages
 using Test
 
 backend = SecondOrder(AutoForwardDiff(), AutoZygote())
@@ -12,8 +13,11 @@ detector = DenseSparsityDetector(AutoForwardDiff(); atol=1e-23)
 diffwith = DifferentiateWith(exp, AutoForwardDiff())
 @test string(diffwith) == "DifferentiateWith(exp, AutoForwardDiff())"
 
-@test DifferentiationInterface.package_name(AutoForwardDiff()) == "ForwardDiff"
-@test DifferentiationInterface.package_name(AutoZygote()) == "Zygote"
-@test DifferentiationInterface.package_name(AutoSparse(AutoForwardDiff())) == "ForwardDiff"
-@test DifferentiationInterface.package_name(SecondOrder(AutoForwardDiff(), AutoZygote())) ==
-    "ForwardDiff, Zygote"
+@test required_packages(AutoForwardDiff()) == ["ForwardDiff"]
+@test required_packages(AutoZygote()) == ["Zygote"]
+@test required_packages(AutoSparse(AutoForwardDiff())) ==
+    ["ForwardDiff", "SparseMatrixColorings"]
+@test required_packages(SecondOrder(AutoForwardDiff(), AutoZygote())) ==
+    ["ForwardDiff", "Zygote"]
+@test required_packages(MixedMode(AutoForwardDiff(), AutoZygote())) ==
+    ["ForwardDiff", "Zygote"]


### PR DESCRIPTION
- Restrict the current error hint to missing packages, and if the `MethodError` is due to something else, refer to the documentation.

```julia
julia> using DifferentiationInterface

julia> f(x, c) = sum(copyto!(c, x))
f (generic function with 1 method)

julia> gradient(f, AutoZygote(), [1.0], Cache([0.0]))
ERROR: MethodError: no method matching _prepare_pullback_aux(::DifferentiationInterface.PullbackFast, ::typeof(f), ::AutoZygote, ::Vector{…}, ::Tuple{…}, ::Cache{…})
The function `_prepare_pullback_aux` exists, but no method is defined for this combination of argument types.

The autodiff backend you chose requires a package which may not be loaded. Please run the following command and try again:

        import Zygote

Closest candidates are:
...

julia> import Zygote

julia> gradient(f, AutoZygote(), [1.0], Cache([0.0]))
ERROR: MethodError: no method matching _prepare_pullback_aux(::DifferentiationInterface.PullbackFast, ::typeof(f), ::AutoZygote, ::Vector{…}, ::Tuple{…}, ::Cache{…})
The function `_prepare_pullback_aux` exists, but no method is defined for this combination of argument types.

The autodiff backend you chose may not be compatible with the operation you want to perform. Please refer to the documentation of DifferentiationInterface.jl and open an issue if necessary.

Closest candidates are:
...
```