### PR TITLE
perf: reduce allocations with Enzyme for in-place functions

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,7 +25,7 @@ jobs:
       actions: write
       contents: read
     strategy:
-      fail-fast: false  # TODO: toggle
+      fail-fast: true  # TODO: toggle
       matrix:
         version:
           - "1.10"

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.35"
+version = "0.6.36"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/docs/src/explanation/backends.md
+++ b/DifferentiationInterface/docs/src/explanation/backends.md
@@ -67,7 +67,7 @@ Moreover, each context type is supported by a specific subset of backends:
 | `AutoFiniteDifferences`    | ✅                  | ✅               |
 | `AutoForwardDiff`          | ✅                  | ✅               |
 | `AutoGTPSA`                | ✅                  | ❌               |
-| `AutoMooncake`             | ✅                  | ❌               |
+| `AutoMooncake`             | ✅                  | ✅               |
 | `AutoPolyesterForwardDiff` | ✅                  | ✅               |
 | `AutoReverseDiff`          | ✅                  | ❌               |
 | `AutoSymbolics`            | ✅                  | ❌               |

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -82,7 +82,7 @@ function DI.value_and_pushforward!(
     y_and_ty = BatchDuplicated(y, ty_sametype)
     annotated_contexts = translate(backend, mode, Val(B), contexts...)
     autodiff(mode, f!_and_df!, Const, y_and_ty, x_and_tx, annotated_contexts...)
-    foreach(copyto_if_different_addresses!, ty_sametype, ty)
+    foreach(copyto_if_different_addresses!, ty, ty_sametype)
     return y, ty
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -1,6 +1,6 @@
 ## Pullback
 
-struct EnzymeReverseTwoArgPullbackPrep{TY}
+struct EnzymeReverseTwoArgPullbackPrep{TY} <: DI.PullbackPrep
     ty_copy::TY
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -115,6 +115,7 @@ function DI.value_and_pullback!(
     mode = reverse_noprimal(backend)
     f!_and_df! = get_f_and_df(f!, backend, mode)
     dx_sametype = convert(typeof(x), only(tx))
+    make_zero!(dx_sametype)
     dy_sametype = convert(typeof(y), only(prep.ty_copy))
     x_and_dx = Duplicated(x, dx_sametype)
     y_and_dy = Duplicated(y, dy_sametype)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_twoarg.jl
@@ -1,5 +1,9 @@
 ## Pullback
 
+struct EnzymeReverseTwoArgPullbackPrep{TY}
+    ty_copy::TY
+end
+
 function DI.prepare_pullback(
     f!::F,
     y,
@@ -8,21 +12,22 @@ function DI.prepare_pullback(
     ty::NTuple,
     contexts::Vararg{DI.Context,C},
 ) where {F,C}
-    return DI.NoPullbackPrep()
+    return EnzymeReverseTwoArgPullbackPrep(map(copy, ty))
 end
 
 function DI.value_and_pullback(
     f!::F,
     y,
-    ::DI.NoPullbackPrep,
+    prep::EnzymeReverseTwoArgPullbackPrep,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     ty::NTuple{1},
     contexts::Vararg{DI.Context,C},
 ) where {F,C}
+    copyto!(only(prep.ty_copy), only(ty))
     mode = reverse_noprimal(backend)
     f!_and_df! = get_f_and_df(f!, backend, mode)
-    dy_sametype = convert(typeof(y), copy(only(ty)))
+    dy_sametype = convert(typeof(y), only(prep.ty_copy))
     y_and_dy = Duplicated(y, dy_sametype)
     annotated_contexts = translate(backend, mode, Val(1), contexts...)
     dinputs = only(
@@ -35,15 +40,16 @@ end
 function DI.value_and_pullback(
     f!::F,
     y,
-    ::DI.NoPullbackPrep,
+    prep::EnzymeReverseTwoArgPullbackPrep,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x::Number,
     ty::NTuple{B},
     contexts::Vararg{DI.Context,C},
 ) where {F,B,C}
+    foreach(copyto!, prep.ty_copy, ty)
     mode = reverse_noprimal(backend)
     f!_and_df! = get_f_and_df(f!, backend, mode, Val(B))
-    ty_sametype = map(Fix1(convert, typeof(y)), copy.(ty))
+    ty_sametype = map(Fix1(convert, typeof(y)), prep.ty_copy)
     y_and_ty = BatchDuplicated(y, ty_sametype)
     annotated_contexts = translate(backend, mode, Val(B), contexts...)
     dinputs = only(
@@ -56,16 +62,17 @@ end
 function DI.value_and_pullback(
     f!::F,
     y,
-    ::DI.NoPullbackPrep,
+    prep::EnzymeReverseTwoArgPullbackPrep,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::NTuple{1},
     contexts::Vararg{DI.Context,C},
 ) where {F,C}
+    copyto!(only(prep.ty_copy), only(ty))
     mode = reverse_noprimal(backend)
     f!_and_df! = get_f_and_df(f!, backend, mode)
-    dx_sametype = make_zero(x)
-    dy_sametype = convert(typeof(y), copy(only(ty)))
+    dx_sametype = make_zero(x)  # allocates
+    dy_sametype = convert(typeof(y), only(prep.ty_copy))
     x_and_dx = Duplicated(x, dx_sametype)
     y_and_dy = Duplicated(y, dy_sametype)
     annotated_contexts = translate(backend, mode, Val(1), contexts...)
@@ -76,19 +83,67 @@ end
 function DI.value_and_pullback(
     f!::F,
     y,
-    ::DI.NoPullbackPrep,
+    prep::EnzymeReverseTwoArgPullbackPrep,
     backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
     x,
     ty::NTuple{B},
     contexts::Vararg{DI.Context,C},
 ) where {F,B,C}
+    foreach(copyto!, prep.ty_copy, ty)
     mode = reverse_noprimal(backend)
     f!_and_df! = get_f_and_df(f!, backend, mode, Val(B))
-    tx_sametype = ntuple(_ -> make_zero(x), Val(B))
-    ty_sametype = map(Fix1(convert, typeof(y)), copy.(ty))
+    tx_sametype = ntuple(_ -> make_zero(x), Val(B))  # allocates
+    ty_sametype = map(Fix1(convert, typeof(y)), prep.ty_copy)
     x_and_tx = BatchDuplicated(x, tx_sametype)
     y_and_ty = BatchDuplicated(y, ty_sametype)
     annotated_contexts = translate(backend, mode, Val(B), contexts...)
     autodiff(mode, f!_and_df!, Const, y_and_ty, x_and_tx, annotated_contexts...)
+    return y, tx_sametype
+end
+
+function DI.value_and_pullback!(
+    f!::F,
+    y,
+    tx::NTuple{1},
+    prep::EnzymeReverseTwoArgPullbackPrep,
+    backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
+    x,
+    ty::NTuple{1},
+    contexts::Vararg{DI.Context,C},
+) where {F,C}
+    copyto!(only(prep.ty_copy), only(ty))
+    mode = reverse_noprimal(backend)
+    f!_and_df! = get_f_and_df(f!, backend, mode)
+    dx_sametype = convert(typeof(x), only(tx))
+    dy_sametype = convert(typeof(y), only(prep.ty_copy))
+    x_and_dx = Duplicated(x, dx_sametype)
+    y_and_dy = Duplicated(y, dy_sametype)
+    annotated_contexts = translate(backend, mode, Val(1), contexts...)
+    autodiff(mode, f!_and_df!, Const, y_and_dy, x_and_dx, annotated_contexts...)
+    copyto_if_different_addresses!(only(tx), dx_sametype)
+    return y, (dx_sametype,)
+end
+
+function DI.value_and_pullback!(
+    f!::F,
+    y,
+    tx::NTuple{B},
+    prep::EnzymeReverseTwoArgPullbackPrep,
+    backend::AutoEnzyme{<:Union{ReverseMode,Nothing}},
+    x,
+    ty::NTuple{B},
+    contexts::Vararg{DI.Context,C},
+) where {F,B,C}
+    foreach(copyto!, prep.ty_copy, ty)
+    mode = reverse_noprimal(backend)
+    f!_and_df! = get_f_and_df(f!, backend, mode, Val(B))
+    tx_sametype = map(Fix1(convert, typeof(x)), tx)
+    make_zero!(tx_sametype)
+    ty_sametype = map(Fix1(convert, typeof(y)), prep.ty_copy)
+    x_and_tx = BatchDuplicated(x, tx_sametype)
+    y_and_ty = BatchDuplicated(y, ty_sametype)
+    annotated_contexts = translate(backend, mode, Val(B), contexts...)
+    autodiff(mode, f!_and_df!, Const, y_and_ty, x_and_tx, annotated_contexts...)
+    foreach(copyto_if_different_addresses!, tx, tx_sametype)
     return y, tx_sametype
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -111,3 +111,10 @@ end
 
 batchify_activity(::Type{Active{T}}, ::Val{B}) where {T,B} = Active{T}
 batchify_activity(::Type{Duplicated{T}}, ::Val{B}) where {T,B} = BatchDuplicated{T,B}
+
+@inline function copyto_if_different_addresses!(dst, src)
+    if dst !== src
+        copyto!(dst, src)
+    end
+    return dst
+end

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -124,3 +124,44 @@ end
         logging=LOGGING,
     )
 end
+
+@testset "Wrong type tangent" begin
+    x, y = [1.0], [1.0]
+    # pushforward
+    dx, dy = [2.0f0], [0.0f0]
+    @test pushforward!(
+        copy, (similar(dy),), AutoEnzyme(; mode=Enzyme.Forward), x, (dx,)
+    )[1] == [2]
+    @test pushforward!(
+        copy, (similar(dy), similar(dy)), AutoEnzyme(; mode=Enzyme.Forward), x, (dx, -dx)
+    )[2] == -[2]
+    @test pushforward!(
+        copyto!, y, (similar(dy),), AutoEnzyme(; mode=Enzyme.Forward), x, (dx,)
+    )[1] == [2]
+    @test pushforward!(
+        copyto!,
+        y,
+        (similar(dy), similar(dy)),
+        AutoEnzyme(; mode=Enzyme.Forward),
+        x,
+        (dx, -dx),
+    )[2] == -[2]
+    # pullback
+    dy, dx = [2.0f0], [0.0f0]
+    @test pullback!(copy, (similar(dx),), AutoEnzyme(; mode=Enzyme.Reverse), x, (dy,))[1] ==
+        [2]
+    @test pullback!(
+        copy, (similar(dx), similar(dx)), AutoEnzyme(; mode=Enzyme.Reverse), x, (dy, -dy)
+    )[2] == -[2]
+    @test pullback!(
+        copyto!, y, (similar(dx),), AutoEnzyme(; mode=Enzyme.Reverse), x, (dy,)
+    )[1] == [2]
+    @test pullback!(
+        copyto!,
+        y,
+        (similar(dx), similar(dx)),
+        AutoEnzyme(; mode=Enzyme.Reverse),
+        x,
+        (dy, -dy),
+    )[2] == -[2]
+end

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -23,10 +23,10 @@ function remove_matrix_inputs(scens::Vector{<:Scenario})  # TODO: remove
 end
 
 backends = [
-    AutoEnzyme(; mode=nothing),
+    # AutoEnzyme(; mode=nothing),
     AutoEnzyme(; mode=Enzyme.Forward),
     AutoEnzyme(; mode=Enzyme.Reverse),
-    AutoEnzyme(; mode=nothing, function_annotation=Enzyme.Const),
+    # AutoEnzyme(; mode=nothing, function_annotation=Enzyme.Const),
 ]
 
 duplicated_backends = [

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -23,10 +23,10 @@ function remove_matrix_inputs(scens::Vector{<:Scenario})  # TODO: remove
 end
 
 backends = [
-    # AutoEnzyme(; mode=nothing),
+    AutoEnzyme(; mode=nothing),
     AutoEnzyme(; mode=Enzyme.Forward),
     AutoEnzyme(; mode=Enzyme.Reverse),
-    # AutoEnzyme(; mode=nothing, function_annotation=Enzyme.Const),
+    AutoEnzyme(; mode=nothing, function_annotation=Enzyme.Const),
 ]
 
 duplicated_backends = [

--- a/DifferentiationInterface/test/Back/Mooncake/test.jl
+++ b/DifferentiationInterface/test/Back/Mooncake/test.jl
@@ -19,7 +19,7 @@ end
 
 test_differentiation(
     backends,
-    default_scenarios(; include_constantified=true);
+    default_scenarios(; include_constantified=true, include_cachified=true);
     excluded=SECOND_ORDER,
     logging=LOGGING,
 );


### PR DESCRIPTION
- Implement faster `pushforward!` and `pullback!` for Enzyme instead of falling back on `pushforward` and `pullback`
- Store a copy of `ty` in the `prep` for `pullback` since it gets reverted by the reverse pass
- Precompute an example `y` for `pullback` to be able to deduce the correct return activity `RA` without relying on `ty` (otherwise it fails when the tangent has the wrong type)

---

- Fix a Mooncake missing test and docs typo