### PR TITLE
docs: warn that preparation is not thread-safe

### DIFF
--- a/DifferentiationInterface/docs/src/explanation/operators.md
+++ b/DifferentiationInterface/docs/src/explanation/operators.md
@@ -117,6 +117,7 @@ op(f, prep, backend, x, [t])  # fast because it skips preparation
 
 !!! warning
     The `prep` object is the last argument before `backend` and it is always mutated, regardless of the bang `!` in the operator name.
+    As a consequence preparation is **not thread safe** and  sharing  `prep` object between threads may lead to undefined behavior.   If you need to run differentiation concurrently, prepare separate `prep` objects for each thread.
 
 ### Reusing preparation
 

--- a/DifferentiationInterface/docs/src/explanation/operators.md
+++ b/DifferentiationInterface/docs/src/explanation/operators.md
@@ -117,7 +117,7 @@ op(f, prep, backend, x, [t])  # fast because it skips preparation
 
 !!! warning
     The `prep` object is the last argument before `backend` and it is always mutated, regardless of the bang `!` in the operator name.
-    As a consequence preparation is **not thread safe** and  sharing  `prep` object between threads may lead to undefined behavior.   If you need to run differentiation concurrently, prepare separate `prep` objects for each thread.
+    As a consequence, preparation is **not thread-safe** and  sharing `prep` objects between threads may lead to unexpected behavior. If you need to run differentiation concurrently, prepare separate `prep` objects for each thread.
 
 ### Reusing preparation
 

--- a/DifferentiationInterface/src/docstrings.jl
+++ b/DifferentiationInterface/src/docstrings.jl
@@ -25,8 +25,9 @@ function docstring_prepare(operator; samepoint=false, inplace=false)
         The preparation result `prep` is only reusable as long as the arguments to `$operator` do not change type or size, and the function and backend themselves are not modified.
         Otherwise, preparation becomes invalid and you need to run it again.
         In some settings, invalid preparations may still give correct results (e.g. for backends that require no preparation), but this is not a semantic guarantee and should not be relied upon.
+
     !!! danger
-        The preparation result `prep` is **not thread safe**. Sharing it between threads may lead to undefined behavior. If you need to run differentiations concurrently, prepare separate `prep` objects for each thread.
+        The preparation result `prep` is **not thread-safe**. Sharing it between threads may lead to unexpected behavior. If you need to run differentiations concurrently, prepare separate `prep` objects for each thread.
 
     When `strict=Val(true)` (the default), type checking is enforced between preparation and execution (but size checking is left to the user).
     While your code may work for different types by setting `strict=Val(false)`, this is not guaranteed by the API and can break without warning.

--- a/DifferentiationInterface/src/docstrings.jl
+++ b/DifferentiationInterface/src/docstrings.jl
@@ -27,7 +27,7 @@ function docstring_prepare(operator; samepoint=false, inplace=false)
         In some settings, invalid preparations may still give correct results (e.g. for backends that require no preparation), but this is not a semantic guarantee and should not be relied upon.
 
     !!! danger
-        The preparation result `prep` is **not thread-safe**. Sharing it between threads may lead to unexpected behavior. If you need to run differentiations concurrently, prepare separate `prep` objects for each thread.
+        The preparation result `prep` is **not thread-safe**. Sharing it between threads may lead to unexpected behavior. If you need to run differentiation concurrently, prepare separate `prep` objects for each thread.
 
     When `strict=Val(true)` (the default), type checking is enforced between preparation and execution (but size checking is left to the user).
     While your code may work for different types by setting `strict=Val(false)`, this is not guaranteed by the API and can break without warning.

--- a/DifferentiationInterface/src/docstrings.jl
+++ b/DifferentiationInterface/src/docstrings.jl
@@ -25,6 +25,8 @@ function docstring_prepare(operator; samepoint=false, inplace=false)
         The preparation result `prep` is only reusable as long as the arguments to `$operator` do not change type or size, and the function and backend themselves are not modified.
         Otherwise, preparation becomes invalid and you need to run it again.
         In some settings, invalid preparations may still give correct results (e.g. for backends that require no preparation), but this is not a semantic guarantee and should not be relied upon.
+    !!! danger
+        The preparation result `prep` is **not thread safe**. Sharing it between threads may lead to undefined behavior. If you need to run differentiations concurrently, prepare separate `prep` objects for each thread.
 
     When `strict=Val(true)` (the default), type checking is enforced between preparation and execution (but size checking is left to the user).
     While your code may work for different types by setting `strict=Val(false)`, this is not guaranteed by the API and can break without warning.


### PR DESCRIPTION
Here are a few lines about thread safety of preparation for the documentation after my question #800 
