### PR TITLE
perf: preallocate `Cache` during preparation for ForwardDiff

### DIFF
--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.6.45"
+version = "0.6.46"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -24,6 +24,7 @@ using ForwardDiff:
     jacobian,
     jacobian!,
     partials,
+    pickchunksize,
     value
 
 DI.check_available(::AutoForwardDiff) = true
@@ -31,7 +32,7 @@ DI.check_available(::AutoForwardDiff) = true
 include("utils.jl")
 include("onearg.jl")
 include("twoarg.jl")
-include("secondorder.jl")
+# include("secondorder.jl")
 include("differentiate_with.jl")
 include("misc.jl")
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -17,8 +17,6 @@ end
 choose_chunk(::AutoForwardDiff{nothing}, x) = Chunk(x)
 choose_chunk(::AutoForwardDiff{chunksize}, x) where {chunksize} = Chunk{chunksize}()
 
-batchsize_val(::Chunk{C}) where {C} = Val(C)
-
 get_tag(f, backend::AutoForwardDiff, x) = backend.tag
 
 function get_tag(f::F, ::AutoForwardDiff{chunksize,Nothing}, x) where {F,chunksize}

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/onearg.jl
@@ -288,6 +288,7 @@ end
 
 ## HVP
 
+#=
 function DI.prepare_hvp(
     f, backend::AutoPolyesterForwardDiff, x, tx::NTuple, contexts::Vararg{DI.Context,C}
 ) where {C}
@@ -357,6 +358,7 @@ function DI.gradient_and_hvp!(
         contexts...,
     )
 end
+=#
 
 ## Second derivative
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceSparseConnectivityTracerExt/DifferentiationInterfaceSparseConnectivityTracerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceSparseConnectivityTracerExt/DifferentiationInterfaceSparseConnectivityTracerExt.jl
@@ -36,7 +36,7 @@ function DI.jacobian_sparsity_with_contexts(
     contexts::Vararg{DI.Context,C},
 ) where {F,C}
     contexts_tracer = jacobian_translate(detector, contexts...)
-    fc = DI.FixTail(f, contexts_tracer)
+    fc = DI.FixTail(f, contexts_tracer...)
     return jacobian_sparsity(fc, x, detector)
 end
 
@@ -48,7 +48,7 @@ function DI.jacobian_sparsity_with_contexts(
     contexts::Vararg{DI.Context,C},
 ) where {F,C}
     contexts_tracer = jacobian_translate(detector, contexts...)
-    fc! = DI.FixTail(f!, contexts_tracer)
+    fc! = DI.FixTail(f!, contexts_tracer...)
     return jacobian_sparsity(fc!, y, x, detector)
 end
 
@@ -59,7 +59,7 @@ function DI.hessian_sparsity_with_contexts(
     contexts::Vararg{DI.Context,C},
 ) where {F,C}
     contexts_tracer = hessian_translate(detector, contexts...)
-    fc = DI.FixTail(f, contexts_tracer)
+    fc = DI.FixTail(f, contexts_tracer...)
     return hessian_sparsity(fc, x, detector)
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -158,7 +158,12 @@ function DI.prepare_hvp(
 end
 
 function DI.hvp(
-    f, prep::DI.HVPPrep, backend::AutoZygote, x, tx::NTuple, contexts::Vararg{DI.Context,C}
+    f,
+    prep::DI.ForwardOverReverseHVPPrep,
+    backend::AutoZygote,
+    x,
+    tx::NTuple,
+    contexts::Vararg{DI.Context,C},
 ) where {C}
     return DI.hvp(f, prep, DI.SecondOrder(AutoForwardDiff(), backend), x, tx, contexts...)
 end
@@ -166,7 +171,7 @@ end
 function DI.hvp!(
     f,
     tg::NTuple,
-    prep::DI.HVPPrep,
+    prep::DI.ForwardOverReverseHVPPrep,
     backend::AutoZygote,
     x,
     tx::NTuple,
@@ -178,7 +183,12 @@ function DI.hvp!(
 end
 
 function DI.gradient_and_hvp(
-    f, prep::DI.HVPPrep, backend::AutoZygote, x, tx::NTuple, contexts::Vararg{DI.Context,C}
+    f,
+    prep::DI.ForwardOverReverseHVPPrep,
+    backend::AutoZygote,
+    x,
+    tx::NTuple,
+    contexts::Vararg{DI.Context,C},
 ) where {C}
     return DI.gradient_and_hvp(
         f, prep, DI.SecondOrder(AutoForwardDiff(), backend), x, tx, contexts...
@@ -189,7 +199,7 @@ function DI.gradient_and_hvp!(
     f,
     grad,
     tg::NTuple,
-    prep::DI.HVPPrep,
+    prep::DI.ForwardOverReverseHVPPrep,
     backend::AutoZygote,
     x,
     tx::NTuple,

--- a/DifferentiationInterface/src/utils/context.jl
+++ b/DifferentiationInterface/src/utils/context.jl
@@ -1,6 +1,9 @@
 struct FixTail{F,A<:Tuple}
     f::F
     tail_args::A
+    function FixTail(f::F, tail_args::Vararg{Any,N}) where {F,N}
+        return new{F,typeof(tail_args)}(f, tail_args)
+    end
 end
 
 function (ft::FixTail)(args::Vararg{Any,N}) where {N}
@@ -113,5 +116,5 @@ with_contexts(f) = f
 
 function with_contexts(f::F, contexts::Vararg{Context,N}) where {F,N}
     tail_args = map(unwrap, contexts)
-    return FixTail(f, tail_args)
+    return FixTail(f, tail_args...)
 end

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -42,7 +42,11 @@ end
     )
 
     test_differentiation(
-        AutoForwardDiff(); correctness=false, type_stability=:prepared, logging=LOGGING
+        AutoForwardDiff();
+        correctness=false,
+        type_stability=:prepared,
+        excluded=[:hvp],  # TODO: toggle
+        logging=LOGGING,
     )
 
     test_differentiation(


### PR DESCRIPTION
- Add a `contexts_dual` field to most preparation objects in the ForwardDiff extension
- Initialize this field with a tuple of the same size as `contexts`, except that
  - non-`Cache` contexts are replaced by `nothing`
  - `Cache` contexts are replaced by `similar(c, Dual{...})`
- During prepared execution, take the `Cache` contexts from `prep.contexts_dual`
- Create `Config`s with `f=nothing` because the `tag` captures the relevant type
- Only take the no-preparation shortcuts when there are no `Cache` contexts
- Temporarily deactivate (Polyester)ForwardDiff HVP optimizations, must be reactivated before the next release