### PR TITLE
Support AutoEnzyme Jacobians inside Reactant kernels

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -95,6 +95,7 @@ jobs:
           - DifferentiateWith
           # - Diffractor
           - Enzyme
+          - EnzymeReactant
           - FastDifferentiation
           - FiniteDiff
           - FiniteDifferences

--- a/DifferentiationInterface/Project.toml
+++ b/DifferentiationInterface/Project.toml
@@ -23,6 +23,7 @@ GPUArraysCore = "46192b85-c4d5-4398-a991-12ede77f4527"
 GTPSA = "b27dd330-f138-47c5-815b-40db9dd9b6e8"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 PolyesterForwardDiff = "98d1487c-24ca-40b6-b7ab-df2af84e126b"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
@@ -49,6 +50,7 @@ DifferentiationInterfacePolyesterForwardDiffExt = [
     "ForwardDiff",
     "DiffResults",
 ]
+DifferentiationInterfaceReactantExt = "Reactant"
 DifferentiationInterfaceReverseDiffExt = ["ReverseDiff", "DiffResults"]
 DifferentiationInterfaceSparseArraysExt = "SparseArrays"
 DifferentiationInterfaceSparseConnectivityTracerExt = "SparseConnectivityTracer"
@@ -76,6 +78,7 @@ HyperHessians = "0.3"
 LinearAlgebra = "1"
 Mooncake = "0.5.25"
 PolyesterForwardDiff = "0.1.2"
+Reactant = "0.2.283"
 ReverseDiff = "1.15.1"
 SparseArrays = "1"
 SparseConnectivityTracer = "0.6.14, 1"

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_onearg.jl
@@ -216,6 +216,40 @@ end
 
 ## Jacobian
 
+struct EnzymeReactantJacobianPrep{SIG, D, P} <: DI.JacobianPrep{SIG}
+    _sig::Val{SIG}
+    directions::D
+    pushforward_prep::P
+end
+
+function prepare_reactant_jacobian(
+        strict::Val,
+        f_or_f!y::Tuple,
+        backend::AutoEnzyme,
+        x,
+        contexts::Vararg{DI.Context, C}
+    ) where {C}
+    _sig = DI.signature(f_or_f!y..., backend, x, contexts...; strict)
+    directions = onehot(x)
+    pushforward_prep = DI.prepare_pushforward_nokwarg(
+        strict, f_or_f!y..., backend, x, directions, contexts...
+    )
+    return EnzymeReactantJacobianPrep(_sig, directions, pushforward_prep)
+end
+
+function reactant_jacobian(
+        f_or_f!y::Tuple,
+        prep::EnzymeReactantJacobianPrep,
+        backend::AutoEnzyme,
+        x,
+        contexts::Vararg{DI.Context, C}
+    ) where {C}
+    columns = DI.pushforward(
+        f_or_f!y..., prep.pushforward_prep, backend, x, prep.directions, contexts...
+    )
+    return DI.stack_vec_col(columns)
+end
+
 struct EnzymeForwardOneArgJacobianPrep{SIG, B, DF, DC, O} <: DI.JacobianPrep{SIG}
     _sig::Val{SIG}
     _valB::Val{B}
@@ -232,6 +266,9 @@ function DI.prepare_jacobian_nokwarg(
         x,
         contexts::Vararg{DI.Constant, C}
     ) where {F, C}
+    if DI._use_reactant_jacobian(backend)
+        return prepare_reactant_jacobian(strict, (f,), backend, x, contexts...)
+    end
     _sig = DI.signature(f, backend, x, contexts...; strict)
     y = f(x, map(DI.unwrap, contexts)...)
     valB = to_val(DI.pick_batchsize(backend, x))
