### PR TITLE
perf: HVP with in-place gradient + inner preparation

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,7 +25,7 @@ jobs:
       actions: write
       contents: read
     strategy:
-      fail-fast: false  # TODO: toggle
+      fail-fast: true  # TODO: toggle
       matrix:
         version:
           - "1.10"

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -25,7 +25,7 @@ jobs:
       actions: write
       contents: read
     strategy:
-      fail-fast: true  # TODO: toggle
+      fail-fast: false  # TODO: toggle
       matrix:
         version:
           - "1.10"

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -109,4 +109,22 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["ADTypes", "Aqua", "ComponentArrays", "DataFrames", "ExplicitImports", "JET", "JLArrays", "JuliaFormatter", "Pkg", "Random", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StableRNGs", "StaticArrays", "Test"]
+test = [
+    "ADTypes",
+    "Aqua",
+    "ComponentArrays",
+    "DataFrames",
+    "ExplicitImports",
+    "ForwardDiff",
+    "JET",
+    "JLArrays",
+    "JuliaFormatter",
+    "Pkg",
+    "Random",
+    "SparseArrays",
+    "SparseConnectivityTracer",
+    "SparseMatrixColorings",
+    "StableRNGs",
+    "StaticArrays",
+    "Test",
+]

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -39,7 +39,7 @@ DifferentiationInterfaceFiniteDifferencesExt = "FiniteDifferences"
 DifferentiationInterfaceForwardDiffExt = ["ForwardDiff", "DiffResults"]
 DifferentiationInterfaceGTPSAExt = "GTPSA"
 DifferentiationInterfaceMooncakeExt = "Mooncake"
-DifferentiationInterfacePolyesterForwardDiffExt = "PolyesterForwardDiff"
+DifferentiationInterfacePolyesterForwardDiffExt = ["PolyesterForwardDiff", "ForwardDiff", "DiffResults"]
 DifferentiationInterfaceReverseDiffExt = ["ReverseDiff", "DiffResults"]
 DifferentiationInterfaceSparseArraysExt = "SparseArrays"
 DifferentiationInterfaceSparseConnectivityTracerExt = "SparseConnectivityTracer"
@@ -115,7 +115,6 @@ test = [
     "ComponentArrays",
     "DataFrames",
     "ExplicitImports",
-    "ForwardDiff",
     "JET",
     "JLArrays",
     "JuliaFormatter",

--- a/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceChainRulesCoreExt/reverse_onearg.jl
@@ -6,11 +6,7 @@ struct ChainRulesPullbackPrepSamePoint{Y,PB} <: DI.PullbackPrep
 end
 
 function DI.prepare_pullback(
-    f,
-    ::AutoReverseChainRules,
-    x,
-    ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::AutoReverseChainRules, x, ty::NTuple, contexts::Vararg{DI.GeneralizedConstant,C}
 ) where {C}
     return DI.NoPullbackPrep()
 end
@@ -21,7 +17,7 @@ function DI.prepare_pullback_same_point(
     backend::AutoReverseChainRules,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     rc = ruleconfig(backend)
     y, pb = rrule_via_ad(rc, f, x, map(DI.unwrap, contexts)...)
@@ -34,7 +30,7 @@ function DI.value_and_pullback(
     backend::AutoReverseChainRules,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     rc = ruleconfig(backend)
     y, pb = rrule_via_ad(rc, f, x, map(DI.unwrap, contexts)...)
@@ -50,7 +46,7 @@ function DI.value_and_pullback(
     ::AutoReverseChainRules,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     (; y, pb) = prep
     tx = map(ty) do dy
@@ -65,7 +61,7 @@ function DI.pullback(
     ::AutoReverseChainRules,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     (; pb) = prep
     tx = map(ty) do dy

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/utils.jl
@@ -48,13 +48,13 @@ force_annotation(f::F) where {F<:Annotation} = f
 force_annotation(f::F) where {F} = Const(f)
 
 @inline function _translate(
-    ::AutoEnzyme, ::Mode, ::Val{B}, c::Union{DI.Constant,DI.BackendContext}
+    ::AutoEnzyme, ::Mode, ::Val{B}, c::DI.GeneralizedConstant
 ) where {B}
     return Const(DI.unwrap(c))
 end
 
 @inline function _translate(
-    backend::AutoEnzyme, mode::Mode, ::Val{B}, c::DI.Cache
+    ::AutoEnzyme, ::Mode, ::Val{B}, c::DI.GeneralizedCache
 ) where {B}
     if B == 1
         return Duplicated(DI.unwrap(c), make_zero(DI.unwrap(c)))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/DifferentiationInterfaceFiniteDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDiffExt/DifferentiationInterfaceFiniteDiffExt.jl
@@ -21,6 +21,7 @@ using FiniteDiff:
 using LinearAlgebra: dot, mul!
 
 DI.check_available(::AutoFiniteDiff) = true
+DI.inner_preparation_behavior(::AutoFiniteDiff) = DI.PrepareInnerSimple()
 
 # see https://github.com/SciML/ADTypes.jl/issues/33
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceFiniteDifferencesExt/DifferentiationInterfaceFiniteDifferencesExt.jl
@@ -7,6 +7,7 @@ using LinearAlgebra: dot
 
 DI.check_available(::AutoFiniteDifferences) = true
 DI.inplace_support(::AutoFiniteDifferences) = DI.InPlaceNotSupported()
+DI.inner_preparation_behavior(::AutoFiniteDifferences) = DI.PrepareInnerSimple()
 
 ## Pushforward
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/DifferentiationInterfaceForwardDiffExt.jl
@@ -28,6 +28,7 @@ using ForwardDiff:
     value
 
 DI.check_available(::AutoForwardDiff) = true
+DI.inner_preparation_behavior(::AutoForwardDiff) = DI.PrepareInnerOverload()
 
 include("utils.jl")
 include("onearg.jl")

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/misc.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/misc.jl
@@ -3,27 +3,16 @@ DI.overloaded_input_type(prep::ForwardDiffOneArgPushforwardPrep) = typeof(prep.x
 DI.overloaded_input_type(prep::ForwardDiffTwoArgPushforwardPrep) = typeof(prep.xdual_tmp)
 
 function DI.overloaded_input(
-    ::typeof(DI.pushforward),
-    f::F,
-    backend::AutoForwardDiff,
-    x,
-    tx::NTuple{B},
-    contexts::Vararg{DI.Context,C},
-) where {F,B,C}
+    ::typeof(DI.pushforward), f::F, backend::AutoForwardDiff, x, tx::NTuple{B}
+) where {F,B}
     T = tag_type(f, backend, x)
     xdual = make_dual(T, x, tx)
     return xdual
 end
 
 function DI.overloaded_input(
-    ::typeof(DI.pushforward),
-    f!::F,
-    y,
-    backend::AutoForwardDiff,
-    x,
-    tx::NTuple{B},
-    contexts::Vararg{DI.Context,C},
-) where {F,B,C}
+    ::typeof(DI.pushforward), f!::F, y, backend::AutoForwardDiff, x, tx::NTuple{B}
+) where {F,B}
     T = tag_type(f!, backend, x)
     xdual = make_dual(T, x, tx)
     return xdual

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/misc.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/misc.jl
@@ -2,6 +2,33 @@
 DI.overloaded_input_type(prep::ForwardDiffOneArgPushforwardPrep) = typeof(prep.xdual_tmp)
 DI.overloaded_input_type(prep::ForwardDiffTwoArgPushforwardPrep) = typeof(prep.xdual_tmp)
 
+function DI.overloaded_input(
+    ::typeof(DI.pushforward),
+    f::F,
+    backend::AutoForwardDiff,
+    x,
+    tx::NTuple{B},
+    contexts::Vararg{DI.Context,C},
+) where {F,B,C}
+    T = tag_type(f, backend, x)
+    xdual = make_dual(T, x, tx)
+    return xdual
+end
+
+function DI.overloaded_input(
+    ::typeof(DI.pushforward),
+    f!::F,
+    y,
+    backend::AutoForwardDiff,
+    x,
+    tx::NTuple{B},
+    contexts::Vararg{DI.Context,C},
+) where {F,B,C}
+    T = tag_type(f!, backend, x)
+    xdual = make_dual(T, x, tx)
+    return xdual
+end
+
 ## Derivative
 function DI.overloaded_input_type(prep::ForwardDiffOneArgDerivativePrep)
     return DI.overloaded_input_type(prep.pushforward_prep)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/onearg.jl
@@ -272,7 +272,7 @@ function DI.value_and_gradient!(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         result = DiffResult(zero(eltype(x)), (grad,))
@@ -292,7 +292,7 @@ function DI.value_and_gradient(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         result = GradientResult(x)
@@ -310,7 +310,7 @@ function DI.gradient!(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         return gradient!(grad, fc, x)
@@ -326,7 +326,7 @@ function DI.gradient(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         return gradient(fc, x)
@@ -435,7 +435,7 @@ function DI.value_and_jacobian!(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         y = fc(x)
@@ -456,7 +456,7 @@ function DI.value_and_jacobian(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         return fc(x), jacobian(fc, x)
@@ -472,7 +472,7 @@ function DI.jacobian!(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         return jacobian!(jac, fc, x)
@@ -488,7 +488,7 @@ function DI.jacobian(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         return jacobian(fc, x)
@@ -738,7 +738,7 @@ function DI.hessian!(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         return hessian!(hess, fc, x)
@@ -754,7 +754,7 @@ function DI.hessian(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         return hessian(fc, x)
@@ -775,7 +775,7 @@ function DI.value_gradient_and_hessian!(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         result = DiffResult(one(eltype(x)), (grad, hess))
@@ -796,7 +796,7 @@ function DI.value_gradient_and_hessian(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc = DI.with_contexts(f, contexts...)
         result = HessianResult(x)

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/twoarg.jl
@@ -117,7 +117,7 @@ end
 function DI.value_and_derivative(
     f!::F, y, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{DI.Context,C}
 ) where {F,C,chunksize,T}
-    if (T === Nothing && contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend})
+    if (T === Nothing && contexts isa NTuple{C,DI.GeneralizedConstant})
         fc! = DI.with_contexts(f!, contexts...)
         result = MutableDiffResult(y, (similar(y),))
         result = derivative!(result, fc!, y, x)
@@ -131,7 +131,7 @@ end
 function DI.value_and_derivative!(
     f!::F, y, der, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{DI.Context,C}
 ) where {F,C,chunksize,T}
-    if (T === Nothing && contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend})
+    if (T === Nothing && contexts isa NTuple{C,DI.GeneralizedConstant})
         fc! = DI.with_contexts(f!, contexts...)
         result = MutableDiffResult(y, (der,))
         result = derivative!(result, fc!, y, x)
@@ -145,7 +145,7 @@ end
 function DI.derivative(
     f!::F, y, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{DI.Context,C}
 ) where {F,C,chunksize,T}
-    if (T === Nothing && contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend})
+    if (T === Nothing && contexts isa NTuple{C,DI.GeneralizedConstant})
         fc! = DI.with_contexts(f!, contexts...)
         return derivative(fc!, y, x)
     else
@@ -157,7 +157,7 @@ end
 function DI.derivative!(
     f!::F, y, der, backend::AutoForwardDiff{chunksize,T}, x, contexts::Vararg{DI.Context,C}
 ) where {F,C,chunksize,T}
-    if (T === Nothing && contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend})
+    if (T === Nothing && contexts isa NTuple{C,DI.GeneralizedConstant})
         fc! = DI.with_contexts(f!, contexts...)
         return derivative!(der, fc!, y, x)
     else
@@ -188,7 +188,7 @@ function DI.prepare!_derivative(
     old_prep::ForwardDiffTwoArgDerivativePrep,
     backend::AutoForwardDiff,
     x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {F,C}
     if y isa Vector
         (; config) = old_prep
@@ -283,7 +283,7 @@ function DI.value_and_jacobian(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc! = DI.with_contexts(f!, contexts...)
         jac = similar(y, length(y), length(x))
@@ -302,7 +302,7 @@ function DI.value_and_jacobian!(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc! = DI.with_contexts(f!, contexts...)
         result = MutableDiffResult(y, (jac,))
@@ -320,7 +320,7 @@ function DI.jacobian(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc! = DI.with_contexts(f!, contexts...)
         return jacobian(fc!, y, x)
@@ -336,7 +336,7 @@ function DI.jacobian!(
     if (
         isnothing(chunksize) &&
         T === Nothing &&
-        contexts isa NTuple{C,DI.ConstantOrFunctionOrBackend}
+        contexts isa NTuple{C,DI.GeneralizedConstant}
     )
         fc! = DI.with_contexts(f!, contexts...)
         return jacobian!(jac, fc!, y, x)
@@ -369,7 +369,7 @@ function DI.prepare!_jacobian(
     old_prep::ForwardDiffTwoArgJacobianPrep,
     backend::AutoForwardDiff,
     x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {F,C}
     if x isa Vector && y isa Vector
         (; config) = old_prep

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -82,14 +82,7 @@ function mypartials!(::Type{T}, ty::NTuple{B}, ydual) where {T,B}
     return ty
 end
 
-# store preparation result with the right input eltype
-struct PrepContext{T<:DI.Prep} <: DI.Context
-    data::T
-end
-
-NotCache = Union{DI.GeneralizedConstant,PrepContext}
-
-_translate(::Type{D}, c::NotCache) where {D<:Dual} = DI.unwrap(c)
+_translate(::Type{D}, c::DI.GeneralizedConstant) where {D<:Dual} = DI.unwrap(c)
 function _translate(::Type{D}, c::DI.Cache) where {D<:Dual}
     c0 = DI.unwrap(c)
     return similar(c0, D)
@@ -102,7 +95,7 @@ function translate(::Type{D}, contexts::NTuple{C,DI.Context}) where {D<:Dual,C}
     return new_contexts
 end
 
-_translate_toprep(::Type{D}, c::NotCache) where {D<:Dual} = nothing
+_translate_toprep(::Type{D}, c::DI.GeneralizedConstant) where {D<:Dual} = nothing
 function _translate_toprep(::Type{D}, c::DI.Cache) where {D<:Dual}
     c0 = DI.unwrap(c)
     return similar(c0, D)
@@ -115,7 +108,7 @@ function translate_toprep(::Type{D}, contexts::NTuple{C,DI.Context}) where {D<:D
     return new_contexts
 end
 
-_translate_prepared(c::NotCache, _pc) = DI.unwrap(c)
+_translate_prepared(c::DI.GeneralizedConstant, _pc) = DI.unwrap(c)
 _translate_prepared(_c::DI.Cache, pc) = pc
 
 function translate_prepared(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -87,7 +87,7 @@ struct PrepContext{T<:DI.Prep} <: DI.Context
     data::T
 end
 
-NotCache = Union{DI.ConstantOrFunctionOrBackend,PrepContext}
+NotCache = Union{DI.GeneralizedConstant,PrepContext}
 
 _translate(::Type{D}, c::NotCache) where {D<:Dual} = DI.unwrap(c)
 function _translate(::Type{D}, c::DI.Cache) where {D<:Dual}

--- a/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceForwardDiffExt/utils.jl
@@ -82,7 +82,11 @@ function mypartials!(::Type{T}, ty::NTuple{B}, ydual) where {T,B}
     return ty
 end
 
-_translate(::Type{D}, c::DI.GeneralizedConstant) where {D<:Dual} = DI.unwrap(c)
+function _translate(
+    ::Type{D}, c::Union{DI.GeneralizedConstant,DI.PrepContext}
+) where {D<:Dual}
+    return DI.unwrap(c)
+end
 function _translate(::Type{D}, c::DI.Cache) where {D<:Dual}
     c0 = DI.unwrap(c)
     return similar(c0, D)
@@ -95,7 +99,11 @@ function translate(::Type{D}, contexts::NTuple{C,DI.Context}) where {D<:Dual,C}
     return new_contexts
 end
 
-_translate_toprep(::Type{D}, c::DI.GeneralizedConstant) where {D<:Dual} = nothing
+function _translate_toprep(
+    ::Type{D}, c::Union{DI.GeneralizedConstant,DI.PrepContext}
+) where {D<:Dual}
+    return nothing
+end
 function _translate_toprep(::Type{D}, c::DI.Cache) where {D<:Dual}
     c0 = DI.unwrap(c)
     return similar(c0, D)
@@ -108,7 +116,7 @@ function translate_toprep(::Type{D}, contexts::NTuple{C,DI.Context}) where {D<:D
     return new_contexts
 end
 
-_translate_prepared(c::DI.GeneralizedConstant, _pc) = DI.unwrap(c)
+_translate_prepared(c::Union{DI.GeneralizedConstant,DI.PrepContext}, _pc) = DI.unwrap(c)
 _translate_prepared(_c::DI.Cache, pc) = pc
 
 function translate_prepared(

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/misc.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/misc.jl
@@ -1,0 +1,11 @@
+function DI.overloaded_input(
+    ::typeof(DI.pushforward), f::F, backend::AutoPolyesterForwardDiff, x, tx::NTuple{B}
+) where {F,B}
+    return DI.overloaded_input(DI.pushforward, f, single_threaded(backend), x, tx)
+end
+
+function DI.overloaded_input(
+    ::typeof(DI.pushforward), f!::F, y, backend::AutoPolyesterForwardDiff, x, tx::NTuple{B}
+) where {F,B}
+    return DI.overloaded_input(DI.pushforward, f!, y, single_threaded(backend), x, tx)
+end

--- a/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/utils.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfacePolyesterForwardDiffExt/utils.jl
@@ -1,0 +1,14 @@
+function DI.pick_batchsize(backend::AutoPolyesterForwardDiff, x::AbstractArray)
+    return DI.pick_batchsize(single_threaded(backend), x)
+end
+
+function DI.pick_batchsize(backend::AutoPolyesterForwardDiff, N::Integer)
+    return DI.pick_batchsize(single_threaded(backend), N)
+end
+
+function DI.threshold_batchsize(
+    backend::AutoPolyesterForwardDiff{chunksize1}, chunksize2::Integer
+) where {chunksize1}
+    chunksize = isnothing(chunksize1) ? nothing : min(chunksize1, chunksize2)
+    return AutoPolyesterForwardDiff(; chunksize, tag=backend.tag)
+end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceTrackerExt/DifferentiationInterfaceTrackerExt.jl
@@ -15,7 +15,7 @@ struct TrackerPullbackPrepSamePoint{Y,PB} <: DI.PullbackPrep
 end
 
 function DI.prepare_pullback(
-    f, ::AutoTracker, x, ty::NTuple, contexts::Vararg{DI.ConstantOrFunctionOrBackend,C}
+    f, ::AutoTracker, x, ty::NTuple, contexts::Vararg{DI.GeneralizedConstant,C}
 ) where {C}
     return DI.NoPullbackPrep()
 end
@@ -26,7 +26,7 @@ function DI.prepare_pullback_same_point(
     ::AutoTracker,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     y, pb = forward(f, x, map(DI.unwrap, contexts)...)
     return TrackerPullbackPrepSamePoint(y, pb)
@@ -38,7 +38,7 @@ function DI.value_and_pullback(
     ::AutoTracker,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     y, pb = forward(f, x, map(DI.unwrap, contexts)...)
     tx = map(ty) do dy
@@ -53,7 +53,7 @@ function DI.value_and_pullback(
     ::AutoTracker,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     (; y, pb) = prep
     tx = map(ty) do dy
@@ -68,7 +68,7 @@ function DI.pullback(
     ::AutoTracker,
     x,
     ty::NTuple,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     (; pb) = prep
     tx = map(ty) do dy
@@ -80,28 +80,20 @@ end
 ## Gradient
 
 function DI.prepare_gradient(
-    f, ::AutoTracker, x, contexts::Vararg{DI.ConstantOrFunctionOrBackend,C}
+    f, ::AutoTracker, x, contexts::Vararg{DI.GeneralizedConstant,C}
 ) where {C}
     return DI.NoGradientPrep()
 end
 
 function DI.value_and_gradient(
-    f,
-    ::DI.NoGradientPrep,
-    ::AutoTracker,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoGradientPrep, ::AutoTracker, x, contexts::Vararg{DI.GeneralizedConstant,C}
 ) where {C}
     (; val, grad) = withgradient(f, x, map(DI.unwrap, contexts)...)
     return val, data(first(grad))
 end
 
 function DI.gradient(
-    f,
-    ::DI.NoGradientPrep,
-    ::AutoTracker,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoGradientPrep, ::AutoTracker, x, contexts::Vararg{DI.GeneralizedConstant,C}
 ) where {C}
     (; grad) = withgradient(f, x, map(DI.unwrap, contexts)...)
     return data(first(grad))
@@ -113,7 +105,7 @@ function DI.value_and_gradient!(
     prep::DI.NoGradientPrep,
     backend::AutoTracker,
     x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     y, new_grad = DI.value_and_gradient(f, prep, backend, x, contexts...)
     return y, copyto!(grad, new_grad)
@@ -125,7 +117,7 @@ function DI.gradient!(
     prep::DI.NoGradientPrep,
     backend::AutoTracker,
     x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     return copyto!(grad, DI.gradient(f, prep, backend, x, contexts...))
 end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -159,7 +159,7 @@ end
 
 function DI.hvp(
     f,
-    prep::DI.ForwardOverReverseHVPPrep,
+    prep::DI.ForwardOverAnythingHVPPrep,
     backend::AutoZygote,
     x,
     tx::NTuple,
@@ -171,7 +171,7 @@ end
 function DI.hvp!(
     f,
     tg::NTuple,
-    prep::DI.ForwardOverReverseHVPPrep,
+    prep::DI.ForwardOverAnythingHVPPrep,
     backend::AutoZygote,
     x,
     tx::NTuple,
@@ -184,7 +184,7 @@ end
 
 function DI.gradient_and_hvp(
     f,
-    prep::DI.ForwardOverReverseHVPPrep,
+    prep::DI.ForwardOverAnythingHVPPrep,
     backend::AutoZygote,
     x,
     tx::NTuple,
@@ -199,7 +199,7 @@ function DI.gradient_and_hvp!(
     f,
     grad,
     tg::NTuple,
-    prep::DI.ForwardOverReverseHVPPrep,
+    prep::DI.ForwardOverAnythingHVPPrep,
     backend::AutoZygote,
     x,
     tx::NTuple,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceZygoteExt/DifferentiationInterfaceZygoteExt.jl
@@ -213,17 +213,13 @@ end
 ## Hessian
 
 function DI.prepare_hessian(
-    f, ::AutoZygote, x, contexts::Vararg{DI.ConstantOrFunctionOrBackend,C}
+    f, ::AutoZygote, x, contexts::Vararg{DI.GeneralizedConstant,C}
 ) where {C}
     return DI.NoHessianPrep()
 end
 
 function DI.hessian(
-    f,
-    ::DI.NoHessianPrep,
-    ::AutoZygote,
-    x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    f, ::DI.NoHessianPrep, ::AutoZygote, x, contexts::Vararg{DI.GeneralizedConstant,C}
 ) where {C}
     fc = DI.with_contexts(f, contexts...)
     hess = hessian(fc, x)
@@ -236,7 +232,7 @@ function DI.hessian!(
     prep::DI.NoHessianPrep,
     backend::AutoZygote,
     x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     return copyto!(hess, DI.hessian(f, prep, backend, x, contexts...))
 end
@@ -246,7 +242,7 @@ function DI.value_gradient_and_hessian(
     prep::DI.NoHessianPrep,
     backend::AutoZygote,
     x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     y, grad = DI.value_and_gradient(f, DI.NoGradientPrep(), backend, x, contexts...)
     hess = DI.hessian(f, prep, backend, x, contexts...)
@@ -260,7 +256,7 @@ function DI.value_gradient_and_hessian!(
     prep::DI.NoHessianPrep,
     backend::AutoZygote,
     x,
-    contexts::Vararg{DI.ConstantOrFunctionOrBackend,C},
+    contexts::Vararg{DI.GeneralizedConstant,C},
 ) where {C}
     y, _ = DI.value_and_gradient!(f, grad, DI.NoGradientPrep(), backend, x, contexts...)
     DI.hessian!(f, hess, prep, backend, x, contexts...)

--- a/DifferentiationInterface/src/first_order/gradient.jl
+++ b/DifferentiationInterface/src/first_order/gradient.jl
@@ -145,7 +145,6 @@ function shuffled_gradient!(
     return nothing
 end
 
-#=
 function shuffled_gradient!(
     grad,
     x,
@@ -158,4 +157,3 @@ function shuffled_gradient!(
     gradient!(f, grad, prep, backend, x, rewrap(unannotated_contexts...)...)
     return nothing
 end
-=#

--- a/DifferentiationInterface/src/first_order/gradient.jl
+++ b/DifferentiationInterface/src/first_order/gradient.jl
@@ -132,3 +132,16 @@ function shuffled_gradient(
 ) where {F,C}
     return gradient(f, prep, backend, x, rewrap(unannotated_contexts...)...)
 end
+
+function shuffled_gradient!(
+    grad,
+    x,
+    f::F,
+    prep::GradientPrep,
+    backend::AbstractADType,
+    rewrap::Rewrap{C},
+    unannotated_contexts::Vararg{Any,C},
+) where {F,C}
+    gradient!(f, grad, prep, backend, x, rewrap(unannotated_contexts...)...)
+    return nothing
+end

--- a/DifferentiationInterface/src/first_order/gradient.jl
+++ b/DifferentiationInterface/src/first_order/gradient.jl
@@ -137,6 +137,19 @@ function shuffled_gradient!(
     grad,
     x,
     f::F,
+    backend::AbstractADType,
+    rewrap::Rewrap{C},
+    unannotated_contexts::Vararg{Any,C},
+) where {F,C}
+    gradient!(f, grad, backend, x, rewrap(unannotated_contexts...)...)
+    return nothing
+end
+
+#=
+function shuffled_gradient!(
+    grad,
+    x,
+    f::F,
     prep::GradientPrep,
     backend::AbstractADType,
     rewrap::Rewrap{C},
@@ -145,3 +158,4 @@ function shuffled_gradient!(
     gradient!(f, grad, prep, backend, x, rewrap(unannotated_contexts...)...)
     return nothing
 end
+=#

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -3,6 +3,9 @@ abstract type FromPrimitive{inplace} <: AbstractADType end
 check_available(fromprim::FromPrimitive) = check_available(fromprim.backend)
 inplace_support(::FromPrimitive{true}) = InPlaceSupported()
 inplace_support(::FromPrimitive{false}) = InPlaceNotSupported()
+function inner_preparation_behavior(fromprim::FromPrimitive)
+    return inner_preparation_behavior(fromprim.backend)
+end
 
 function pick_batchsize(fromprim::FromPrimitive, N::Integer)
     return pick_batchsize(fromprim.backend, N)

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -14,10 +14,16 @@ Wrapper which forces a given backend to act as a reverse-mode backend.
 
 Used in internal testing.
 """
-struct AutoReverseFromPrimitive{B} <: FromPrimitive
+struct AutoReverseFromPrimitive{inplace,B<:AbstractADType} <: FromPrimitive
     backend::B
 end
 
+function AutoReverseFromPrimitive(backend::AbstractADType; inplace=false)
+    return AutoReverseFromPrimitive{inplace,typeof(backend)}(backend)
+end
+
+inplace_support(::AutoReverseFromPrimitive{true}) = InPlaceSupported()
+inplace_support(::AutoReverseFromPrimitive{false}) = InPlaceNotSupported()
 ADTypes.mode(::AutoReverseFromPrimitive) = ADTypes.ReverseMode()
 
 function threshold_batchsize(fromprim::AutoReverseFromPrimitive, dimension::Integer)

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -1,10 +1,110 @@
-abstract type FromPrimitive <: AbstractADType end
+abstract type FromPrimitive{inplace} <: AbstractADType end
 
 check_available(fromprim::FromPrimitive) = check_available(fromprim.backend)
-inplace_support(fromprim::FromPrimitive) = inplace_support(fromprim.backend)
+inplace_support(::FromPrimitive{true}) = InPlaceSupported()
+inplace_support(::FromPrimitive{false}) = InPlaceNotSupported()
 
 function pick_batchsize(fromprim::FromPrimitive, N::Integer)
     return pick_batchsize(fromprim.backend, N)
+end
+
+"""
+    AutoForwardFromPrimitive
+
+Wrapper which forces a given backend to act as a reverse-mode backend.
+
+Used in internal testing.
+"""
+struct AutoForwardFromPrimitive{inplace,B<:AbstractADType} <: FromPrimitive{inplace}
+    backend::B
+end
+
+function AutoForwardFromPrimitive(backend::AbstractADType; inplace=true)
+    return AutoForwardFromPrimitive{inplace,typeof(backend)}(backend)
+end
+
+ADTypes.mode(::AutoForwardFromPrimitive) = ADTypes.ForwardMode()
+
+function threshold_batchsize(
+    fromprim::AutoForwardFromPrimitive{inplace}, dimension::Integer
+) where {inplace}
+    return AutoForwardFromPrimitive(
+        threshold_batchsize(fromprim.backend, dimension); inplace
+    )
+end
+
+struct FromPrimitivePushforwardPrep{E<:PushforwardPrep} <: PushforwardPrep
+    pushforward_prep::E
+end
+
+function prepare_pushforward(
+    f::F, fromprim::AutoForwardFromPrimitive, x, tx::NTuple, contexts::Vararg{Context,C}
+) where {F,C}
+    primitive_prep = prepare_pushforward(f, fromprim.backend, x, tx, contexts...)
+    return FromPrimitivePushforwardPrep(primitive_prep)
+end
+
+function prepare_pushforward(
+    f!::F, y, fromprim::AutoForwardFromPrimitive, x, tx::NTuple, contexts::Vararg{Context,C}
+) where {F,C}
+    primitive_prep = prepare_pushforward(f!, y, fromprim.backend, x, tx, contexts...)
+    return FromPrimitivePushforwardPrep(primitive_prep)
+end
+
+function value_and_pushforward(
+    f::F,
+    prep::FromPrimitivePushforwardPrep,
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    tx::NTuple,
+    contexts::Vararg{Context,C},
+) where {F,C}
+    return value_and_pushforward(
+        f, prep.pushforward_prep, fromprim.backend, x, tx, contexts...
+    )
+end
+
+function value_and_pushforward(
+    f!::F,
+    y,
+    prep::FromPrimitivePushforwardPrep,
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    tx::NTuple,
+    contexts::Vararg{Context,C},
+) where {F,C}
+    return value_and_pushforward(
+        f!, y, prep.pushforward_prep, fromprim.backend, x, tx, contexts...
+    )
+end
+
+function value_and_pushforward!(
+    f::F,
+    ty::NTuple,
+    prep::FromPrimitivePushforwardPrep,
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    tx::NTuple,
+    contexts::Vararg{Context,C},
+) where {F,C}
+    return value_and_pushforward!(
+        f, ty, prep.pushforward_prep, fromprim.backend, x, tx, contexts...
+    )
+end
+
+function value_and_pushforward!(
+    f!::F,
+    y,
+    ty::NTuple,
+    prep::FromPrimitivePushforwardPrep,
+    fromprim::AutoForwardFromPrimitive,
+    x,
+    tx::NTuple,
+    contexts::Vararg{Context,C},
+) where {F,C}
+    return value_and_pushforward!(
+        f!, y, ty, prep.pushforward_prep, fromprim.backend, x, tx, contexts...
+    )
 end
 
 """
@@ -14,7 +114,7 @@ Wrapper which forces a given backend to act as a reverse-mode backend.
 
 Used in internal testing.
 """
-struct AutoReverseFromPrimitive{inplace,B<:AbstractADType} <: FromPrimitive
+struct AutoReverseFromPrimitive{inplace,B<:AbstractADType} <: FromPrimitive{inplace}
     backend::B
 end
 
@@ -22,12 +122,14 @@ function AutoReverseFromPrimitive(backend::AbstractADType; inplace=true)
     return AutoReverseFromPrimitive{inplace,typeof(backend)}(backend)
 end
 
-inplace_support(::AutoReverseFromPrimitive{true}) = InPlaceSupported()
-inplace_support(::AutoReverseFromPrimitive{false}) = InPlaceNotSupported()
 ADTypes.mode(::AutoReverseFromPrimitive) = ADTypes.ReverseMode()
 
-function threshold_batchsize(fromprim::AutoReverseFromPrimitive, dimension::Integer)
-    return AutoReverseFromPrimitive(threshold_batchsize(fromprim.backend, dimension))
+function threshold_batchsize(
+    fromprim::AutoReverseFromPrimitive{inplace}, dimension::Integer
+) where {inplace}
+    return AutoReverseFromPrimitive(
+        threshold_batchsize(fromprim.backend, dimension); inplace
+    )
 end
 
 struct FromPrimitivePullbackPrep{E<:PullbackPrep} <: PullbackPrep

--- a/DifferentiationInterface/src/misc/from_primitive.jl
+++ b/DifferentiationInterface/src/misc/from_primitive.jl
@@ -18,7 +18,7 @@ struct AutoReverseFromPrimitive{inplace,B<:AbstractADType} <: FromPrimitive
     backend::B
 end
 
-function AutoReverseFromPrimitive(backend::AbstractADType; inplace=false)
+function AutoReverseFromPrimitive(backend::AbstractADType; inplace=true)
     return AutoReverseFromPrimitive{inplace,typeof(backend)}(backend)
 end
 

--- a/DifferentiationInterface/src/misc/overloading.jl
+++ b/DifferentiationInterface/src/misc/overloading.jl
@@ -7,3 +7,13 @@ If it exists, return the overloaded input type which will be passed to the diffe
     This function is experimental and not part of the public API.
 """
 function overloaded_input_type end
+
+function overloaded_input(::typeof(pushforward), f, backend::AbstractADType, x, tx::NTuple)
+    throw(ArgumentError("Overloaded input not defined"))
+end
+
+function overloaded_input(
+    ::typeof(pushforward), f!, y, backend::AbstractADType, x, tx::NTuple
+)
+    throw(ArgumentError("Overloaded input not defined"))
+end

--- a/DifferentiationInterface/src/misc/simple_finite_diff.jl
+++ b/DifferentiationInterface/src/misc/simple_finite_diff.jl
@@ -18,6 +18,7 @@ end
 ADTypes.mode(::AutoSimpleFiniteDiff) = ForwardMode()
 check_available(::AutoSimpleFiniteDiff) = true
 inplace_support(::AutoSimpleFiniteDiff) = InPlaceSupported()
+inner_preparation_behavior(::AutoSimpleFiniteDiff) = PrepareInnerSimple()
 
 function pick_batchsize(::AutoSimpleFiniteDiff{nothing}, N::Integer)
     B = reasonable_batchsize(N, 12)

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -172,16 +172,12 @@ function _prepare_hvp_aux(
     grad_buffer = similar(x)
     rewrap = Rewrap(contexts...)
     # Inner gradient
-    inner_gradient_prep = let
-        xo = overloaded_input(pushforward, shuffled_gradient, outer(backend), x, tx)
-        prepare_gradient(f, inner(backend), xo, contexts...)
-    end
-    inner_gradient_in_prep = let
-        xo = overloaded_input(
-            pushforward, shuffled_gradient!, grad_buffer, outer(backend), x, tx
-        )
-        prepare_gradient(f, inner(backend), xo, contexts...)
-    end
+    xo = overloaded_input(pushforward, shuffled_gradient, outer(backend), x, tx)
+    xoi = overloaded_input(
+        pushforward, shuffled_gradient!, grad_buffer, outer(backend), x, tx
+    )
+    inner_gradient_prep = prepare_gradient(f, inner(backend), xo, contexts...)
+    inner_gradient_in_prep = prepare_gradient(f, inner(backend), xoi, contexts...)
     # Outer pushforward
     new_contexts = (
         FunctionContext(f),

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -551,8 +551,7 @@ end
 
 ## Reverse over reverse
 
-struct ReverseOverReverseHVPPrep{G,PO<:PullbackPrep,PI<:Union{Nothing,PullbackPrep}} <:
-       HVPPrep
+struct ReverseOverReverseHVPPrep{G,PO,PI} <: HVPPrep
     # pullback of gradient
     grad_buffer::G
     outer_pullback_prep::PO

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -60,33 +60,43 @@ function gradient_and_hvp! end
 function prepare_hvp(
     f::F, backend::AbstractADType, x, tx::NTuple, contexts::Vararg{Context,C}
 ) where {F,C}
-    return _prepare_hvp_aux(hvp_mode(backend), f, backend, x, tx, contexts...)
+    return _prepare_hvp_aux(
+        hvp_mode(backend),
+        inner_preparation_behavior(outer(backend)),
+        f,
+        backend,
+        x,
+        tx,
+        contexts...,
+    )
 end
 
 ## Forward over anything
 
-struct ForwardOverAnythingHVPPrep{
-    G,PO<:PushforwardPrep,PI<:Union{Nothing,PushforwardPrep}
-} <: HVPPrep
+struct ForwardOverAnythingHVPPrep{G,GO,GI,PO,PI} <: HVPPrep
     # pushforward of many pushforwards in theory, but pushforward of gradient in practice
     grad_buffer::G
+    maybe_inner_gradient_prep::GO
+    maybe_inner_gradient_in_prep::GI
     outer_pushforward_prep::PO
     outer_pushforward_in_prep::PI
 end
 
 function _prepare_hvp_aux(
     ::ForwardOverAnything,
+    ::DontPrepareInner,
     f::F,
     backend::AbstractADType,
     x,
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
+    grad_buffer = similar(x)
     rewrap = Rewrap(contexts...)
+    # Outer pushforward
     new_contexts = (
         FunctionContext(f), BackendContext(inner(backend)), Constant(rewrap), contexts...
     )
-    grad_buffer = similar(x)
     outer_pushforward_prep = prepare_pushforward(
         shuffled_gradient, outer(backend), x, tx, new_contexts...
     )
@@ -98,7 +108,131 @@ function _prepare_hvp_aux(
         nothing
     end
     return ForwardOverAnythingHVPPrep(
-        grad_buffer, outer_pushforward_prep, outer_pushforward_in_prep
+        grad_buffer, (), (), outer_pushforward_prep, outer_pushforward_in_prep
+    )
+end
+
+function _prepare_hvp_aux(
+    ::ForwardOverAnything,
+    ::PrepareInnerSimple,
+    f::F,
+    backend::AbstractADType,
+    x,
+    tx::NTuple,
+    contexts::Vararg{Context,C},
+) where {F,C}
+    grad_buffer = similar(x)
+    rewrap = Rewrap(contexts...)
+    # Inner gradient
+    inner_gradient_prep = prepare_gradient(f, inner(backend), x, contexts...)
+    inner_gradient_in_prep = inner_gradient_prep
+    # Outer pushforward
+    new_contexts = (
+        FunctionContext(f),
+        PrepContext(inner_gradient_prep),
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
+    )
+    new_contexts_in = (
+        FunctionContext(f),
+        PrepContext(inner_gradient_in_prep),
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
+    )
+    outer_pushforward_prep = prepare_pushforward(
+        shuffled_gradient, outer(backend), x, tx, new_contexts...
+    )
+    outer_pushforward_in_prep = if inplace_support(outer(backend)) isa InPlaceSupported
+        prepare_pushforward(
+            shuffled_gradient!, grad_buffer, outer(backend), x, tx, new_contexts_in...
+        )
+    else
+        nothing
+    end
+    return ForwardOverAnythingHVPPrep(
+        grad_buffer,
+        (inner_gradient_prep,),
+        (inner_gradient_in_prep,),
+        outer_pushforward_prep,
+        outer_pushforward_in_prep,
+    )
+end
+
+function _prepare_hvp_aux(
+    ::ForwardOverAnything,
+    ::PrepareInnerOverload,
+    f::F,
+    backend::AbstractADType,
+    x,
+    tx::NTuple,
+    contexts::Vararg{Context,C},
+) where {F,C}
+    grad_buffer = similar(x)
+    rewrap = Rewrap(contexts...)
+    # Inner gradient
+    new_contexts_unknown = (
+        FunctionContext(f),
+        UnknownContext(),
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
+    )
+    inner_gradient_prep = let
+        xo = overloaded_input(
+            pushforward,
+            shuffled_gradient,
+            outer(backend),
+            x,
+            tx,
+            new_contexts_unknown...,
+        )
+        prepare_gradient(f, inner(backend), xo, contexts...)
+    end
+    inner_gradient_in_prep = let
+        xo = overloaded_input(
+            pushforward,
+            shuffled_gradient!,
+            grad_buffer,
+            outer(backend),
+            x,
+            tx,
+            new_contexts_unknown...,
+        )
+        prepare_gradient(f, inner(backend), xo, contexts...)
+    end
+    # Outer pushforward
+    new_contexts = (
+        FunctionContext(f),
+        PrepContext(inner_gradient_prep),
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
+    )
+    new_contexts_in = (
+        FunctionContext(f),
+        PrepContext(inner_gradient_in_prep),
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
+    )
+    outer_pushforward_prep = prepare_pushforward(
+        shuffled_gradient, outer(backend), x, tx, new_contexts...
+    )
+    outer_pushforward_in_prep = if inplace_support(outer(backend)) isa InPlaceSupported
+        prepare_pushforward(
+            shuffled_gradient!, grad_buffer, outer(backend), x, tx, new_contexts_in...
+        )
+    else
+        nothing
+    end
+    return ForwardOverAnythingHVPPrep(
+        grad_buffer,
+        (inner_gradient_prep,),
+        (inner_gradient_in_prep,),
+        outer_pushforward_prep,
+        outer_pushforward_in_prep,
     )
 end
 
@@ -110,10 +244,14 @@ function hvp(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; outer_pushforward_prep) = prep
+    (; maybe_inner_gradient_prep, outer_pushforward_prep) = prep
     rewrap = Rewrap(contexts...)
     new_contexts = (
-        FunctionContext(f), BackendContext(inner(backend)), Constant(rewrap), contexts...
+        FunctionContext(f),
+        map(PrepContext, maybe_inner_gradient_prep)...,
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
     )
     return pushforward(
         shuffled_gradient, outer_pushforward_prep, outer(backend), x, tx, new_contexts...
@@ -144,10 +282,14 @@ function _hvp_aux!(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; grad_buffer, outer_pushforward_in_prep) = prep
+    (; grad_buffer, maybe_inner_gradient_in_prep, outer_pushforward_in_prep) = prep
     rewrap = Rewrap(contexts...)
     new_contexts = (
-        FunctionContext(f), BackendContext(inner(backend)), Constant(rewrap), contexts...
+        FunctionContext(f),
+        map(PrepContext, maybe_inner_gradient_in_prep)...,
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
     )
     return pushforward!(
         shuffled_gradient!,
@@ -171,10 +313,14 @@ function _hvp_aux!(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; outer_pushforward_prep) = prep
+    (; maybe_inner_gradient_prep, outer_pushforward_prep) = prep
     rewrap = Rewrap(contexts...)
     new_contexts = (
-        FunctionContext(f), BackendContext(inner(backend)), Constant(rewrap), contexts...
+        FunctionContext(f),
+        map(PrepContext, maybe_inner_gradient_prep)...,
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
     )
     return pushforward!(
         shuffled_gradient,
@@ -195,10 +341,14 @@ function gradient_and_hvp(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; outer_pushforward_prep) = prep
+    (; maybe_inner_gradient_prep, outer_pushforward_prep) = prep
     rewrap = Rewrap(contexts...)
     new_contexts = (
-        FunctionContext(f), BackendContext(inner(backend)), Constant(rewrap), contexts...
+        FunctionContext(f),
+        map(PrepContext, maybe_inner_gradient_prep)...,
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
     )
     return value_and_pushforward(
         shuffled_gradient, outer_pushforward_prep, outer(backend), x, tx, new_contexts...
@@ -231,10 +381,14 @@ function _gradient_and_hvp_aux!(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; outer_pushforward_in_prep) = prep
+    (; maybe_inner_gradient_in_prep, outer_pushforward_in_prep) = prep
     rewrap = Rewrap(contexts...)
     new_contexts = (
-        FunctionContext(f), BackendContext(inner(backend)), Constant(rewrap), contexts...
+        FunctionContext(f),
+        map(PrepContext, maybe_inner_gradient_in_prep)...,
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
     )
     value_and_pushforward!(
         shuffled_gradient!,
@@ -260,10 +414,14 @@ function _gradient_and_hvp_aux!(
     tx::NTuple,
     contexts::Vararg{Context,C},
 ) where {F,C}
-    (; outer_pushforward_prep) = prep
+    (; maybe_inner_gradient_prep, outer_pushforward_prep) = prep
     rewrap = Rewrap(contexts...)
     new_contexts = (
-        FunctionContext(f), BackendContext(inner(backend)), Constant(rewrap), contexts...
+        FunctionContext(f),
+        map(PrepContext, maybe_inner_gradient_prep)...,
+        BackendContext(inner(backend)),
+        Constant(rewrap),
+        contexts...,
     )
     new_grad, _ = value_and_pushforward!(
         shuffled_gradient,
@@ -287,6 +445,7 @@ end
 
 function _prepare_hvp_aux(
     ::ReverseOverForward,
+    ::InnerPreparationBehavior,
     f::F,
     backend::AbstractADType,
     x,
@@ -402,6 +561,7 @@ end
 
 function _prepare_hvp_aux(
     ::ReverseOverReverse,
+    ::InnerPreparationBehavior,
     f::F,
     backend::AbstractADType,
     x,

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -65,7 +65,7 @@ end
 
 ## Forward over anything
 
-struct ForwardOverAnythingPrep{G,PO<:PushforwardPrep,PI<:PushforwardPrep} <: HVPPrep
+struct ForwardOverAnythingHVPPrep{G,PO<:PushforwardPrep,PI<:PushforwardPrep} <: HVPPrep
     # pushforward of many pushforwards in theory, but pushforward of gradient in practice
     grad_buffer::G
     outer_pushforward_prep::PO
@@ -91,14 +91,14 @@ function _prepare_hvp_aux(
     outer_pushforward_in_prep = prepare_pushforward(
         shuffled_gradient!, grad_buffer, outer(backend), x, tx, new_contexts...
     )
-    return ForwardOverAnythingPrep(
+    return ForwardOverAnythingHVPPrep(
         grad_buffer, outer_pushforward_prep, outer_pushforward_in_prep
     )
 end
 
 function hvp(
     f::F,
-    prep::ForwardOverAnythingPrep,
+    prep::ForwardOverAnythingHVPPrep,
     backend::AbstractADType,
     x,
     tx::NTuple,
@@ -117,7 +117,7 @@ end
 function hvp!(
     f::F,
     tg::NTuple,
-    prep::ForwardOverAnythingPrep,
+    prep::ForwardOverAnythingHVPPrep,
     backend::AbstractADType,
     x,
     tx::NTuple,
@@ -132,7 +132,7 @@ function _hvp_aux!(
     ::InPlaceSupported,
     f::F,
     tg::NTuple,
-    prep::ForwardOverAnythingPrep,
+    prep::ForwardOverAnythingHVPPrep,
     backend::AbstractADType,
     x,
     tx::NTuple,
@@ -159,7 +159,7 @@ function _hvp_aux!(
     ::InPlaceNotSupported,
     f::F,
     tg::NTuple,
-    prep::ForwardOverAnythingPrep,
+    prep::ForwardOverAnythingHVPPrep,
     backend::AbstractADType,
     x,
     tx::NTuple,
@@ -183,7 +183,7 @@ end
 
 function gradient_and_hvp(
     f::F,
-    prep::ForwardOverAnythingPrep,
+    prep::ForwardOverAnythingHVPPrep,
     backend::AbstractADType,
     x,
     tx::NTuple,
@@ -203,7 +203,7 @@ function gradient_and_hvp!(
     f::F,
     grad,
     tg::NTuple,
-    prep::ForwardOverAnythingPrep,
+    prep::ForwardOverAnythingHVPPrep,
     backend::AbstractADType,
     x,
     tx::NTuple,
@@ -219,7 +219,7 @@ function _gradient_and_hvp_aux!(
     f::F,
     grad,
     tg::NTuple,
-    prep::ForwardOverAnythingPrep,
+    prep::ForwardOverAnythingHVPPrep,
     backend::AbstractADType,
     x,
     tx::NTuple,
@@ -248,7 +248,7 @@ function _gradient_and_hvp_aux!(
     f::F,
     grad,
     tg::NTuple,
-    prep::ForwardOverAnythingPrep,
+    prep::ForwardOverAnythingHVPPrep,
     backend::AbstractADType,
     x,
     tx::NTuple,

--- a/DifferentiationInterface/src/second_order/hvp.jl
+++ b/DifferentiationInterface/src/second_order/hvp.jl
@@ -172,33 +172,13 @@ function _prepare_hvp_aux(
     grad_buffer = similar(x)
     rewrap = Rewrap(contexts...)
     # Inner gradient
-    new_contexts_unknown = (
-        FunctionContext(f),
-        UnknownContext(),
-        BackendContext(inner(backend)),
-        Constant(rewrap),
-        contexts...,
-    )
     inner_gradient_prep = let
-        xo = overloaded_input(
-            pushforward,
-            shuffled_gradient,
-            outer(backend),
-            x,
-            tx,
-            new_contexts_unknown...,
-        )
+        xo = overloaded_input(pushforward, shuffled_gradient, outer(backend), x, tx)
         prepare_gradient(f, inner(backend), xo, contexts...)
     end
     inner_gradient_in_prep = let
         xo = overloaded_input(
-            pushforward,
-            shuffled_gradient!,
-            grad_buffer,
-            outer(backend),
-            x,
-            tx,
-            new_contexts_unknown...,
+            pushforward, shuffled_gradient!, grad_buffer, outer(backend), x, tx
         )
         prepare_gradient(f, inner(backend), xo, contexts...)
     end

--- a/DifferentiationInterface/src/utils/context.jl
+++ b/DifferentiationInterface/src/utils/context.jl
@@ -22,6 +22,9 @@ Abstract supertype for additional context arguments, which can be passed to diff
 """
 abstract type Context end
 
+abstract type GeneralizedConstant <: Context end
+abstract type GeneralizedCache <: Context end
+
 unwrap(c::Context) = c.data
 Base.:(==)(c1::Context, c2::Context) = unwrap(c1) == unwrap(c2)
 
@@ -58,7 +61,7 @@ julia> gradient(f, AutoForwardDiff(), [1.0, 2.0], Constant(100))
  400.0
 ```
 """
-struct Constant{T} <: Context
+struct Constant{T} <: GeneralizedConstant
     data::T
 end
 
@@ -94,7 +97,7 @@ julia> gradient(f, prep, AutoForwardDiff(), [3.0, 4.0], Cache(zeros(2)))
  1.0
 ````
 """
-struct Cache{T} <: Context
+struct Cache{T} <: GeneralizedCache
     data::T
 end
 
@@ -103,15 +106,19 @@ maker(::Cache) = cache_maker
 
 ## Internal contexts for passing stuff around
 
-struct FunctionContext{T} <: Context
+struct FunctionContext{T} <: GeneralizedConstant
     data::T
 end
 
-struct BackendContext{T} <: Context
+struct BackendContext{T} <: GeneralizedConstant
     data::T
 end
 
-const ConstantOrFunctionOrBackend = Union{Constant,FunctionContext,BackendContext}
+struct PrepContext{T} <: GeneralizedConstant
+    data::T
+end
+
+struct UnknownContext <: Context end
 
 ## Context manipulation
 

--- a/DifferentiationInterface/src/utils/context.jl
+++ b/DifferentiationInterface/src/utils/context.jl
@@ -114,7 +114,7 @@ struct BackendContext{T} <: GeneralizedConstant
     data::T
 end
 
-struct PrepContext{T} <: GeneralizedConstant
+struct PrepContext{T} <: GeneralizedCache
     data::T
 end
 

--- a/DifferentiationInterface/src/utils/traits.jl
+++ b/DifferentiationInterface/src/utils/traits.jl
@@ -141,6 +141,8 @@ Traits identifying second-order backends that compute HVPs in forward over forwa
 """
 struct ForwardOverForward <: HVPMode end
 
+const ForwardOverAnything = Union{ForwardOverForward,ForwardOverReverse}
+
 """
     hvp_mode(backend)
 

--- a/DifferentiationInterface/src/utils/traits.jl
+++ b/DifferentiationInterface/src/utils/traits.jl
@@ -171,6 +171,18 @@ function hvp_mode(backend::AutoSparse)
     throw(ArgumentError("HVP mode not defined for $backend`."))
 end
 
+## Inner prep
+
+abstract type InnerPreparationBehavior end
+
+struct PrepareInnerSimple <: InnerPreparationBehavior end
+struct PrepareInnerOverload <: InnerPreparationBehavior end
+struct DontPrepareInner <: InnerPreparationBehavior end
+
+inner_preparation_behavior(::AbstractADType) = DontPrepareInner()
+
+function overloaded_input end
+
 ## Conversions
 
 Base.Bool(::InPlaceSupported) = true

--- a/DifferentiationInterface/src/utils/traits.jl
+++ b/DifferentiationInterface/src/utils/traits.jl
@@ -175,15 +175,33 @@ end
 
 abstract type InnerPreparationBehavior end
 
+"""
+    PrepareInnerSimple
+
+Trait identifying outer backends for which the inner backend in second-order autodiff should be prepared with the same input type.
+"""
 struct PrepareInnerSimple <: InnerPreparationBehavior end
+
+"""
+    PrepareInnerOverload
+
+Trait identifying outer backends for which the inner backend in second-order autodiff should be prepared with an overloaded input type.
+"""
 struct PrepareInnerOverload <: InnerPreparationBehavior end
+
+"""
+    DontPrepareInner
+
+Trait identifying outer backends for which the inner backend in second-order autodiff should not be prepared at all.
+"""
 struct DontPrepareInner <: InnerPreparationBehavior end
 
-inner_preparation_behavior(::AbstractADType) = DontPrepareInner()
+"""
+    inner_preparation_behavior(backend::AbstractADType)
 
-function overloaded_input(optype, f, backend, x, args...)
-    throw(ArgumentError("Just to appease JET"))
-end
+Return [`PrepareInnerSimple`](@ref), [`PrepareInnerOverload`](@ref) or [`DontPrepareInner`](@ref) in a statically predictable way.
+"""
+inner_preparation_behavior(::AbstractADType) = DontPrepareInner()
 
 ## Conversions
 

--- a/DifferentiationInterface/src/utils/traits.jl
+++ b/DifferentiationInterface/src/utils/traits.jl
@@ -181,7 +181,9 @@ struct DontPrepareInner <: InnerPreparationBehavior end
 
 inner_preparation_behavior(::AbstractADType) = DontPrepareInner()
 
-function overloaded_input end
+function overloaded_input(optype, f, backend, x, args...)
+    throw(ArgumentError("Just to appease JET"))
+end
 
 ## Conversions
 

--- a/DifferentiationInterface/test/Back/FiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDiff/test.jl
@@ -15,6 +15,8 @@ LOGGING = get(ENV, "CI", "false") == "false"
 for backend in [AutoFiniteDiff()]
     @test check_available(backend)
     @test check_inplace(backend)
+    @test DifferentiationInterface.inner_preparation_behavior(backend) isa
+        DifferentiationInterface.PrepareInnerSimple
 end
 
 @testset "Dense" begin
@@ -23,6 +25,13 @@ end
         default_scenarios(; include_constantified=true, include_cachified=true);
         excluded=[:second_derivative, :hvp],
         logging=LOGGING,
+    )
+
+    test_differentiation(
+        SecondOrder(AutoFiniteDiff(; relstep=1e-5, absstep=1e-5), AutoFiniteDiff()),
+        default_scenarios();
+        logging=LOGGING,
+        rtol=1e-2,
     )
 
     test_differentiation(

--- a/DifferentiationInterface/test/Back/FiniteDifferences/test.jl
+++ b/DifferentiationInterface/test/Back/FiniteDifferences/test.jl
@@ -13,6 +13,8 @@ LOGGING = get(ENV, "CI", "false") == "false"
 for backend in [AutoFiniteDifferences(; fdm=FiniteDifferences.central_fdm(3, 1))]
     @test check_available(backend)
     @test !check_inplace(backend)
+    @test DifferentiationInterface.inner_preparation_behavior(backend) isa
+        DifferentiationInterface.PrepareInnerSimple
 end
 
 test_differentiation(

--- a/DifferentiationInterface/test/Back/ForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/ForwardDiff/test.jl
@@ -42,11 +42,7 @@ end
     )
 
     test_differentiation(
-        AutoForwardDiff();
-        correctness=false,
-        type_stability=:prepared,
-        excluded=[:hvp],  # TODO: toggle
-        logging=LOGGING,
+        AutoForwardDiff(); correctness=false, type_stability=:prepared, logging=LOGGING
     )
 
     test_differentiation(

--- a/DifferentiationInterface/test/Back/PolyesterForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/PolyesterForwardDiff/test.jl
@@ -22,6 +22,8 @@ backends = [
 for backend in backends
     @test check_available(backend)
     @test check_inplace(backend)
+    @test DifferentiationInterface.inner_preparation_behavior(backend) isa
+        DifferentiationInterface.PrepareInnerOverload
 end
 
 test_differentiation(
@@ -29,6 +31,12 @@ test_differentiation(
     default_scenarios(; include_constantified=true, include_cachified=true);
     logging=LOGGING,
     excluded=SECOND_ORDER,
+);
+
+test_differentiation(
+    SecondOrder(AutoPolyesterForwardDiff(), AutoPolyesterForwardDiff()),
+    default_scenarios();
+    logging=LOGGING,
 );
 
 @testset "Batch size" begin

--- a/DifferentiationInterface/test/Back/PolyesterForwardDiff/test.jl
+++ b/DifferentiationInterface/test/Back/PolyesterForwardDiff/test.jl
@@ -12,8 +12,10 @@ check_no_implicit_imports(DifferentiationInterface)
 
 LOGGING = get(ENV, "CI", "false") == "false"
 
+struct MyTag end
+
 backends = [
-    AutoPolyesterForwardDiff(; tag=:hello),  #
+    AutoPolyesterForwardDiff(; tag=ForwardDiff.Tag(MyTag(), Float64)),  #
     AutoPolyesterForwardDiff(; chunksize=2),
 ]
 
@@ -23,7 +25,10 @@ for backend in backends
 end
 
 test_differentiation(
-    backends, default_scenarios(; include_constantified=true); logging=LOGGING
+    backends,
+    default_scenarios(; include_constantified=true, include_cachified=true);
+    logging=LOGGING,
+    excluded=SECOND_ORDER,
 );
 
 @testset "Batch size" begin

--- a/DifferentiationInterface/test/Core/Internals/_formalities.jl
+++ b/DifferentiationInterface/test/Core/Internals/_formalities.jl
@@ -3,7 +3,6 @@
 using Aqua: Aqua
 using DifferentiationInterface
 using ExplicitImports
-using ForwardDiff: ForwardDiff
 using JET: JET
 using JuliaFormatter: JuliaFormatter
 using Test
@@ -37,7 +36,7 @@ end
     @test check_all_qualified_accesses_via_owners(DifferentiationInterface) === nothing
     @test check_no_self_qualified_accesses(DifferentiationInterface) === nothing
     if VERSION >= v"1.11"
-        @test check_all_explicit_imports_are_public(DifferentiationInterface) === nothing
+        @test check_all_explicit_imports_are_public(DifferentiationInterface;) === nothing
         @test_skip check_all_qualified_accesses_are_public(DifferentiationInterface) ===
             nothing
     end

--- a/DifferentiationInterface/test/Core/Internals/_formalities.jl
+++ b/DifferentiationInterface/test/Core/Internals/_formalities.jl
@@ -3,6 +3,7 @@
 using Aqua: Aqua
 using DifferentiationInterface
 using ExplicitImports
+using ForwardDiff: ForwardDiff
 using JET: JET
 using JuliaFormatter: JuliaFormatter
 using Test

--- a/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
@@ -16,12 +16,12 @@ backends = [ #
 
 second_order_backends = [ #
     SecondOrder(
-        AutoSimpleFiniteDiff(; chunksize=5),
+        AutoForwardFromPrimitive(AutoSimpleFiniteDiff(; chunksize=5)),
         AutoReverseFromPrimitive(AutoSimpleFiniteDiff(; chunksize=4)),
     ),
     SecondOrder(
         AutoReverseFromPrimitive(AutoSimpleFiniteDiff(; chunksize=5)),
-        AutoSimpleFiniteDiff(; chunksize=4),
+        AutoForwardFromPrimitive(AutoSimpleFiniteDiff(; chunksize=4)),
     ),
 ]
 

--- a/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
@@ -11,6 +11,7 @@ LOGGING = get(ENV, "CI", "false") == "false"
 
 backends = [ #
     AutoSimpleFiniteDiff(; chunksize=5),
+    AutoForwardFromPrimitive(AutoSimpleFiniteDiff(; chunksize=4)),
     AutoReverseFromPrimitive(AutoSimpleFiniteDiff(; chunksize=4)),
 ]
 
@@ -68,7 +69,7 @@ end
     test_differentiation(
         second_order_hvp_backends;
         excluded=vcat(FIRST_ORDER, :hessian, :second_derivative),
-        logging=true,
+        logging=LOGGING,
     )
 
     test_differentiation(backends, complex_scenarios(); logging=LOGGING)

--- a/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
@@ -9,6 +9,7 @@ LOGGING = get(ENV, "CI", "false") == "false"
 backends = [ #
     AutoSimpleFiniteDiff(; chunksize=5),
     AutoReverseFromPrimitive(AutoSimpleFiniteDiff(; chunksize=4)),
+    AutoReverseFromPrimitive(AutoSimpleFiniteDiff(; chunksize=3); inplace=false),
 ]
 
 second_order_backends = [ #

--- a/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
+++ b/DifferentiationInterface/test/Core/SimpleFiniteDiff/test.jl
@@ -121,3 +121,12 @@ end
         @test only(column_groups(hess_prep)) == 1:10
     end
 end
+
+@testset "Misc" begin
+    @test_throws ArgumentError DifferentiationInterface.overloaded_input(
+        pushforward, sum, AutoSimpleFiniteDiff(), 1, (1, 2)
+    )
+    @test_throws ArgumentError DifferentiationInterface.overloaded_input(
+        pushforward, copyto!, [1.0], AutoSimpleFiniteDiff(), [1.0], ([1.0], [1.0])
+    )
+end


### PR DESCRIPTION
Fixes #86 by allowing preparation of the inner gradient in a forward-over-reverse HVP

- Define new trait `inner_preparation_behavior` with three modalities:
  - `PrepareInnerSimple` (for finite difference backends)
  - `PrepareInnerOverload` (for ForwardDiff)
  - `DontPrepareInner` (for everyone else at the moment, but can evolve)
- Restructure context type hierarchy and add a `PrepContext` for passing a preparation object created on the correct input type (it cannot be passed as a `Cache` because some of its values may matter):
  - ForwardDiff will keep it as-is
  - Enzyme will `Duplicate` it
- Split `hvp` logic depending on
  - whether the outer backend supports in-place functions (determines whether to use `shuffled_gradient` or `shuffled_gradient!`)
  - what type of `inner_preparation_behavior` the outer backend has
- Define `overloaded_input` for ForwardDiff and PolyesterForwardDiff to prepare the inner gradient on the right input type
- Fix `Cache` handling for PolyesterForwardDiff (was incorrectly advertised as supported until now)
- Add more tests, including on a new `AutoForwardFromPrimitive`