### PR TITLE
fix: set `args_to_zero` to `true` for constant arguments in reverse-mode Mooncake

### DIFF
--- a/DifferentiationInterface/CHANGELOG.md
+++ b/DifferentiationInterface/CHANGELOG.md
@@ -11,17 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Set `args_to_zero` to `true` for constant arguments in reverse-mode Mooncake ([#1040](https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/#1040))
+- Set `args_to_zero` to `true` for constant arguments in reverse-mode Mooncake ([#1041](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/1041))
 
 ## [0.7.19](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.18...v0.7.19)
 
 ### Fixed
 
-- Set `args_to_zero` to `true` for closures in reverse-mode Mooncake ([#1039](https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/1039))
+- Set `args_to_zero` to `true` for closures in reverse-mode Mooncake ([#1039](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/1039))
 
 ### Added
 
-- Add `forward_counterpart` and `reverse_counterpart` to retrieve the forward- or reverse-mode counterpart of a backend ([#1025](https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/1025))
+- Add `forward_counterpart` and `reverse_counterpart` to retrieve the forward- or reverse-mode counterpart of a backend ([#1036](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/1036))
 
 ## [0.7.18](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.17...DifferentiationInterface-v0.7.18)
 

--- a/DifferentiationInterface/CHANGELOG.md
+++ b/DifferentiationInterface/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.19...main)
+## [Unreleased](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.20...main)
+
+## [0.7.20](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.19...v0.7.19)
+
+### Fixed
+
+- Set `args_to_zero` to `true` for constant arguments in reverse-mode Mooncake ([#1040](https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/#1040))
 
 ## [0.7.19](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.18...v0.7.19)
 

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -1,6 +1,6 @@
 name = "DifferentiationInterface"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
-version = "0.7.19"
+version = "0.7.20"
 authors = ["Guillaume Dalle", "Adrian Hill"]
 
 [deps]

--- a/DifferentiationInterface/docs/src/dev/math.md
+++ b/DifferentiationInterface/docs/src/dev/math.md
@@ -16,7 +16,7 @@ Consider a mathematical function $f(x, c, s) = y$ where
 -  $y \in \mathcal{Y}$ is the output
 
 In Julia code, some of the input arguments might be mutated, while the output may be written to as well.
-Therefore, the proper model is a function $\phi(x_0, c_0, s_0, y_0) = (x_1, c_1, s_1, y_1)$ where $a_0$ is the state of argument $a$ before $f$ is run, while $a_1$ is its state after $a$ is run.
+Therefore, the proper model is a function $\phi(x_0, c_0, s_0, y_0) = (x_1, c_1, s_1, y_1)$ where $a_0$ is the state of argument $a$ before $f$ is run, while $a_1$ is its state after $f$ is run.
 
 DI makes the following hypotheses on the implementation of $f$ (aka the behavior of $\phi$):
 
@@ -83,3 +83,7 @@ Should the shadow/dual memory inside `prep` be reset before every AD call?
 
 - In forward mode, no need ($\dot{c}$ will remain $0$ if it is initialized to $0$)
 - In reverse mode, just set $\bar{x} = 0$ ($\bar{s}$ will be reset to $0$ at every AD call)
+
+!!! warning "Mooncake's constant handling"
+    As noticed in [Mooncake#1238](https://github.com/chalk-lab/Mooncake.jl/issues/1238), the actual pullback implemented by Mooncake doesn't annihilate the influence of $\bar{c}_1$ onto $\bar{x}_0$.
+    Thus, constant contexts also need to be zeroed out systematically with this backend, otherwise noise will accumulate into their cotangents.

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/onearg.jl
@@ -12,11 +12,11 @@ function DI.prepare_pullback_nokwarg(
     _sig = DI.signature(f, backend, x, ty, contexts...; strict)
     config = get_config(backend)
     cache = prepare_pullback_cache(f, x, map(DI.unwrap, contexts)...; config)
-    contexts_tup_false = map(_ -> false, contexts)
+    contexts_tup_true_except_cache = map(c -> !(c isa DI.Cache), contexts)
     args_to_zero = (
-        tangent_type(typeof(f)) != NoTangent,  # f
+        true,  # f
         true,  # x
-        contexts_tup_false...,
+        contexts_tup_true_except_cache...,
     )
     prep = MooncakeOneArgPullbackPrep(_sig, cache, args_to_zero)
     return prep
@@ -112,11 +112,11 @@ function DI.prepare_gradient_nokwarg(
     _sig = DI.signature(f, backend, x, contexts...; strict)
     config = get_config(backend)
     cache = prepare_gradient_cache(f, x, map(DI.unwrap, contexts)...; config)
-    contexts_tup_false = map(_ -> false, contexts)
+    contexts_tup_true_except_cache = map(c -> !(c isa DI.Cache), contexts)
     args_to_zero = (
-        tangent_type(typeof(f)) != NoTangent,  # f
+        true,  # f
         true,  # x
-        contexts_tup_false...,
+        contexts_tup_true_except_cache...,
     )
     prep = MooncakeGradientPrep(_sig, cache, args_to_zero)
     return prep

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/twoarg.jl
@@ -25,13 +25,13 @@ function DI.prepare_pullback_nokwarg(
         config,
     )
     dy_backup = zero_tangent_or_primal(y, backend)
-    contexts_tup_false = map(_ -> false, contexts)
+    contexts_tup_true_except_cache = map(c -> !(c isa DI.Cache), contexts)
     args_to_zero = (
         false,  # call_and_return
-        tangent_type(typeof(f!)) != NoTangent,  # f!
+        true,  # f!
         false,  # y
         true,  # x
-        contexts_tup_false...,
+        contexts_tup_true_except_cache...,
     )
     prep = MooncakeTwoArgPullbackPrep(
         _sig, cache, dy_backup, args_to_zero

--- a/DifferentiationInterface/test/Back/Mooncake/test.jl
+++ b/DifferentiationInterface/test/Back/Mooncake/test.jl
@@ -102,19 +102,37 @@ if pkgversion(Mooncake) < v"0.5.25"
     )
 end
 
-@testset "Closure over differentiable data" begin
+@testset "Zeroing of constant contexts" begin
     # https://github.com/chalk-lab/Mooncake.jl/issues/1238
-    function make_f()
-        data = [1.0, 2.0, 3.0]
-        return p -> sum(abs2, LowerTriangular([p[1] 0 0; p[2] p[1] 0; p[3] p[2] p[1]] + I) \ data)
+    @testset "Closure" begin
+        function make_f()
+            data = [1.0, 2.0, 3.0]
+            return p -> sum(
+                abs2,
+                LowerTriangular([p[1] 0 0; p[2] p[1] 0; p[3] p[2] p[1]] + I) \ data
+            )
+        end
+        f = make_f()
+        xA = [0.3, 0.5, 0.2]
+        xB = [1.5, 2.0, -1.0]
+        backend = AutoMooncake()
+        g = gradient(f, backend, xB)
+        prep = prepare_gradient(f, backend, xA)
+        @test gradient(f, prep, backend, xB) ≈ g
+        @test gradient(f, prep, backend, xB) ≈ g
     end
-
-    f = make_f()
-    xA = [0.3, 0.5, 0.2]
-    xB = [1.5, 2.0, -1.0]
-    b = AutoMooncake()
-    g = gradient(f, b, xB)
-    prep = prepare_gradient(f, b, xA)
-    @test gradient(f, prep, b, xB) ≈ g
-    @test gradient(f, prep, b, xB) ≈ g
+    @testset "Constant context" begin
+        f(p, data) = sum(
+            abs2,
+            LowerTriangular([p[1] 0 0; p[2] p[1] 0; p[3] p[2] p[1]] + I) \ data
+        )
+        data = [1.0, 2.0, 3.0]
+        xA = [0.3, 0.5, 0.2]
+        xB = [1.5, 2.0, -1.0]
+        backend = AutoMooncake()
+        g = gradient(f, backend, xB, Constant(data))
+        prep = prepare_gradient(f, backend, xA, Constant(data))
+        @test gradient(f, prep, backend, xB, Constant(data)) ≈ g
+        @test gradient(f, prep, backend, xB, Constant(data)) ≈ g
+    end
 end


### PR DESCRIPTION
Fixes #1038 for real