@@ -242,6 +279,29 @@ function DI.prepare_jacobian_nokwarg(
     return EnzymeForwardOneArgJacobianPrep(
         _sig, valB, df, context_shadows, basis_shadows, length(y)
     )
+end
+
+function DI.jacobian(
+        f::F,
+        prep::EnzymeReactantJacobianPrep,
+        backend::AutoEnzyme{<:Union{ForwardMode, Nothing}},
+        x,
+        contexts::Vararg{DI.Context, C},
+    ) where {F, C}
+    DI.check_prep(f, prep, backend, x, contexts...)
+    return reactant_jacobian((f,), prep, backend, x, contexts...)
+end
+
+function DI.jacobian!(
+        f::F,
+        jac,
+        prep::EnzymeReactantJacobianPrep,
+        backend::AutoEnzyme{<:Union{ForwardMode, Nothing}},
+        x,
+        contexts::Vararg{DI.Context, C},
+    ) where {F, C}
+    DI.check_prep(f, prep, backend, x, contexts...)
+    return copyto!(jac, reactant_jacobian((f,), prep, backend, x, contexts...))
 end
 
 function DI.jacobian(

--- a/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceEnzymeExt/forward_twoarg.jl
@@ -114,3 +114,97 @@ function DI.pushforward!(
     DI.value_and_pushforward!(f!, y, ty, prep, backend, x, tx, contexts...)
     return ty
 end
+
+## Jacobian
+
+struct EnzymeReactantTwoArgJacobianPrep{SIG, D, P} <: DI.JacobianPrep{SIG}
+    _sig::Val{SIG}
+    directions::D
+    pushforward_prep::P
+end
+
+function reactant_out_of_place(x, f!::F, y, contexts...) where {F}
+    new_y = zero(y)
+    f!(new_y, x, contexts...)
+    return new_y
+end
+
+function prepare_reactant_twoarg_jacobian(
+        strict::Val,
+        f!::F,
+        y,
+        backend::AutoEnzyme,
+        x,
+        contexts::Vararg{DI.Context, C}
+    ) where {F, C}
+    _sig = DI.signature(f!, y, backend, x, contexts...; strict)
+    directions = onehot(x)
+    wrapped_contexts = (DI.Constant(f!), DI.Constant(y), contexts...)
+    pushforward_prep = DI.prepare_pushforward_nokwarg(
+        strict, reactant_out_of_place, backend, x, directions, wrapped_contexts...
+    )
+    return EnzymeReactantTwoArgJacobianPrep(_sig, directions, pushforward_prep)
+end
+
+function reactant_twoarg_jacobian(
+        f!::F,
+        y,
+        prep::EnzymeReactantTwoArgJacobianPrep,
+        backend::AutoEnzyme,
+        x,
+        contexts::Vararg{DI.Context, C}
+    ) where {F, C}
+    wrapped_contexts = (DI.Constant(f!), DI.Constant(y), contexts...)
+    columns = DI.pushforward(
+        reactant_out_of_place,
+        prep.pushforward_prep,
+        backend,
+        x,
+        prep.directions,
+        wrapped_contexts...,
+    )
+    return DI.stack_vec_col(columns)
+end
+
+function DI.prepare_jacobian_nokwarg(
+        strict::Val,
+        f!::F,
+        y,
+        backend::AutoEnzyme{<:Union{ForwardMode, Nothing}},
+        x,
+        contexts::Vararg{DI.Context, C}
+    ) where {F, C}
+    if DI._use_reactant_jacobian(backend)
+        return prepare_reactant_twoarg_jacobian(strict, f!, y, backend, x, contexts...)
+    end
+    batch_size_settings = DI.pick_batchsize(backend, x)
+    return DI._prepare_jacobian_aux(
+        strict, DI.PushforwardFast(), batch_size_settings, y, (f!, y), backend, x, contexts...
+    )
+end
+
+function DI.jacobian(
+        f!::F,
+        y,
+        prep::EnzymeReactantTwoArgJacobianPrep,
+        backend::AutoEnzyme{<:Union{ForwardMode, Nothing}},
+        x,
+        contexts::Vararg{DI.Context, C},
+    ) where {F, C}
+    DI.check_prep(f!, y, prep, backend, x, contexts...)
+    return reactant_twoarg_jacobian(f!, y, prep, backend, x, contexts...)
+end
+
+function DI.jacobian!(
+        f!::F,
+        y,
+        jac,
+        prep::EnzymeReactantTwoArgJacobianPrep,
+        backend::AutoEnzyme{<:Union{ForwardMode, Nothing}},
+        x,
+        contexts::Vararg{DI.Context, C},
+    ) where {F, C}
+    DI.check_prep(f!, y, prep, backend, x, contexts...)
+    new_jac = reactant_twoarg_jacobian(f!, y, prep, backend, x, contexts...)
+    return copyto!(jac, new_jac)
+end

--- a/DifferentiationInterface/ext/DifferentiationInterfaceReactantExt.jl
+++ b/DifferentiationInterface/ext/DifferentiationInterfaceReactantExt.jl
@@ -1,0 +1,9 @@
+module DifferentiationInterfaceReactantExt
+
+using ADTypes: AutoEnzyme
+import DifferentiationInterface as DI
+using Reactant: within_compile
+
+DI._use_reactant_jacobian(::AutoEnzyme) = within_compile()
+
+end

--- a/DifferentiationInterface/src/first_order/jacobian.jl
+++ b/DifferentiationInterface/src/first_order/jacobian.jl
@@ -131,6 +131,8 @@ end
 
 ## Preparation
 
+_use_reactant_jacobian(::AbstractADType) = false
+
 abstract type StandardJacobianPrep{SIG} <: JacobianPrep{SIG} end
 
 struct PushforwardJacobianPrep{

--- a/DifferentiationInterface/test/Back/EnzymeReactant/Project.toml
+++ b/DifferentiationInterface/test/Back/EnzymeReactant/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+DifferentiationInterface = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+DifferentiationInterfaceTest = "a82114a7-5aa3-49a8-9643-716bb13727a3"
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+Reactant = "3c362404-f566-11ee-1572-e11a4b42c853"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+DifferentiationInterface = { path = "../../.." }

--- a/DifferentiationInterface/test/Back/EnzymeReactant/test.jl
+++ b/DifferentiationInterface/test/Back/EnzymeReactant/test.jl
@@ -1,0 +1,71 @@
+using DifferentiationInterface:
+    AutoEnzyme,
+    Constant,
+    jacobian,
+    jacobian!,
+    prepare_jacobian,
+    value_and_jacobian
+using Enzyme: Enzyme
+using Reactant: Reactant, @jit
+using Test
+
+f(x, p) = x .^ 2 .- p
+f!(y, x, p) = y .= f(x, p)
+
+function oop_jacobian(x, p)
+    backend = AutoEnzyme()
+    prep = prepare_jacobian(f, backend, x, Constant(p))
+    return jacobian(f, prep, backend, x, Constant(p))
+end
+
+function oop_value_and_jacobian(x, p)
+    backend = AutoEnzyme()
+    prep = prepare_jacobian(f, backend, x, Constant(p))
+    return value_and_jacobian(f, prep, backend, x, Constant(p))
+end
+
+function iip_jacobian(x, p)
+    backend = AutoEnzyme()
+    y = zero(x)
+    prep = prepare_jacobian(f!, y, backend, x, Constant(p))
+    return jacobian(f!, y, prep, backend, x, Constant(p))
+end
+
+function iip_value_and_jacobian(x, p)
+    backend = AutoEnzyme()
+    y = zero(x)
+    prep = prepare_jacobian(f!, y, backend, x, Constant(p))
+    return value_and_jacobian(f!, y, prep, backend, x, Constant(p))
+end
+
+function oop_jacobian!(x, p)
+    backend = AutoEnzyme()
+    jac = similar(x, length(x), length(x))
+    prep = prepare_jacobian(f, backend, x, Constant(p))
+    return jacobian!(f, jac, prep, backend, x, Constant(p))
+end
+
+function iip_jacobian!(x, p)
+    backend = AutoEnzyme()
+    y = zero(x)
+    jac = similar(x, length(x), length(x))
+    prep = prepare_jacobian(f!, y, backend, x, Constant(p))
+    return jacobian!(f!, y, jac, prep, backend, x, Constant(p))
+end
+
+@testset "AutoEnzyme Jacobian inside Reactant" begin
+    x = Reactant.to_rarray(Float32[1, 2])
+    p = Reactant.to_rarray(Float32[3, 4])
+    expected_jacobian = Float32[2 0; 0 4]
+
+    @test @jit(oop_jacobian(x, p)) ≈ expected_jacobian
+    value, jac = @jit oop_value_and_jacobian(x, p)
+    @test value ≈ Float32[-2, 0]
+    @test jac ≈ expected_jacobian
+    @test @jit(iip_jacobian(x, p)) ≈ expected_jacobian
+    value, jac = @jit iip_value_and_jacobian(x, p)
+    @test value ≈ Float32[-2, 0]
+    @test jac ≈ expected_jacobian
+    @test @jit(oop_jacobian!(x, p)) ≈ expected_jacobian
+    @test @jit(iip_jacobian!(x, p)) ≈ expected_jacobian
+end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## What changed and why

`AutoEnzyme()` Jacobian preparation scalar-indexes Reactant traced arrays, so ordinary DifferentiationInterface Jacobian calls fail inside `Reactant.@jit`. This adds a Reactant weak extension that detects compilation and routes forward/default `AutoEnzyme` Jacobians through Enzyme's traced-compatible batched forward autodiff path (`onehot` directions plus DI pushforwards). Both out-of-place and mutating functions return Reactant arrays and support allocating, mutating, and value-plus-Jacobian APIs.

The higher-level `Enzyme.jacobian` convenience function is not used because its forward implementation currently fails in `tupstack` for traced arrays; the underlying public Enzyme primitives work. The mutating-function route wraps the residual out of place because differentiating a mutated traced output directly produced zero tangents.

Closes https://github.com/JuliaDiff/DifferentiationInterface.jl/issues/1066

This is the DifferentiationInterface prerequisite for removing the custom Jacobian lowering in https://github.com/SciML/NonlinearSolve.jl/pull/1197.

## Verification

Failing before the fix, using the exact new test file against unmodified `main` at `f0fb136d`:

```text
$ TMPDIR="$PWD/../di_base_repro/.tmp" JULIA_DEPOT_PATH="$PWD/../di_repro/.julia_depot" ~/.juliaup/bin/julia +1.12.6 --project=../di_base_repro -e 'include("DifferentiationInterface/test/Back/EnzymeReactant/test.jl")'
ERROR: LoadError: Some tests did not pass: 0 passed, 0 failed, 2 errored, 0 broken.
Scalar indexing is disallowed.
Test Summary:                       | Error  Total   Time
AutoEnzyme Jacobian inside Reactant |     2      2  28.1s
```

Passing with the fix:

```text
$ TMPDIR="$PWD/../di_repro/.tmp" JULIA_DEPOT_PATH="$PWD/../di_repro/.julia_depot" JULIA_DI_TEST_GROUP=EnzymeReactant ~/.juliaup/bin/julia +1.12.6 --project=DifferentiationInterface/test/Back/EnzymeReactant -e 'using Pkg; Pkg.develop([PackageSpec(path="DifferentiationInterface"), PackageSpec(path="DifferentiationInterfaceTest")]); Pkg.instantiate(); include("DifferentiationInterface/test/Back/run_backend.jl")'
Test Summary:  | Pass  Total     Time
EnzymeReactant |    8      8  1m10.9s
```

Existing Enzyme backend group:

```text
$ TMPDIR="$PWD/../di_repro/.tmp" JULIA_DEPOT_PATH="$PWD/../di_repro/.julia_depot" JULIA_DI_TEST_GROUP=Enzyme ~/.juliaup/bin/julia +1.12.6 --project=DifferentiationInterface/test/Back/Enzyme -e 'using Pkg; Pkg.develop(path="DifferentiationInterface"); Pkg.develop(path="DifferentiationInterfaceTest"); Pkg.instantiate(); include("DifferentiationInterface/test/Back/run_backend.jl")'
Test Summary: |  Pass  Broken  Total      Time
Enzyme        | 93886       2  93888  80m26.4s
```

Core formalities, including Aqua, JET, documentation, and ExplicitImports:

```text
$ TMPDIR="$PWD/../di_repro/.tmp" JULIA_DEPOT_PATH="$PWD/../di_repro/.julia_depot" JULIA_DI_TEST_GROUP=Internals ~/.juliaup/bin/julia +1.12.6 -e 'using Pkg; Pkg.activate("./DifferentiationInterface/test"); Pkg.develop(path="./DifferentiationInterfaceTest"); Pkg.instantiate(); Pkg.activate("./DifferentiationInterface"); Pkg.test("DifferentiationInterface"; allow_reresolve=false)'
Test Summary:                      | Pass  Broken  Total     Time
DifferentiationInterface.jl (Core) |  162       2    164  1m48.0s
Testing DifferentiationInterface tests passed
```

Repository pre-commit hooks passed for every changed file: typos, YAML/TOML validation, large-file and conflict checks, whitespace/EOF checks, and Runic formatting.

## Not verified

- Reactant compilation with explicit reverse-mode `AutoEnzyme` is not supported by this change; default and forward mode are the intended Jacobian route.
- Julia 1.10 and 1.11 Reactant runs were not executed locally. Draft CI exercises Julia 1.12; the non-draft matrix will exercise all three supported Julia versions.
- The docs build was not run because no docstring, rendered documentation, or public API changed.
- GPU-specific Reactant execution was not run; the test used the PJRT CPU runtime.

## Reviewer notes

- Reactant is a weak dependency with minimum compat `0.2.283`, the version used for the reproducer and verification.
- Reactant and DifferentiationInterface are both MIT-licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://chatgpt.com/codex/tasks/01a03a07-4f58-7d73-90d2-5e7aa3ba9fd7
