### PR TITLE
chore: clean up backend testing CI 

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-    tags: ['*']
+    tags: [ '*' ]
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [ opened, reopened, synchronize, ready_for_review ]
   workflow_dispatch:
 
 concurrency:
@@ -21,7 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skipci') }}
     timeout-minutes: 180
-    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+    permissions:
+      # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read
     strategy:
@@ -56,22 +57,15 @@ jobs:
           arch: x64
       - uses: julia-actions/cache@v3
       - name: Install dependencies & run tests
-        run: julia --color=yes -e '
-          using Pkg;
-          Pkg.activate("./DifferentiationInterface/test");
-          if VERSION < v"1.11";
-          Pkg.rm("DifferentiationInterfaceTest");
-          Pkg.resolve();
-          else;
-          Pkg.develop(; path="./DifferentiationInterfaceTest");
-          end;
-          Pkg.activate("./DifferentiationInterface");
-          test_kwargs = (; allow_reresolve=false, coverage=true);
-          if ENV["JULIA_DI_PR_DRAFT"] == "true";
-          Pkg.test("DifferentiationInterface"; julia_args=["-O1"], test_kwargs...);
-          else;
-          Pkg.test("DifferentiationInterface"; test_kwargs...);
-          end;'
+        run: julia --color=yes -e ' using Pkg;
+          Pkg.activate("./DifferentiationInterface/test"); if VERSION < v"1.11";
+          Pkg.rm("DifferentiationInterfaceTest"); Pkg.resolve(); else;
+          Pkg.develop(; path="./DifferentiationInterfaceTest"); end;
+          Pkg.activate("./DifferentiationInterface"); test_kwargs = (;
+          allow_reresolve=false, coverage=true); if ENV["JULIA_DI_PR_DRAFT"] ==
+          "true"; Pkg.test("DifferentiationInterface"; julia_args=["-O1"],
+          test_kwargs...); else; Pkg.test("DifferentiationInterface";
+          test_kwargs...); end;'
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: ./DifferentiationInterface/src,./DifferentiationInterface/ext,./DifferentiationInterface/test
@@ -87,7 +81,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skipci') }}
     timeout-minutes: 120
-    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+    permissions:
+      # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read
     strategy:
@@ -116,13 +111,9 @@ jobs:
           - Zygote
         skip_lts:
           - ${{ github.event.pull_request.draft }}
-        skip_pre:
-          - ${{ github.event.pull_request.draft }}
         exclude:
           - skip_lts: true
             version: '1.10'
-          - skip_pre: true
-            version: '1.12'
           - version: '1.11'
             group: ChainRules
     env:
@@ -136,12 +127,21 @@ jobs:
           version: ${{ matrix.version }}
           arch: x64
       - uses: julia-actions/cache@v3
-      - name: Install dependencies & run tests
-        run: julia --code-coverage=user --color=yes -e '
-          using Pkg;
-          group = ENV["JULIA_DI_TEST_GROUP"];
+      - name: Install dependencies & run tests (draft)
+        if: ${{ github.event.pull_request.draft }}
+        run: julia --code-coverage=user --color=yes -e ' using Pkg; group =
+          ENV["JULIA_DI_TEST_GROUP"];
           Pkg.activate("./DifferentiationInterface/test/Back/$group");
-          Pkg.develop([PackageSpec(path="./DifferentiationInterface"), PackageSpec(path="./DifferentiationInterfaceTest")]);
+          Pkg.develop([PackageSpec(path="./DifferentiationInterface"),
+          PackageSpec(path="./DifferentiationInterfaceTest")]);
+          include("./DifferentiationInterface/test/Back/run_backend.jl");'
+      - name: Install dependencies & run tests (not draft)
+        if: ${{ github.event.pull_request.draft }}
+        run: julia -O1 --code-coverage=user --color=yes -e ' using Pkg; group =
+          ENV["JULIA_DI_TEST_GROUP"];
+          Pkg.activate("./DifferentiationInterface/test/Back/$group");
+          Pkg.develop([PackageSpec(path="./DifferentiationInterface"),
+          PackageSpec(path="./DifferentiationInterfaceTest")]);
           include("./DifferentiationInterface/test/Back/run_backend.jl");'
       - uses: julia-actions/julia-processcoverage@v1
         with:
@@ -158,7 +158,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skipci') }}
     timeout-minutes: 60
-    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+    permissions:
+      # needed to allow julia-actions/cache to proactively delete old caches that it has created
       actions: write
       contents: read
     strategy:
@@ -193,15 +194,13 @@ jobs:
           arch: x64
       - uses: julia-actions/cache@v3
       - name: Install dependencies & run tests
-        run: julia --project=./DifferentiationInterfaceTest --color=yes -e '
-          using Pkg;
-          Pkg.Registry.update();
-          Pkg.develop(path="./DifferentiationInterface");
+        run: julia --project=./DifferentiationInterfaceTest --color=yes -e ' using Pkg;
+          Pkg.Registry.update(); Pkg.develop(path="./DifferentiationInterface");
           if ENV["JULIA_DI_PR_DRAFT"] == "true";
