### PR TITLE
feat: use `JVPCache` for FiniteDiff pushforwards

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.37"
+version = "0.6.38"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -56,7 +56,7 @@ Enzyme = "0.13.17"
 EnzymeCore = "0.8.8"
 ExplicitImports = "1.10.1"
 FastDifferentiation = "0.4.3"
-FiniteDiff = "2.23.1"
+FiniteDiff = "2.27.0"
 FiniteDifferences = "0.12.31"
 ForwardDiff = "0.10.36"
 GTPSA = "1.4.0"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/DifferentiationInterfaceFiniteDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/DifferentiationInterfaceFiniteDiffExt.jl
@@ -7,6 +7,7 @@ using FiniteDiff:
     GradientCache,
     HessianCache,
     JacobianCache,
+    JVPCache,
     finite_difference_derivative,
     finite_difference_gradient,
     finite_difference_gradient!,
@@ -14,6 +15,8 @@ using FiniteDiff:
     finite_difference_hessian!,
     finite_difference_jacobian,
     finite_difference_jacobian!,
+    finite_difference_jvp,
+    finite_difference_jvp!,
     default_relstep
 using LinearAlgebra: dot, mul!
 

--- a/DifferentiationInterface/test/Back/FiniteDiff/benchmark.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/benchmark.jl
@@ -1,0 +1,31 @@
+using Pkg
+Pkg.add("FiniteDiff")
+
+using ADTypes: ADTypes
+using DifferentiationInterface, DifferentiationInterfaceTest
+import DifferentiationInterface as DI
+import DifferentiationInterfaceTest as DIT
+using FiniteDiff: FiniteDiff
+using Test
+
+@testset "Benchmarking sparse" begin
+    filtered_sparse_scenarios = filter(sparse_scenarios(; band_sizes=[])) do scen
+        DIT.function_place(scen) == :in &&
+            DIT.operator_place(scen) == :in &&
+            scen.x isa AbstractVector &&
+            scen.y isa AbstractVector
+    end
+
+    data = benchmark_differentiation(
+        MyAutoSparse(AutoFiniteDiff()),
+        filtered_sparse_scenarios;
+        benchmark=:prepared,
+        excluded=SECOND_ORDER,
+        logging=LOGGING,
+    )
+    @testset "Analyzing benchmark results" begin
+        @testset "$(row[:scenario])" for row in eachrow(data)
+            @test row[:allocs] == 0
+        end
+    end
+end

--- a/DifferentiationInterface/test/Back/FiniteDiff/benchmark.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/benchmark.jl
@@ -8,6 +8,8 @@ import DifferentiationInterfaceTest as DIT
 using FiniteDiff: FiniteDiff
 using Test
 
+LOGGING = get(ENV, "CI", "false") == "false"
+
 @testset "Benchmarking sparse" begin
     filtered_sparse_scenarios = filter(sparse_scenarios(; band_sizes=[])) do scen
         DIT.function_place(scen) == :in &&

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-Pkg.add("FiniteDiff")
+Pkg.add(; url="https://github.com/JuliaDiff/FiniteDiff.jl", rev="os/finite_difference_jvp`")
 
 using DifferentiationInterface, DifferentiationInterfaceTest
 using DifferentiationInterface: DenseSparsityDetector
@@ -16,6 +16,15 @@ for backend in [AutoFiniteDiff()]
     @test check_available(backend)
     @test check_inplace(backend)
 end
