### PR TITLE
feat: support cache contexts with Zygote using Buffer

### DIFF
--- a/DifferentiationInterface/docs/src/explanation/backends.md
+++ b/DifferentiationInterface/docs/src/explanation/backends.md
@@ -72,7 +72,7 @@ Moreover, each context type is supported by a specific subset of backends:
 | `AutoReverseDiff`          | ✅                  | ❌               |
 | `AutoSymbolics`            | ✅                  | ❌               |
 | `AutoTracker`              | ✅                  | ❌               |
-| `AutoZygote`               | ✅                  | ❌               |
+| `AutoZygote`               | ✅                  | 🔀               |
 
 ## Second order
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -4,7 +4,14 @@ using ADTypes: AutoForwardDiff, AutoZygote
 import DifferentiationInterface as DI
 using ForwardDiff: ForwardDiff
 using Zygote:
-    ZygoteRuleConfig, gradient, hessian, jacobian, pullback, withgradient, withjacobian
+    Buffer,
+    ZygoteRuleConfig,
+    gradient,
+    hessian,
+    jacobian,
+    pullback,
+    withgradient,
+    withjacobian
 
 struct ZygoteNothingError <: Exception
     f
@@ -27,6 +34,9 @@ check_nothing(::Any, f, x, contexts) = nothing
 DI.check_available(::AutoZygote) = true
 DI.inplace_support(::AutoZygote) = DI.InPlaceNotSupported()
 
+translate(c::DI.Context) = DI.unwrap(c)
+translate(c::DI.Cache) = Buffer(DI.unwrap(c))
+
 ## Pullback
 
 struct ZygotePullbackPrepSamePoint{Y,PB} <: DI.PullbackPrep
@@ -35,32 +45,22 @@ struct ZygotePullbackPrepSamePoint{Y,PB} <: DI.PullbackPrep
 end
 
 function DI.prepare_pullback(
-    f, ::AutoZygote, x, ty::NTuple, contexts::Vararg{DI.ConstantOrFunctionOrBackend,C}
+    f, ::AutoZygote, x, ty::NTuple, contexts::Vararg{DI.Context,C}
 ) where {C}
     return DI.NoPullbackPrep()
 end
 
 function DI.prepare_pullback_same_point(
-    f,
-    ::DI.NoPullbackPrep,
-    ::AutoZygote,
-    x,
-    ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoPullbackPrep, ::AutoZygote, x, ty::NTuple, contexts::Vararg{DI.Context,C}
 ) where {C}
-    y, pb = pullback(f, x, map(DI.unwrap, contexts)...)
+    y, pb = pullback(f, x, map(translate, contexts)...)
     return ZygotePullbackPrepSamePoint(y, pb)
 end
 
 function DI.value_and_pullback(
-    f,
-    ::DI.NoPullbackPrep,
-    ::AutoZygote,
-    x,
-    ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoPullbackPrep, ::AutoZygote, x, ty::NTuple, contexts::Vararg{DI.Context,C}
 ) where {C}
-    y, pb = pullback(f, x, map(DI.unwrap, contexts)...)
+    y, pb = pullback(f, x, map(translate, contexts)...)
     tx = map(ty) do dy
         first(pb(dy))
     end
@@ -74,7 +74,7 @@ function DI.value_and_pullback(
     ::AutoZygote,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.Context,C},
 ) where {C}
     (; y, pb) = prep
     tx = map(ty) do dy
@@ -90,7 +90,7 @@ function DI.pullback(
     ::AutoZygote,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.Context,C},
 ) where {C}
     (; pb) = prep
     tx = map(ty) do dy
@@ -102,112 +102,72 @@ end
 
 ## Gradient
 
-function DI.prepare_gradient(
-    f, ::AutoZygote, x, contexts::Vararg{DI.ConstantOrFunctionOrBackend,C}
-) where {C}
+function DI.prepare_gradient(f, ::AutoZygote, x, contexts::Vararg{DI.Context,C}) where {C}
     return DI.NoGradientPrep()
 end
 
 function DI.value_and_gradient(
-    f,
-    ::DI.NoGradientPrep,
-    ::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoGradientPrep, ::AutoZygote, x, contexts::Vararg{DI.Context,C}
 ) where {C}
-    (; val, grad) = withgradient(f, x, map(DI.unwrap, contexts)...)
+    (; val, grad) = withgradient(f, x, map(translate, contexts)...)
     check_nothing(first(grad), f, x, contexts)
     return val, first(grad)
 end
 
 function DI.gradient(
-    f,
-    ::DI.NoGradientPrep,
-    ::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoGradientPrep, ::AutoZygote, x, contexts::Vararg{DI.Context,C}
 ) where {C}
-    grad = gradient(f, x, map(DI.unwrap, contexts)...)
+    grad = gradient(f, x, map(translate, contexts)...)
     check_nothing(first(grad), f, x, contexts)
     return first(grad)
 end
 
 function DI.value_and_gradient!(
-    f,
-    grad,
-    prep::DI.NoGradientPrep,
-    backend::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, grad, prep::DI.NoGradientPrep, backend::AutoZygote, x, contexts::Vararg{DI.Context,C}
 ) where {C}
     y, new_grad = DI.value_and_gradient(f, prep, backend, x, contexts...)
     return y, copyto!(grad, new_grad)
 end
 
 function DI.gradient!(
-    f,
-    grad,
-    prep::DI.NoGradientPrep,
-    backend::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, grad, prep::DI.NoGradientPrep, backend::AutoZygote, x, contexts::Vararg{DI.Context,C}
 ) where {C}
     return copyto!(grad, DI.gradient(f, prep, backend, x, contexts...))
 end
 
 ## Jacobian
 
