### PR TITLE
fix: revert native Mooncake HVP to make CI duration reasonable

### DIFF
--- a/DifferentiationInterface/CHANGELOG.md
+++ b/DifferentiationInterface/CHANGELOG.md
@@ -9,10 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.21](https://github.com/JuliaDiff/DifferentiationInterface.jl/compare/DifferentiationInterface-v0.7.20...v0.7.21)
 
-### Added
-
-- Use native Mooncake HVP in forward-over-reverse ([#1042](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/1042))
-
 ### Fixed
 
 - Make FiniteDiff prep non-allocating with static arrays ([#1019](https://github.com/JuliaDiff/DifferentiationInterface.jl/pull/1019))

--- a/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/DifferentiationInterfaceMooncakeExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceMooncakeExt/DifferentiationInterfaceMooncakeExt.jl
@@ -46,7 +46,7 @@ include("onearg.jl")
 include("twoarg.jl")
 include("forward_onearg.jl")
 include("forward_twoarg.jl")
-include("second_order.jl")
+# include("second_order.jl")
 include("differentiate_with.jl")
 
 end


### PR DESCRIPTION
With Mooncake's native HVP (#1042), CI doesn't finish before the 3-hour mark on Julia 1.10 and 1.11, so I'll revert it for now but keep the code around knowing that it passes tests