### PR TITLE
test: add Mooncake to Lux and Flux tests

### DIFF
--- a/DifferentiationInterface/test/Down/Flux/test.jl
+++ b/DifferentiationInterface/test/Down/Flux/test.jl
@@ -1,11 +1,12 @@
 using Pkg
-Pkg.add(["FiniteDifferences", "Enzyme", "Flux", "Zygote"])
+Pkg.add(["FiniteDifferences", "Enzyme", "Flux", "Mooncake", "Zygote"])
 
 using DifferentiationInterface, DifferentiationInterfaceTest
 import DifferentiationInterfaceTest as DIT
 using Enzyme: Enzyme
 using FiniteDifferences: FiniteDifferences
 using Flux: Flux
+using Mooncake: Mooncake
 using Random
 using Zygote: Zygote
 using Test
@@ -14,6 +15,7 @@ LOGGING = get(ENV, "CI", "false") == "false"
 
 test_differentiation(
     [
+        AutoMooncake(; config=nothing),
         AutoZygote(),
         # AutoEnzyme(), # TODO a few scenarios fail
     ],

--- a/DifferentiationInterface/test/Down/Lux/test.jl
+++ b/DifferentiationInterface/test/Down/Lux/test.jl
@@ -1,5 +1,5 @@
 using Pkg
-Pkg.add(["ForwardDiff", "Lux", "LuxTestUtils", "Zygote"])
+Pkg.add(["ForwardDiff", "Lux", "LuxTestUtils", "Mooncake", "Zygote"])
 
 using ComponentArrays: ComponentArrays
 using DifferentiationInterface, DifferentiationInterfaceTest
@@ -7,12 +7,13 @@ import DifferentiationInterfaceTest as DIT
 using ForwardDiff: ForwardDiff
 using Lux: Lux
 using LuxTestUtils: LuxTestUtils
+using Mooncake: Mooncake
 using Random
 
 LOGGING = get(ENV, "CI", "false") == "false"
 
 test_differentiation(
-    AutoZygote(),
+    [AutoMooncake(; config=nothing), AutoZygote()],
     DIT.lux_scenarios(Random.Xoshiro(63));
     isapprox=DIT.lux_isapprox,
     rtol=1.0f-2,


### PR DESCRIPTION
At the moment, the Lux tests are still based on ComponentArrays, we should probably change that to handle native parameter gradients