### PR TITLE
Fix mangled contributors list

### DIFF
--- a/DifferentiationInterface/docs/make.jl
+++ b/DifferentiationInterface/docs/make.jl
@@ -17,6 +17,15 @@ links = InterLinks(
 
 readme_str = read(joinpath(@__DIR__, "..", "README.md"), String)
 readme_str = replace(readme_str, "> [!CAUTION]\n> " => "!!! warning\n    ")
+#= The all-contributors table is raw HTML, which Documenter's Markdown parser escapes
+instead of rendering. Wrap it in a `@raw html` block, leaving the README untouched. =#
+readme_str = replace(
+    readme_str,
+    r"<!-- ALL-CONTRIBUTORS-LIST:START.*?<!-- ALL-CONTRIBUTORS-LIST:END -->"s =>
+        table -> "```@raw html\n$table\n```",
+)
+# GitHub lowercases heading anchors, Documenter does not, so the badge link needs fixing.
+readme_str = replace(readme_str, "](#contributors)" => "](#Contributors)")
 write(joinpath(@__DIR__, "src", "index.md"), readme_str)
 
 makedocs(;


### PR DESCRIPTION
I was looking at the docs and noticed the Contributors was not rendering properly. When the README is converted to the `index.md` file it wasn't respecting the HTML so I wrapped in a raw HTML block. Also, when i clicked on the badge to quickly see if it was fixed i noticed that didn't work (not that thats a huge deal) so i then realized that there was an issue in how github vs. documentor handled the heading anchors. both are now fixed and i checked the docs local 