-function DI.prepare_jacobian(
-    f, ::AutoZygote, x, contexts::Vararg{DI.ConstantOrFunctionOrBackend,C}
-) where {C}
+function DI.prepare_jacobian(f, ::AutoZygote, x, contexts::Vararg{DI.Context,C}) where {C}
     return DI.NoJacobianPrep()
 end
 
 function DI.value_and_jacobian(
-    f,
-    ::DI.NoJacobianPrep,
-    ::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoJacobianPrep, ::AutoZygote, x, contexts::Vararg{DI.Context,C}
 ) where {C}
-    y = f(x, map(DI.unwrap, contexts)...)
+    y = f(x, map(translate, contexts)...)
     # https://github.com/FluxML/Zygote.jl/issues/1506
-    jac = jacobian(f, x, map(DI.unwrap, contexts)...)
+    jac = jacobian(f, x, map(translate, contexts)...)
     check_nothing(first(jac), f, x, contexts)
     return y, first(jac)
 end
 
 function DI.jacobian(
-    f,
-    ::DI.NoJacobianPrep,
-    ::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoJacobianPrep, ::AutoZygote, x, contexts::Vararg{DI.Context,C}
 ) where {C}
-    jac = jacobian(f, x, map(DI.unwrap, contexts)...)
+    jac = jacobian(f, x, map(translate, contexts)...)
     check_nothing(first(jac), f, x, contexts)
     return first(jac)
 end
 
 function DI.value_and_jacobian!(
-    f,
-    jac,
-    prep::DI.NoJacobianPrep,
-    backend::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, jac, prep::DI.NoJacobianPrep, backend::AutoZygote, x, contexts::Vararg{DI.Context,C}
 ) where {C}
     y, new_jac = DI.value_and_jacobian(f, prep, backend, x, contexts...)
     return y, copyto!(jac, new_jac)
 end
 
 function DI.jacobian!(
-    f,
-    jac,
-    prep::DI.NoJacobianPrep,
-    backend::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, jac, prep::DI.NoJacobianPrep, backend::AutoZygote, x, contexts::Vararg{DI.Context,C}
 ) where {C}
     return copyto!(jac, DI.jacobian(f, prep, backend, x, contexts...))
 end
@@ -217,22 +177,13 @@ end
 # Beware, this uses ForwardDiff for the inner differentiation
 
 function DI.prepare_hvp(
-    f,
-    backend::AutoZygote,
-    x,
-    tx::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, backend::AutoZygote, x, tx::NTuple, contexts::Vararg{DI.Context,C}
 ) where {C}
     return DI.prepare_hvp(f, DI.SecondOrder(AutoForwardDiff(), backend), x, tx, contexts...)
 end
 
 function DI.hvp(
-    f,
-    prep::DI.HVPPrep,
-    backend::AutoZygote,
-    x,
-    tx::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, prep::DI.HVPPrep, backend::AutoZygote, x, tx::NTuple, contexts::Vararg{DI.Context,C}
 ) where {C}
     return DI.hvp(f, prep, DI.SecondOrder(AutoForwardDiff(), backend), x, tx, contexts...)
 end
@@ -244,7 +195,7 @@ function DI.hvp!(
     backend::AutoZygote,
     x,
     tx::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.Context,C},
 ) where {C}
     return DI.hvp!(
         f, tg, prep, DI.SecondOrder(AutoForwardDiff(), backend), x, tx, contexts...
@@ -252,12 +203,7 @@ function DI.hvp!(
 end
 
 function DI.gradient_and_hvp(
-    f,
-    prep::DI.HVPPrep,
-    backend::AutoZygote,
-    x,
-    tx::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, prep::DI.HVPPrep, backend::AutoZygote, x, tx::NTuple, contexts::Vararg{DI.Context,C}
 ) where {C}
     return DI.gradient_and_hvp(
         f, prep, DI.SecondOrder(AutoForwardDiff(), backend), x, tx, contexts...
@@ -272,7 +218,7 @@ function DI.gradient_and_hvp!(
     backend::AutoZygote,
     x,
     tx::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.Context,C},
 ) where {C}
     return DI.gradient_and_hvp!(
         f, grad, tg, prep, DI.SecondOrder(AutoForwardDiff(), backend), x, tx, contexts...

--- a/DifferentiationInterface/test/Back/Zygote/test.jl
+++ b/DifferentiationInterface/test/Back/Zygote/test.jl
@@ -27,7 +27,7 @@ end
 @testset "Dense" begin
     test_differentiation(
         backends,
-        default_scenarios(; include_constantified=true);
+        default_scenarios(; include_constantified=true, include_cachified=true);
         excluded=[:second_derivative],
         logging=LOGGING,
     )


### PR DESCRIPTION
- Translate `DI.Cache` contexts into a `Zygote.Buffer`. Note that this requires avoiding type annotations `::AbstractArray` for such arguments.