### PR TITLE
fix: speed up Mooncake by avoiding tuple broadcasting

### DIFF
--- a/DifferentiationInterface/CHANGELOG.md
+++ b/DifferentiationInterface/CHANGELOG.md
@@ -5,11 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.7...main)
+## [Unreleased](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.8...main)
+
+## [0.7.8](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.7...DifferentiationInterface-v0.7.8)
+
+### Added
 
   - Support the new `ADTypes.NoAutoDiff` ([#851](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/851))
 
+### Fixed
+
+  - Speed up Mooncake by avoiding tuple broadcasting ([#853](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/853))
+
 ## [0.7.7](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.6...DifferentiationInterface-v0.7.7)
+
+### Fixed
 
   - Improve support for empty inputs (still not guaranteed) ([#835](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/835))
 

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,7 +1,7 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 authors = ["Guillaume Dalle", "Adrian Hill"]
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/forward_onearg.jl
@@ -47,7 +47,7 @@ function DI.value_and_pushforward(
         return y, dy
     end
     y = first(ys_and_ty[1])
-    ty = last.(ys_and_ty)
+    ty = map(last, ys_and_ty)
     return y, ty
 end
 

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/onearg.jl
@@ -55,7 +55,7 @@ function DI.value_and_pullback(
         y, _copy_output(new_dx)
     end
     y = first(ys_and_tx[1])
-    tx = last.(ys_and_tx)
+    tx = map(last, ys_and_tx)
     return y, tx
 end
 


### PR DESCRIPTION
```julia
using BenchmarkTools, DifferentiationInterface, Mooncake
backend = AutoMooncakeForward();
prep = prepare_derivative(sin, backend, 0.1);
@btime value_and_derivative($sin, $prep, $backend, 1.0);
```

Before:

```julia
julia> @btime value_and_derivative($sin, $prep, $backend, 1.0);
  480.128 ns (14 allocations: 320 bytes)
```

After:

```julia
julia> @btime value_and_derivative($sin, $prep, $backend, 1.0);
  0.916 ns (0 allocations: 0 bytes)
```