+
+test_differentiation(
+    AutoFiniteDiff(),
+    default_scenarios();
+    excluded=[
+        :second_derivative, :hvp, :hessian, :jacobian, :derivative, :gradient, :pullback
+    ],
+    logging=LOGGING,
+);
 
 test_differentiation(
     AutoFiniteDiff(),

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-Pkg.add(; url="https://github.com/JuliaDiff/FiniteDiff.jl", rev="os/finite_difference_jvp`")
+Pkg.add("FiniteDiff")
 
 using DifferentiationInterface, DifferentiationInterfaceTest
 using DifferentiationInterface: DenseSparsityDetector

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -17,30 +17,32 @@ for backend in [AutoFiniteDiff()]
     @test check_inplace(backend)
 end
 
-test_differentiation(
-    [AutoFiniteDiff(; fdtype=Val(:forward)), AutoFiniteDiff(; fdtype=Val(:central))],
-    default_scenarios(; include_constantified=true);
-    excluded=[
-        :second_derivative, :hvp, :hessian, :jacobian, :derivative, :gradient, :pullback
-    ],
-    logging=LOGGING,
-);
+@testset "Dense" begin
+    test_differentiation(
+        AutoFiniteDiff(),
+        default_scenarios(; include_constantified=true, include_cachified=true);
+        excluded=[:second_derivative, :hvp],
+        logging=LOGGING,
+    )
 
-test_differentiation(
-    AutoFiniteDiff(),
-    default_scenarios(; include_constantified=true, include_cachified=true);
-    excluded=[:second_derivative, :hvp],
-    logging=LOGGING,
-);
+    test_differentiation(
+        [
+            AutoFiniteDiff(; relstep=cbrt(eps(Float64))),
+            AutoFiniteDiff(; relstep=cbrt(eps(Float64)), absstep=cbrt(eps(Float64))),
+        ];
+        excluded=[:second_derivative, :hvp],
+        logging=LOGGING,
+    )
+end
 
-test_differentiation(
-    [
-        AutoFiniteDiff(; relstep=cbrt(eps(Float64))),
-        AutoFiniteDiff(; relstep=cbrt(eps(Float64)), absstep=cbrt(eps(Float64))),
-    ];
-    excluded=[:second_derivative, :hvp],
-    logging=LOGGING,
-);
+@testset "Sparse" begin
+    test_differentiation(
+        MyAutoSparse(AutoFiniteDiff()),
+        sparse_scenarios();
+        excluded=SECOND_ORDER,
+        logging=LOGGING,
+    )
+end
 
 @testset "Complex" begin
     test_differentiation(AutoFiniteDiff(), complex_scenarios(); logging=LOGGING)

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -18,7 +18,7 @@ for backend in [AutoFiniteDiff()]
 end
 
 test_differentiation(
-    AutoFiniteDiff(),
+    [AutoFiniteDiff(; fdtype=Val(:forward)), AutoFiniteDiff(; fdtype=Val(:central))],
     default_scenarios();
     excluded=[
         :second_derivative, :hvp, :hessian, :jacobian, :derivative, :gradient, :pullback

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -19,7 +19,7 @@ end
 
 test_differentiation(
     [AutoFiniteDiff(; fdtype=Val(:forward)), AutoFiniteDiff(; fdtype=Val(:central))],
-    default_scenarios();
+    default_scenarios(; include_constantified=true);
     excluded=[
         :second_derivative, :hvp, :hessian, :jacobian, :derivative, :gradient, :pullback
     ],

--- a/DifferentiationInterface/test/Back/ForwardDiff/benchmark.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/benchmark.jl
@@ -1,0 +1,52 @@
+using Pkg
+Pkg.add("ForwardDiff")
+
+using ADTypes: ADTypes
+using DifferentiationInterface, DifferentiationInterfaceTest
+import DifferentiationInterface as DI
+import DifferentiationInterfaceTest as DIT
+using ForwardDiff: ForwardDiff
+using StaticArrays: StaticArrays, @SVector
+using Test
+
+LOGGING = get(ENV, "CI", "false") == "false"
+
+@testset verbose = true "Benchmarking static" begin
+    filtered_static_scenarios = filter(static_scenarios(; include_batchified=false)) do scen
+        DIT.function_place(scen) == :out && DIT.operator_place(scen) == :out
+    end
+    data = benchmark_differentiation(
+        AutoForwardDiff(),
+        filtered_static_scenarios;
+        benchmark=:prepared,
+        excluded=[:hessian, :pullback],  # TODO: figure this out
+        logging=LOGGING,
+    )
+    @testset "Analyzing benchmark results" begin
+        @testset "$(row[:scenario])" for row in eachrow(data)
+            @test row[:allocs] == 0
+        end
+    end
+end
+
+@testset "Benchmarking sparse" begin
+    filtered_sparse_scenarios = filter(sparse_scenarios(; band_sizes=[])) do scen
+        DIT.function_place(scen) == :in &&
+            DIT.operator_place(scen) == :in &&
+            scen.x isa AbstractVector &&
+            scen.y isa AbstractVector
+    end
+
+    data = benchmark_differentiation(
+        MyAutoSparse(AutoForwardDiff()),
+        filtered_sparse_scenarios;
+        benchmark=:prepared,
+        excluded=SECOND_ORDER,
+        logging=LOGGING,
+    )
+    @testset "Analyzing benchmark results" begin
+        @testset "$(row[:scenario])" for row in eachrow(data)
+            @test row[:allocs] == 0
+        end
+    end
+end

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -28,55 +28,49 @@ for backend in backends
     @test check_inplace(backend)
 end
 
-## Dense
+@testset "Dense" begin
+    test_differentiation(
+        backends, default_scenarios(; include_constantified=true); logging=LOGGING
+    )
 
-test_differentiation(
-    backends, default_scenarios(; include_constantified=true); logging=LOGGING
-);
+    test_differentiation(
+        AutoForwardDiff(),
+        default_scenarios(;
+            include_normal=false, include_batchified=false, include_cachified=true
+        );
+        logging=LOGGING,
+    )
 
-test_differentiation(
-    AutoForwardDiff(),
-    default_scenarios(;
-        include_normal=false, include_batchified=false, include_cachified=true
-    );
-    logging=LOGGING,
-);
+    test_differentiation(
+        AutoForwardDiff(); correctness=false, type_stability=:prepared, logging=LOGGING
+    )
 
-test_differentiation(
-    AutoForwardDiff(); correctness=false, type_stability=:prepared, logging=LOGGING
-);
+    test_differentiation(
+        AutoForwardDiff(; chunksize=5);
+        correctness=false,
+        type_stability=:full,
+        excluded=[:hessian],
+        logging=LOGGING,
+    )
+end
 
-test_differentiation(
-    AutoForwardDiff(; chunksize=5);
-    correctness=false,
-    type_stability=:full,
-    excluded=[:hessian],
-    logging=LOGGING,
-);
+@testset "Sparse" begin
+    test_differentiation(
+        MyAutoSparse(AutoForwardDiff()), default_scenarios(); logging=LOGGING
+    )
 
-test_differentiation(
-    backends,
-    vcat(component_scenarios(), static_scenarios()); # FD accesses individual indices
-    excluded=vcat(SECOND_ORDER, [:jacobian]),  # jacobian is super slow for some reason
-    logging=LOGGING,
-);
+    test_differentiation(
+        MyAutoSparse(AutoForwardDiff()),
+        sparse_scenarios(; include_constantified=true);
+        sparsity=true,
+        logging=LOGGING,
+    )
+end
 
-## Sparse
+@testset "Weird" begin
+    test_differentiation(AutoForwardDiff(), component_scenarios(); logging=LOGGING)
+    test_differentiation(AutoForwardDiff(), static_scenarios(); logging=LOGGING)
 
-test_differentiation(MyAutoSparse(AutoForwardDiff()), default_scenarios(); logging=LOGGING);
-
-test_differentiation(
-    MyAutoSparse(AutoForwardDiff()),
-    sparse_scenarios(; include_constantified=true);
-    sparsity=true,
-    logging=LOGGING,
-);
-
-## Static
-
-test_differentiation(AutoForwardDiff(), static_scenarios(); logging=LOGGING)
-
-@testset verbose = true "StaticArrays" begin
     @testset "Batch size" begin
         @test DI.pick_batchsize(AutoForwardDiff(), rand(7)) isa DI.BatchSizeSettings{7}
         @test DI.pick_batchsize(AutoForwardDiff(; chunksize=5), rand(7)) isa
@@ -87,23 +81,7 @@ test_differentiation(AutoForwardDiff(), static_scenarios(); logging=LOGGING)
             AutoForwardDiff(; chunksize=5), @SVector(rand(7))
         )) isa DI.BatchSizeSettings{5}
     end
-
-    filtered_static_scenarios = filter(static_scenarios(; include_batchified=false)) do scen
-        DIT.function_place(scen) == :out && DIT.operator_place(scen) == :out
-    end
-    data = benchmark_differentiation(
-        AutoForwardDiff(),
-        filtered_static_scenarios;
-        benchmark=:prepared,
-        excluded=[:hessian, :pullback],  # TODO: figure this out
-        logging=LOGGING,
-    )
-    @testset "Analyzing benchmark results" begin
-        @testset "$(row[:scenario])" for row in eachrow(data)
-            @test row[:allocs] == 0
-        end
-    end
-end;
+end
 
 @testset verbose = true "Overloaded inputs" begin
     backend = AutoForwardDiff()


### PR DESCRIPTION
- For array-to-array pushforwards with FiniteDiff, enable preparation thanks to the new `JVPCache`
- Add benchmarks proving that sparse Jacobians are now alloc-free for ForwardDiff and FiniteDiff

Related:

- https://github.com/JuliaDiff/FiniteDiff.jl/pull/191