-          Pkg.test("DifferentiationInterfaceTest"; allow_reresolve=false, coverage=true, julia_args=["-O1"]);
-          else;
-          Pkg.test("DifferentiationInterfaceTest"; allow_reresolve=false, coverage=true);
-          end;'
+          Pkg.test("DifferentiationInterfaceTest"; allow_reresolve=false,
+          coverage=true, julia_args=["-O1"]); else;
+          Pkg.test("DifferentiationInterfaceTest"; allow_reresolve=false,
+          coverage=true); end;'
       - uses: julia-actions/julia-processcoverage@v1
         with:
           directories: ./DifferentiationInterfaceTest/src,./DifferentiationInterfaceTest/ext,./DifferentiationInterfaceTest/test

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -36,15 +36,13 @@ jobs:
           - Internals
           - SimpleFiniteDiff
           - ZeroBackends
-        skip_lts:
-          - ${{ github.event.pull_request.draft }}
-        skip_pre:
+        skip_past:
           - ${{ github.event.pull_request.draft }}
         exclude:
-          - skip_lts: true
+          - skip_past: true
             version: '1.10'
-          - skip_pre: true
-            version: '1.12'
+          - skip_past: true
+            version: '1.11'
     env:
       JULIA_DI_TEST_TYPE: 'Core'
       JULIA_DI_TEST_GROUP: ${{ matrix.group }}
@@ -109,11 +107,13 @@ jobs:
           - Symbolics
           - Tracker
           - Zygote
-        skip_lts:
+        skip_past:
           - ${{ github.event.pull_request.draft }}
         exclude:
-          - skip_lts: true
+          - skip_past: true
             version: '1.10'
+          - skip_past: true
+            version: '1.11'
           - version: '1.11'
             group: ChainRules
     env:
@@ -174,15 +174,13 @@ jobs:
           - Zero
           - Standard
           - Weird
-        skip_lts:
-          - ${{ github.event.pull_request.draft }}
-        skip_pre:
+        skip_past:
           - ${{ github.event.pull_request.draft }}
         exclude:
-          - skip_lts: true
+          - skip_past: true
             version: '1.10'
-          - skip_pre: true
-            version: '1.12'
+          - skip_past: true
+            version: '1.11'
     env:
       JULIA_DIT_TEST_GROUP: ${{ matrix.group }}
       JULIA_DI_PR_DRAFT: ${{ github.event.pull_request.draft }}

--- a/DifferentiationInterface/test/Back/ChainRules/Project.toml
+++ b/DifferentiationInterface/test/Back/ChainRules/Project.toml
@@ -8,3 +8,6 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/DifferentiateWith/Project.toml
+++ b/DifferentiationInterface/test/Back/DifferentiateWith/Project.toml
@@ -12,3 +12,6 @@ SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/Enzyme/Project.toml
+++ b/DifferentiationInterface/test/Back/Enzyme/Project.toml
@@ -9,3 +9,6 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/FastDifferentiation/Project.toml
+++ b/DifferentiationInterface/test/Back/FastDifferentiation/Project.toml
@@ -8,3 +8,6 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/FiniteDiff/Project.toml
+++ b/DifferentiationInterface/test/Back/FiniteDiff/Project.toml
@@ -9,3 +9,6 @@ FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/FiniteDifferences/Project.toml
+++ b/DifferentiationInterface/test/Back/FiniteDifferences/Project.toml
@@ -7,3 +7,6 @@ FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/ForwardDiff/Project.toml
+++ b/DifferentiationInterface/test/Back/ForwardDiff/Project.toml
@@ -13,3 +13,6 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/GTPSA/Project.toml
+++ b/DifferentiationInterface/test/Back/GTPSA/Project.toml
@@ -8,3 +8,6 @@ JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/Mooncake/Project.toml
+++ b/DifferentiationInterface/test/Back/Mooncake/Project.toml
@@ -8,3 +8,6 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/PolyesterForwardDiff/Project.toml
+++ b/DifferentiationInterface/test/Back/PolyesterForwardDiff/Project.toml
@@ -8,3 +8,6 @@ PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/ReverseDiff/Project.toml
+++ b/DifferentiationInterface/test/Back/ReverseDiff/Project.toml
@@ -9,3 +9,6 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/SparsityDetector/Project.toml
+++ b/DifferentiationInterface/test/Back/SparsityDetector/Project.toml
@@ -11,3 +11,6 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/Symbolics/Project.toml
+++ b/DifferentiationInterface/test/Back/Symbolics/Project.toml
@@ -8,3 +8,6 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/Tracker/Project.toml
+++ b/DifferentiationInterface/test/Back/Tracker/Project.toml
@@ -7,3 +7,6 @@ SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/Zygote/Project.toml
+++ b/DifferentiationInterface/test/Back/Zygote/Project.toml
@@ -11,3 +11,6 @@ SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }


### PR DESCRIPTION
- Add Pkg sources to backend test envs
- Switch draft backend testing to `-O1`
- Make draft PRs only run on 1.12