### PR TITLE
fix: handle constant derivatives with runtime activity for Enzyme

### DIFF
--- a/DifferentiationInterface/CHANGELOG.md
+++ b/DifferentiationInterface/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.7...main)
 
+### Fixed
+
+  - Handle constant derivatives with runtime activity for Enzyme
+
 ## [0.7.7](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.6...DifferentiationInterface-v0.7.7)
+
+### Fixed
 
   - Improve support for empty inputs (still not guaranteed) ([#835](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/835))
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/DifferentiationInterfaceEnzymeExt.jl
@@ -1,7 +1,7 @@
 module DifferentiationInterfaceEnzymeExt
 
 using ADTypes: ADTypes, AutoEnzyme
-using Base: Fix1
+using Base: Fix1, datatype_pointerfree
 import DifferentiationInterface as DI
 using EnzymeCore:
     Active,
@@ -42,7 +42,8 @@ using Enzyme:
     jacobian,
     make_zero,
     make_zero!,
-    onehot
+    onehot,
+    runtime_activity
 
 DI.check_available(::AutoEnzyme) = true
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/reverse_onearg.jl
@@ -7,6 +7,7 @@ function seeded_autodiff_thunk(
 ) where {ReturnPrimal,FA<:Annotation,RA<:Annotation,N}
     forward, reverse = autodiff_thunk(rmode, FA, RA, typeof.(args)...)
     tape, result, shadow_result = forward(f, args...)
+    shadow_result = runtime_activity_safeguard(rmode, result, shadow_result)
     if RA <: Active
         dinputs = only(reverse(f, args..., dresult, tape))
     else
@@ -30,6 +31,7 @@ function batch_seeded_autodiff_thunk(
     rmode_rightwidth = ReverseSplitWidth(rmode, Val(B))
     forward, reverse = autodiff_thunk(rmode_rightwidth, FA, RA, typeof.(args)...)
     tape, result, shadow_results = forward(f, args...)
+    shadow_results = runtime_activity_safeguard(rmode_rightwidth, result, shadow_results)
     if RA <: Active
         dinputs = only(reverse(f, args..., dresults, tape))
     else

--- a/DifferentiationInterface/test/Back/Enzyme/test.jl
+++ b/DifferentiationInterface/test/Back/Enzyme/test.jl
@@ -196,3 +196,19 @@ end
         excluded=[:jacobian],
     )
 end;
+
+@testset "Runtime activity" begin
+    # TODO: higher-level operators not tested
+    test_differentiation(
+        AutoEnzyme(; mode=Enzyme.set_runtime_activity(Enzyme.Forward)),
+        DIT.unknown_activity(default_scenarios());
+        excluded=vcat(SECOND_ORDER, :jacobian, :gradient, :derivative, :pullback),
+        logging=LOGGING,
+    )
+    test_differentiation(
+        AutoEnzyme(; mode=Enzyme.set_runtime_activity(Enzyme.Reverse)),
+        DIT.unknown_activity(default_scenarios());
+        excluded=vcat(SECOND_ORDER, :jacobian, :gradient, :derivative, :pushforward),
+        logging=LOGGING,
+    )
+end

--- a/DifferentiationInterfaceTest/test/weird.jl
+++ b/DifferentiationInterfaceTest/test/weird.jl
@@ -65,6 +65,13 @@ test_differentiation(
     logging=LOGGING,
 );
 
+test_differentiation(
+    AutoFiniteDiff(),
+    unknown_activity(default_scenarios);
+    excluded=SECOND_ORDER,
+    logging=LOGGING,
+);
+
 ## Neural nets
 
 test_differentiation(


### PR DESCRIPTION
Fixes #666 

Unfortunately, since it relies on `pointer(y) == pointer(dy)`, it only works for `Array` at the moment. Any clue on how to generalize to arbitrary structs is welcome (keeping in mind that `y === dy` doesn't do what we want)

cc @wsmoses