### PR TITLE
fix: set `args_to_zero` to `true` for closures in reverse-mode Mooncake

### DIFF
--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/onearg.jl
@@ -14,7 +14,7 @@ function DI.prepare_pullback_nokwarg(
     cache = prepare_pullback_cache(f, x, map(DI.unwrap, contexts)...; config)
     contexts_tup_false = map(_ -> false, contexts)
     args_to_zero = (
-        false,  # f
+        true,  # f
         true,  # x
         contexts_tup_false...,
     )
@@ -114,7 +114,7 @@ function DI.prepare_gradient_nokwarg(
     cache = prepare_gradient_cache(f, x, map(DI.unwrap, contexts)...; config)
     contexts_tup_false = map(_ -> false, contexts)
     args_to_zero = (
-        false,  # f
+        true,  # f
         true,  # x
         contexts_tup_false...,
     )

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/onearg.jl
@@ -14,7 +14,7 @@ function DI.prepare_pullback_nokwarg(
     cache = prepare_pullback_cache(f, x, map(DI.unwrap, contexts)...; config)
     contexts_tup_false = map(_ -> false, contexts)
     args_to_zero = (
-        true,  # f
+        tangent_type(typeof(f)) != NoTangent,  # f
         true,  # x
         contexts_tup_false...,
     )
@@ -114,7 +114,7 @@ function DI.prepare_gradient_nokwarg(
     cache = prepare_gradient_cache(f, x, map(DI.unwrap, contexts)...; config)
     contexts_tup_false = map(_ -> false, contexts)
     args_to_zero = (
-        true,  # f
+        tangent_type(typeof(f)) != NoTangent,  # f
         true,  # x
         contexts_tup_false...,
     )

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/twoarg.jl
@@ -28,7 +28,7 @@ function DI.prepare_pullback_nokwarg(
     contexts_tup_false = map(_ -> false, contexts)
     args_to_zero = (
         false,  # call_and_return
-        true,  # f!
+        tangent_type(typeof(f)) != NoTangent,  # f!
         false,  # y
         true,  # x
         contexts_tup_false...,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/twoarg.jl
@@ -28,7 +28,7 @@ function DI.prepare_pullback_nokwarg(
     contexts_tup_false = map(_ -> false, contexts)
     args_to_zero = (
         false,  # call_and_return
-        tangent_type(typeof(f)) != NoTangent,  # f!
+        tangent_type(typeof(f!)) != NoTangent,  # f!
         false,  # y
         true,  # x
         contexts_tup_false...,

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/twoarg.jl
@@ -28,7 +28,7 @@ function DI.prepare_pullback_nokwarg(
     contexts_tup_false = map(_ -> false, contexts)
     args_to_zero = (
         false,  # call_and_return
-        false,  # f!
+        true,  # f!
         false,  # y
         true,  # x
         contexts_tup_false...,

--- a/DifferentiationInterface/test/Back/Mooncake/Project.toml
+++ b/DifferentiationInterface/test/Back/Mooncake/Project.toml
@@ -3,6 +3,7 @@ ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
 DifferentiationInterfaceTest = "a82114a7-5aa3-49a8-9643-716bb13727a3"
 ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
@@ -10,7 +11,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
-DifferentiationInterface = { path = "../../.." }
+DifferentiationInterface = {path = "../../.."}
 
 [compat]
 Mooncake = ">=0.5.25"

--- a/DifferentiationInterface/test/Back/Mooncake/test.jl
+++ b/DifferentiationInterface/test/Back/Mooncake/test.jl
@@ -112,9 +112,9 @@ end
     f = make_f()
     xA = [0.3, 0.5, 0.2]
     xB = [1.5, 2.0, -1.0]
-    b = DI.AutoMooncake()
-    g = DI.gradient(f, b, xB)
-    prep = DI.prepare_gradient(f, b, xA)
-    @test DI.gradient(f, prep, b, xB) ≈ g
-    @test DI.gradient(f, prep, b, xB) ≈ g
+    b = AutoMooncake()
+    g = gradient(f, b, xB)
+    prep = prepare_gradient(f, b, xA)
+    @test gradient(f, prep, b, xB) ≈ g
+    @test gradient(f, prep, b, xB) ≈ g
 end

--- a/DifferentiationInterface/test/Back/Mooncake/test.jl
+++ b/DifferentiationInterface/test/Back/Mooncake/test.jl
@@ -2,6 +2,7 @@ include("../../testutils.jl")
 
 using DifferentiationInterface, DifferentiationInterfaceTest
 using Mooncake: Mooncake
+using LinearAlgebra
 using Test
 
 using ExplicitImports
@@ -26,6 +27,7 @@ test_differentiation(
     default_scenarios();
     excluded = SECOND_ORDER,
     logging = LOGGING,
+    testset_name = "Basics"
 );
 
 test_differentiation(
@@ -40,6 +42,7 @@ test_differentiation(
     );
     excluded = SECOND_ORDER,
     logging = LOGGING,
+    testset_name = "Constantified and cachified"
 );
 
 test_differentiation(
@@ -47,6 +50,7 @@ test_differentiation(
     nomatrix(default_scenarios());
     excluded = SECOND_ORDER,
     logging = LOGGING,
+    testset_name = "No friendly tangents"
 );
 
 EXCLUDED = @static if VERSION ≥ v"1.11-" && VERSION ≤ v"1.12-"
@@ -64,6 +68,7 @@ test_differentiation(
     nomatrix(default_scenarios());
     excluded = EXCLUDED,
     logging = LOGGING,
+    testset_name = "Second order"
 )
 
 @testset "NamedTuples" begin
@@ -80,6 +85,24 @@ if pkgversion(Mooncake) < v"0.5.25"
         backends[3:4],
         nomatrix(static_scenarios());
         logging = LOGGING,
-        excluded = SECOND_ORDER
+        excluded = SECOND_ORDER,
+        testset_name = "Static scenarios"
     )
+end
+
+@testset "Closure over differentiable data" begin
+    # https://github.com/chalk-lab/Mooncake.jl/issues/1238
+    function make_f()
+        data = [1.0, 2.0, 3.0]
+        return p -> sum(abs2, LowerTriangular([p[1] 0 0; p[2] p[1] 0; p[3] p[2] p[1]] + I) \ data)
+    end
+
+    f = make_f()
+    xA = [0.3, 0.5, 0.2]
+    xB = [1.5, 2.0, -1.0]
+    b = DI.AutoMooncake()
+    g = DI.gradient(f, b, xB)
+    prep = DI.prepare_gradient(f, b, xA)
+    @test DI.gradient(f, prep, b, xB) ≈ g
+    @test DI.gradient(f, prep, b, xB) ≈ g
 end

--- a/DifferentiationInterface/test/testutils.jl
+++ b/DifferentiationInterface/test/testutils.jl
@@ -23,7 +23,8 @@ using DifferentiationInterfaceTest:
     static_scenarios,
     component_scenarios,
     gpu_scenarios,
-    empty_scenarios
+    empty_scenarios,
+    test_counterparts
 
 function MyAutoSparse(backend::AbstractADType)
     return AutoSparse(

--- a/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
+++ b/DifferentiationInterfaceTest/src/DifferentiationInterfaceTest.jl
@@ -151,7 +151,6 @@ include("test_differentiation.jl")
 export FIRST_ORDER, SECOND_ORDER
 export Scenario, compute_results
 export test_differentiation, benchmark_differentiation
-export test_counterparts
 export DifferentiationBenchmarkDataRow
 
 @compile_workload begin

--- a/DifferentiationInterfaceTest/test/zero_backends.jl
+++ b/DifferentiationInterfaceTest/test/zero_backends.jl
@@ -4,7 +4,7 @@ using DataFrames
 using DifferentiationInterface
 using DifferentiationInterface: AutoZeroForward, AutoZeroReverse
 using DifferentiationInterfaceTest
-using DifferentiationInterfaceTest: allocfree_scenarios, no_matrices
+using DifferentiationInterfaceTest: allocfree_scenarios, no_matrices, test_counterparts
 using Test
 
 ## Counterparts


### PR DESCRIPTION
Fixes #1038 by resetting the tangent data of `f` whenever it has a nontrivial tangent type.

Also solves a small docs issue related to #1036 