### PR TITLE
fix: correct FastDifferentiation error with in-place matrix operators

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.39"
+version = "0.6.40"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/onearg.jl
@@ -56,7 +56,7 @@ function DI.pushforward!(
 ) where {C}
     for b in eachindex(tx, ty)
         dx, dy = tx[b], ty[b]
-        prep.jvp_exe!(vec(dy), myvec(x), myvec(dx), map(myvec_unwrap, contexts)...)
+        prep.jvp_exe!(myvec(dy), myvec(x), myvec(dx), map(myvec_unwrap, contexts)...)
     end
     return ty
 end
@@ -143,7 +143,7 @@ function DI.pullback!(
 ) where {C}
     for b in eachindex(tx, ty)
         dx, dy = tx[b], ty[b]
-        prep.vjp_exe!(vec(dx), myvec(x), myvec(dy), map(myvec_unwrap, contexts)...)
+        prep.vjp_exe!(myvec(dx), myvec(x), myvec(dy), map(myvec_unwrap, contexts)...)
     end
     return tx
 end
@@ -221,7 +221,7 @@ function DI.derivative!(
     x,
     contexts::Vararg{DI.Context,C},
 ) where {C}
-    prep.der_exe!(vec(der), myvec(x), map(myvec_unwrap, contexts)...)
+    prep.der_exe!(myvec(der), myvec(x), map(myvec_unwrap, contexts)...)
     return der
 end
 
@@ -448,7 +448,7 @@ function DI.second_derivative!(
     x,
     contexts::Vararg{DI.Context,C},
 ) where {C}
-    prep.der2_exe!(vec(der2), myvec(x), map(myvec_unwrap, contexts)...)
+    prep.der2_exe!(myvec(der2), myvec(x), map(myvec_unwrap, contexts)...)
     return der2
 end
 
@@ -533,7 +533,7 @@ function DI.hvp!(
 ) where {C}
     for b in eachindex(tx, tg)
         dx, dg = tx[b], tg[b]
-        prep.hvp_exe!(dg, myvec(x), myvec(dx), map(myvec_unwrap, contexts)...)
+        prep.hvp_exe!(myvec(dg), myvec(x), myvec(dx), map(myvec_unwrap, contexts)...)
     end
     return tg
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFastDifferentiationExt/twoarg.jl
@@ -228,7 +228,7 @@ function DI.value_and_derivative!(
     contexts::Vararg{DI.Context,C},
 ) where {C}
     f!(y, x, map(DI.unwrap, contexts)...)
-    prep.der_exe!(der, myvec(x), map(myvec_unwrap, contexts)...)
+    prep.der_exe!(myvec(der), myvec(x), map(myvec_unwrap, contexts)...)
     return y, der
 end
 
@@ -253,7 +253,7 @@ function DI.derivative!(
     x,
     contexts::Vararg{DI.Context,C},
 ) where {C}
-    prep.der_exe!(der, myvec(x), map(myvec_unwrap, contexts)...)
+    prep.der_exe!(myvec(der), myvec(x), map(myvec_unwrap, contexts)...)
     return der
 end
 

--- a/DifferentiationInterface/test/Back/SymbolicBackends/fastdifferentiation.jl
+++ b/DifferentiationInterface/test/Back/SymbolicBackends/fastdifferentiation.jl
@@ -17,9 +17,7 @@ end
 
 test_differentiation(
     AutoFastDifferentiation(),
-    filter(default_scenarios(; include_constantified=true, include_cachified=true)) do s
-        !(s.x isa AbstractMatrix) && !(s.y isa AbstractMatrix)
-    end;
+    default_scenarios(; include_constantified=true, include_cachified=true);
     logging=LOGGING,
 );
 


### PR DESCRIPTION
Fixes #677 thanks to the advice in https://github.com/brianguenter/FastDifferentiation.jl/issues/106